### PR TITLE
Fix: Use dynamic plate_cols calculation matching GUI

### DIFF
--- a/src/orca-slice-engine/main.cpp
+++ b/src/orca-slice-engine/main.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
+#include <cmath>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
@@ -54,6 +55,13 @@ enum class OutputFormat {
     GCODE,
     GCODE_3MF
 };
+
+// Compute column count for plate grid layout (matches GUI's PartPlate.hpp logic)
+inline int compute_colum_count(int count) {
+    float value = sqrt((float)count);
+    float round_value = round(value);
+    return (value > round_value) ? (round_value + 1) : round_value;
+}
 
 void print_usage(const char* program_name) {
     std::cout << "OrcaSlicer Cloud Slicing Engine v" << SLIC3R_VERSION << std::endl;
@@ -464,7 +472,8 @@ int main(int argc, char* argv[]) {
         // origin.x = col * plate_stride_x
         // origin.y = -row * plate_stride_y (negative Y for downward layout)
         const double LOGICAL_PART_PLATE_GAP = 0.2;  // 1/5, same as GUI
-        const int plate_cols = 1;  // Engine uses single-column layout
+        // Calculate column count dynamically based on total plates (matches GUI logic)
+        const int plate_cols = compute_colum_count(static_cast<int>(plates_to_process.size()));
 
         int row = plate_index / plate_cols;
         int col = plate_index % plate_cols;


### PR DESCRIPTION
## Summary
修复独立切片引擎的 plate 网格布局列数计算，使其与 GUI 完全一致。

## Problem
引擎硬编码 `plate_cols = 1`，但 GUI 使用 `compute_colum_count()` 动态计算列数：
- 2 plates → GUI 用 2 列，引擎用 1 列
- 3 plates → GUI 用 2 列，引擎用 1 列

这导致 plate 1 和 2 的模型在 GUI 中显示到盘外面（只有 plate 3 碰巧正确）。

## Solution
添加 `compute_colum_count()` 函数，与 GUI 的 `PartPlate.hpp` 逻辑完全一致：
```cpp
inline int compute_colum_count(int count) {
    float value = sqrt((float)count);
    float round_value = round(value);
    return (value > round_value) ? (round_value + 1) : round_value;
}
```

## Testing
- [ ] 3 盘项目：引擎切片后导入 GUI，3 个盘的模型位置都应正确

## Related
- Follow-up fix for PR #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)