### PR TITLE
Fix build failure with GCC 15 (C23 bool keyword in MQTTPacket.h)

### DIFF
--- a/src/mqtt/externals/paho-mqtt-c/src/MQTTPacket.h
+++ b/src/mqtt/externals/paho-mqtt-c/src/MQTTPacket.h
@@ -28,7 +28,9 @@
 #include "LinkedList.h"
 #include "Clients.h"
 
+#if !defined(__bool_true_false_are_defined) && !defined(__cplusplus) && (__STDC_VERSION__ < 202311L)
 typedef unsigned int bool;
+#endif
 typedef void* (*pf)(int, unsigned char, char*, size_t);
 
 #include "MQTTProperties.h"


### PR DESCRIPTION
## Summary

- Fix compilation error with GCC 15+ where `typedef unsigned int bool` fails because C23 makes `bool` a keyword
- Guard the typedef with preprocessor checks so it only applies on older C standards
- Enables building on Ubuntu 25.10+ and other distributions shipping GCC 15

## Error

```
src/mqtt/externals/paho-mqtt-c/src/MQTTPacket.h:31:26: error: 'bool' cannot be defined via 'typedef'
   31 | typedef unsigned int bool;
      |                      ^~~~
```

## Fix

```c
#if !defined(__bool_true_false_are_defined) && !defined(__cplusplus) && (__STDC_VERSION__ < 202311L)
typedef unsigned int bool;
#endif
```

This preserves existing behavior on older compilers while allowing compilation on GCC 15+ with C23 support.

## Note

This is a fix to vendored paho-mqtt-c code. The upstream paho project has already addressed this in newer releases.

## Test plan

- [x] Builds successfully with GCC 15.2 on Ubuntu 25.10
- [x] Builds successfully with AddressSanitizer enabled
- [ ] Verify no regressions on GCC 12/13/14

🤖 Generated with [Claude Code](https://claude.com/claude-code)