### PR TITLE
Fix crash in SSWCP color_to_int for RGBA color strings

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -3065,10 +3065,10 @@ void SSWCP_MachineOption_Instance::sw_GetFileFilamentMapping()
                 }
             } else {
                 for (int i = 1; i <= 8; ++i) {
-                    if (oriclr[7 - i] - '0' >= 0 && oriclr[7 - i] - '0' <= 9) {
-                        res += std::pow(16, i - 1) * (oriclr[7 - i] - '0');
+                    if (oriclr[9 - i] - '0' >= 0 && oriclr[9 - i] - '0' <= 9) {
+                        res += std::pow(16, i - 1) * (oriclr[9 - i] - '0');
                     } else {
-                        res += std::pow(16, i - 1) * (oriclr[7 - i] - 'A' + 10);
+                        res += std::pow(16, i - 1) * (oriclr[9 - i] - 'A' + 10);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Fix out-of-bounds string access in `color_to_int` lambda in `SSWCP.cpp` that crashes when parsing 9-character RGBA color strings (e.g. `"#FFFFFFFF"`)
- The 8-digit (RGBA) branch used `oriclr[7 - i]` which evaluates to `oriclr[-1]` when `i=8`, wrapping to `std::string::npos` and causing SIGABRT
- Fix: use `oriclr[9 - i]` for the RGBA branch to correctly index from the end of the 9-character string

## Root Cause

The `color_to_int` lambda validates that `oriclr` is either 7 or 9 characters starting with `#`. For the 7-character case (`#RRGGBB`), the loop `oriclr[7 - i]` for `i` in `[1, 6]` correctly accesses indices 6 down to 1. However, for the 9-character case (`#RRGGBBAA`), the same `oriclr[7 - i]` formula is used with `i` in `[1, 8]`, which accesses index -1 when `i=8`.

## Reproduction

1. Load a model in Snapmaker Orca
2. Slice the model
3. Click "Print" to send to printer via the WebPreprintDialog
4. The `sw_GetFileFilamentMapping` command triggers `color_to_int` with an RGBA color string
5. Application crashes with SIGABRT

## GDB Backtrace

```
#6  std::__cxx11::basic_string::operator[] (__pos=18446744073709551615)
#7  operator() (oriclr="#FFFFFFFF") at SSWCP.cpp:3074
#8  sw_GetFileFilamentMapping() at SSWCP.cpp:3094
```

## Test plan

- [x] Verified fix by building with AddressSanitizer (`-fsanitize=address -O2`) and successfully sending print jobs without crash
- [ ] Verify RGBA color values are parsed correctly (compare parsed integer with expected value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)