### PR TITLE
Fix stack-use-after-scope in wipe tower GCode generation

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -715,7 +715,7 @@ std::string WipeTowerIntegration::append_tcr2(GCode& gcodegen, const WipeTower::
     // For Snapmaker Artision
     gcodegen.m_next_wipe_x = 0;
     gcodegen.m_next_wipe_y = 0;
-    auto transformed_pos   = Eigen::Rotation2Df(wipe_tower_rotation) * tcr.start_pos + wipe_tower_offset;
+    Vec2f transformed_pos  = Eigen::Rotation2Df(wipe_tower_rotation) * tcr.start_pos + wipe_tower_offset;
     gcodegen.m_next_wipe_x = transformed_pos(0);
     gcodegen.m_next_wipe_y = transformed_pos(1);
 


### PR DESCRIPTION
## Summary

- Fix undefined behavior (stack-use-after-scope) in `WipeTowerIntegration::append_tcr2()` caused by using `auto` with an Eigen expression template
- The `auto` type deduction creates a lazy expression that holds references to destroyed temporaries, causing reads from dead stack memory
- This causes intermittent crashes during slicing, particularly when background slicing runs concurrently with UI operations

## Root Cause

In the Snapmaker Artision wipe tower code (GCode.cpp:718):

```cpp
// BUG: auto deduces an Eigen expression template type that holds
// references to temporaries destroyed at end of statement
auto transformed_pos = Eigen::Rotation2Df(wipe_tower_rotation) * tcr.start_pos + wipe_tower_offset;
gcodegen.m_next_wipe_x = transformed_pos(0);  // reads dead stack memory!
```

`auto` deduces a `CwiseBinaryOp<scalar_sum_op, Product<Rotation2D, Vec2f>, Vec2f>` expression template that lazily evaluates when accessed. The intermediate `Product<Rotation2D, Vec2f>` temporary is destroyed before `transformed_pos(0)` is called.

## Fix

Use explicit `Vec2f` type to force immediate evaluation:

```cpp
Vec2f transformed_pos = Eigen::Rotation2Df(wipe_tower_rotation) * tcr.start_pos + wipe_tower_offset;
```

## Detection

Found using AddressSanitizer (`-fsanitize=address -O2`):

```
ERROR: AddressSanitizer: stack-use-after-scope
READ of size 4 at 0x... thread T183
    #0 Eigen::internal::scalar_sum_op<float,float>::operator()
    #4 WipeTowerIntegration::append_tcr2 GCode.cpp:719
    #5 WipeTowerIntegration::tool_change GCode.cpp:951
    #6 GCode::process_layer GCode.cpp:4230
```

## Impact

This is undefined behavior that reads corrupted stack data. Depending on optimization level and stack layout, it can:
- Produce incorrect wipe tower coordinates (silent data corruption)
- Crash during slicing (SIGSEGV/SIGABRT)
- Appear to work correctly (masking the bug)

## Test plan

- [x] AddressSanitizer build (`-O2 -g -fsanitize=address`) no longer reports stack-use-after-scope
- [ ] Verify wipe tower positioning is correct with multi-extruder prints

🤖 Generated with [Claude Code](https://claude.com/claude-code)