### PR TITLE
Fix retract keys sort order in PrintConfig (debug build crash)

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -6160,10 +6160,12 @@ void PrintConfigDef::init_extruder_option_keys()
         "deretraction_speed",
         "long_retractions_when_cut",
         "retract_before_wipe",
+        "retract_length_toolchange",
         "retract_lift_above",
         "retract_lift_below",
         "retract_lift_enforce",
         "retract_restart_extra",
+        "retract_restart_extra_toolchange",
         "retract_when_changing_layer",
         "retraction_distances_when_cut",
         "retraction_length",
@@ -6174,9 +6176,7 @@ void PrintConfigDef::init_extruder_option_keys()
         "wipe_distance",
         "z_hop",
         "z_hop_types",
-        "z_hop_when_prime",
-        "retract_length_toolchange",
-        "retract_restart_extra_toolchange"
+        "z_hop_when_prime"
     };
     assert(std::is_sorted(m_extruder_retract_keys.begin(), m_extruder_retract_keys.end()));
 }
@@ -6195,10 +6195,12 @@ void PrintConfigDef::init_filament_option_keys()
         "deretraction_speed",
         "long_retractions_when_cut",
         "retract_before_wipe",
+        "retract_length_toolchange",
         "retract_lift_above",
         "retract_lift_below",
         "retract_lift_enforce",
         "retract_restart_extra",
+        "retract_restart_extra_toolchange",
         "retract_when_changing_layer",
         "retraction_distances_when_cut",
         "retraction_length",
@@ -6208,8 +6210,6 @@ void PrintConfigDef::init_filament_option_keys()
         "wipe_distance",
         "z_hop",
         "z_hop_types",
-        "retract_length_toolchange",
-        "retract_restart_extra_toolchange",
     };
     assert(std::is_sorted(m_filament_retract_keys.begin(), m_filament_retract_keys.end()));
 }


### PR DESCRIPTION
## Summary

- Fix alphabetical sort order of `m_extruder_retract_keys` and `m_filament_retract_keys` in `PrintConfig.cpp`
- `retract_length_toolchange` and `retract_restart_extra_toolchange` were appended at the end of the sorted lists instead of being inserted at their correct alphabetical positions
- This causes `std::is_sorted` assertion failure and immediate crash on startup in debug builds (`-DCMAKE_BUILD_TYPE=Debug`)

## Root Cause

When the toolchange retraction keys were added to Snapmaker Orca, they were appended at the end of the sorted key lists. Alphabetically, `retract_le...` sorts before `retract_li...`, and `retract_restart_extra_toolchange` sorts after `retract_restart_extra` but before `retract_when_changing_layer`.

## Fix

Move the keys to their correct alphabetical positions:
- `retract_length_toolchange` → after `retract_before_wipe`, before `retract_lift_above`
- `retract_restart_extra_toolchange` → after `retract_restart_extra`, before `retract_when_changing_layer`

## Test plan

- [x] Verified sort order using `sort` utility: extracted keys, sorted, diffed — no differences
- [x] Debug build starts successfully without assertion failure
- [ ] Release build unaffected (assertions disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)