### PR TITLE
Delete the onScriptMessage log to prevent excessive logging from causing the main thread to lag.

### DIFF
--- a/src/slic3r/GUI/PrinterWebView.cpp
+++ b/src/slic3r/GUI/PrinterWebView.cpp
@@ -184,10 +184,10 @@ void PrinterWebView::OnLoaded(wxWebViewEvent &evt)
 }
 
 void PrinterWebView::OnScriptMessage(wxWebViewEvent& evt) {
-    BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
+    // BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
 
-    if (wxGetApp().get_mode() == comDevelop)
-        wxLogMessage("Script message received; value = %s, handler = %s", evt.GetString(), evt.GetMessageHandler());
+    // if (wxGetApp().get_mode() == comDevelop)
+    //     wxLogMessage("Script message received; value = %s, handler = %s", evt.GetString(), evt.GetMessageHandler());
 
     // test
     SSWCP::handle_web_message(evt.GetString().ToUTF8().data(), m_browser);

--- a/src/slic3r/GUI/WebDeviceDialog.cpp
+++ b/src/slic3r/GUI/WebDeviceDialog.cpp
@@ -123,10 +123,10 @@ void WebDeviceDialog::OnError(wxWebViewEvent &evt)
 
 void WebDeviceDialog::OnScriptMessage(wxWebViewEvent &evt)
 {
-    BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
+    // BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
 
-    if (wxGetApp().get_mode() == comDevelop)
-        wxLogMessage("Script message received; value = %s, handler = %s", evt.GetString(), evt.GetMessageHandler());
+    // if (wxGetApp().get_mode() == comDevelop)
+    //     wxLogMessage("Script message received; value = %s, handler = %s", evt.GetString(), evt.GetMessageHandler());
 
     // test
     SSWCP::handle_web_message(evt.GetString().ToUTF8().data(), m_browser);

--- a/src/slic3r/GUI/WebGuideDialog.cpp
+++ b/src/slic3r/GUI/WebGuideDialog.cpp
@@ -379,11 +379,11 @@ void GuideFrame::OnScriptMessage(wxWebViewEvent &evt)
 {
     try {
         wxString strInput = evt.GetString();
-        BOOST_LOG_TRIVIAL(trace) << "GuideFrame::OnScriptMessage;OnRecv:" << strInput.c_str();
+        // BOOST_LOG_TRIVIAL(trace) << "GuideFrame::OnScriptMessage;OnRecv:" << strInput.c_str();
         json     j        = json::parse(strInput);
 
         wxString strCmd = j["command"];
-        BOOST_LOG_TRIVIAL(trace) << "GuideFrame::OnScriptMessage;Command:" << strCmd;
+        // BOOST_LOG_TRIVIAL(trace) << "GuideFrame::OnScriptMessage;Command:" << strCmd;
 
         if (strCmd == "close_page") {
             this->EndModal(wxID_CANCEL);
@@ -418,7 +418,7 @@ void GuideFrame::OnScriptMessage(wxWebViewEvent &evt)
             //wxString strJS = wxString::Format("HandleStudio(%s)", m_Res.dump(-1, ' ', false, json::error_handler_t::ignore));
             wxString strJS = wxString::Format("HandleStudio(%s)", m_Res.dump(-1, ' ', true));
 
-            BOOST_LOG_TRIVIAL(trace) << "GuideFrame::OnScriptMessage;request_userguide_profile:" << strJS.c_str();
+            // BOOST_LOG_TRIVIAL(trace) << "GuideFrame::OnScriptMessage;request_userguide_profile:" << strJS.c_str();
             wxGetApp().CallAfter([this,strJS] { RunScript(strJS); });
         }
         else if (strCmd == "request_custom_filaments") {
@@ -548,7 +548,7 @@ void GuideFrame::OnScriptMessage(wxWebViewEvent &evt)
         }
     } catch (std::exception &e) {
         // wxMessageBox(e.what(), "json Exception", MB_OK);
-        BOOST_LOG_TRIVIAL(trace) << "GuideFrame::OnScriptMessage;Error:" << e.what();
+        // BOOST_LOG_TRIVIAL(trace) << "GuideFrame::OnScriptMessage;Error:" << e.what();
     }
 
     //wxString strAll = m_ProfileJson.dump(-1,' ',false, json::error_handler_t::ignore);

--- a/src/slic3r/GUI/WebPreprintDialog.cpp
+++ b/src/slic3r/GUI/WebPreprintDialog.cpp
@@ -196,10 +196,10 @@ void WebPreprintDialog::OnError(wxWebViewEvent &event)
 
 void WebPreprintDialog::OnScriptMessage(wxWebViewEvent &evt)
 {
-    BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
+    // BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
 
-    if (wxGetApp().get_mode() == comDevelop)
-        wxLogMessage("Script message received; value = %s, handler = %s", evt.GetString(), evt.GetMessageHandler());
+    // if (wxGetApp().get_mode() == comDevelop)
+    //     wxLogMessage("Script message received; value = %s, handler = %s", evt.GetString(), evt.GetMessageHandler());
 
     // test
     SSWCP::handle_web_message(evt.GetString().ToUTF8().data(), m_browser);

--- a/src/slic3r/GUI/WebPresetDialog.cpp
+++ b/src/slic3r/GUI/WebPresetDialog.cpp
@@ -397,11 +397,11 @@ void WebPresetDialog::OnScriptMessage(wxWebViewEvent& evt)
 {
     try {
         wxString strInput = evt.GetString();
-        BOOST_LOG_TRIVIAL(trace) << "WebPresetDialog::OnScriptMessage;OnRecv:" << strInput.c_str();
+        // BOOST_LOG_TRIVIAL(trace) << "WebPresetDialog::OnScriptMessage;OnRecv:" << strInput.c_str();
         json j = json::parse(strInput);
 
         wxString strCmd = j["command"];
-        BOOST_LOG_TRIVIAL(trace) << "WebPresetDialog::OnScriptMessage;Command:" << strCmd;
+        // BOOST_LOG_TRIVIAL(trace) << "WebPresetDialog::OnScriptMessage;Command:" << strCmd;
 
         if (strCmd == "close_page") {
             this->EndModal(wxID_CANCEL);
@@ -485,7 +485,7 @@ void WebPresetDialog::OnScriptMessage(wxWebViewEvent& evt)
             // wxString strJS = wxString::Format("HandleStudio(%s)", m_Res.dump(-1, ' ', false, json::error_handler_t::ignore));
             wxString strJS = wxString::Format("HandleStudio(%s)", m_Res.dump(-1, ' ', true));
 
-            BOOST_LOG_TRIVIAL(trace) << "WebPresetDialog::OnScriptMessage;request_userguide_profile:" << strJS.c_str();
+            // BOOST_LOG_TRIVIAL(trace) << "WebPresetDialog::OnScriptMessage;request_userguide_profile:" << strJS.c_str();
             wxGetApp().CallAfter([this, strJS] { RunScript(strJS); });
         } else if (strCmd == "request_custom_filaments") {
             wxString strJS = update_custom_filaments();
@@ -640,7 +640,7 @@ void WebPresetDialog::OnScriptMessage(wxWebViewEvent& evt)
         }
     } catch (std::exception& e) {
         // wxMessageBox(e.what(), "json Exception", MB_OK);
-        BOOST_LOG_TRIVIAL(trace) << "WebPresetDialog::OnScriptMessage;Error:" << e.what();
+        // BOOST_LOG_TRIVIAL(trace) << "WebPresetDialog::OnScriptMessage;Error:" << e.what();
     }
 
     {

--- a/src/slic3r/GUI/WebUrlDialog.cpp
+++ b/src/slic3r/GUI/WebUrlDialog.cpp
@@ -135,11 +135,11 @@ void WebUrlDialog::OnError(wxWebViewEvent &event)
 
 void WebUrlDialog::OnScriptMessage(wxWebViewEvent &evt)
 {
-    BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
+    // BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
 
-    if (wxGetApp().get_mode() == comDevelop)
-        wxLogMessage("Script message received; value = %s, handler = %s", 
-                    evt.GetString(), evt.GetMessageHandler());
+    // if (wxGetApp().get_mode() == comDevelop)
+    //     wxLogMessage("Script message received; value = %s, handler = %s",
+    //                 evt.GetString(), evt.GetMessageHandler());
 
     // 处理SSWCP消息
     SSWCP::handle_web_message(evt.GetString().ToUTF8().data(), m_browser);

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -659,7 +659,7 @@ void WebViewPanel::OnNewWindow(wxWebViewEvent& evt)
 
 void WebViewPanel::OnScriptMessage(wxWebViewEvent& evt)
 {
-    BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
+    // BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetString().ToUTF8().data();
     // update login status
     if (m_LoginUpdateTimer == nullptr) {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " Create Timer";
@@ -667,8 +667,8 @@ void WebViewPanel::OnScriptMessage(wxWebViewEvent& evt)
         m_LoginUpdateTimer->Start(2000);
     }
 
-    if (wxGetApp().get_mode() == comDevelop)
-        wxLogMessage("Script message received; value = %s, handler = %s", evt.GetString(), evt.GetMessageHandler());
+    // if (wxGetApp().get_mode() == comDevelop)
+    //     wxLogMessage("Script message received; value = %s, handler = %s", evt.GetString(), evt.GetMessageHandler());
 
     // test
     SSWCP::handle_web_message(evt.GetString().ToUTF8().data(), m_browser);


### PR DESCRIPTION
…ctions

- Commented out BOOST_LOG_TRIVIAL(trace) logs in all webview OnScriptMessage handlers
- Commented out wxLogMessage developer mode logs that severely impact performance
- Affected files: WebPresetDialog, WebGuideDialog, WebViewDialog, WebPreprintDialog, PrinterWebView, WebUrlDialog, WebDeviceDialog
- Total: 13 trace logs + 5 wxLogMessage logs commented out

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
