### PR TITLE
fix(engine): Align plate size calculation with GUI for gcode.3mf export

### DIFF
--- a/src/orca-slice-engine/main.cpp
+++ b/src/orca-slice-engine/main.cpp
@@ -460,8 +460,13 @@ int main(int argc, char* argv[]) {
                 for (const Vec2d& pt : printable_area_opt->values) {
                     bbox.merge(pt);
                 }
-                plate_width = bbox.size().x();
-                plate_depth = bbox.size().y();
+                // Apply same offset as GUI's Bed3D::Axes::DefaultTipRadius
+                // GUI calculates bed bounding box with axes tip radius offset
+                // See: src/slic3r/GUI/3DScene.cpp Bed3D::Axes::DefaultTipRadius = 2.5
+                // The bounding_box calculation subtracts 2.5 * 0.5 = 1.25 from each side
+                constexpr double BED_AXES_TIP_RADIUS = 1.25;  // 2.5 * 0.5
+                plate_width = bbox.size().x() - BED_AXES_TIP_RADIUS;
+                plate_depth = bbox.size().y() - BED_AXES_TIP_RADIUS;
             }
         }
 


### PR DESCRIPTION
## Summary
Fix plate size calculation in orca-slice-engine to be consistent with GUI.

## Problem
When importing gcode.3mf files generated by orca-slice-engine back into Snapmaker Orca GUI, plates and models appear misaligned - models show up outside their designated plate boundaries.

## Root Cause
The plate size calculation was inconsistent between engine and GUI:
- Engine: uses printable_area bounding box directly (no offset)
- GUI: uses bed_bounding_box - 1.25mm (Bed3D::Axes::DefaultTipRadius)

This caused plate_origin to be calculated differently, resulting in spatial mismatch between model coordinates and plate bounding boxes.

## Solution
Apply the same BED_AXES_TIP_RADIUS offset (1.25mm) to plate size calculation in the engine to match GUI behavior.

## Changes
- Added BED_AXES_TIP_RADIUS constant (1.25mm)
- Subtract offset from plate_width and plate_depth

## Testing
Test with gcode.3mf export and verify models are correctly positioned within their designated plates.