### PR TITLE
Bugfix: server message backlog

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -598,6 +598,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/MQTT.cpp
     Utils/MoonRaker.cpp
     Utils/MoonRaker.hpp
+    Utils/TimeSyncManager.cpp
+    Utils/TimeSyncManager.hpp
     Utils/TimeoutMap.hpp
 )
 

--- a/src/slic3r/Utils/MoonRaker.cpp
+++ b/src/slic3r/Utils/MoonRaker.cpp
@@ -252,7 +252,7 @@ Moonraker::Moonraker(DynamicPrintConfig* config)
     , m_apikey(config->opt_string("printhost_apikey"))
     , m_cafile(config->opt_string("printhost_cafile"))
     , m_ssl_revoke_best_effort(config->opt_bool("printhost_ssl_ignore_revoke"))
-    , time_sync_manager_(std::make_unique<TimeSyncManager>())
+    , time_sync_manager_(std::make_shared<TimeSyncManager>())
 {
     auto& wcp_loger = GUI::WCP_Logger::getInstance();
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 初始化Moonraker实例，主机: " << m_host;
@@ -1137,7 +1137,12 @@ bool Moonraker_Mqtt::set_engine(const std::shared_ptr<MqttClient>& engine, std::
     m_mqtt_client_tls = engine;
 
     BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] 设置消息回调函数";
-    m_mqtt_client_tls->SetMessageCallback([this](const std::string& topic, const std::string& payload) {
+    std::weak_ptr<TimeSyncManager> weak_tsm = time_sync_manager_;
+    m_mqtt_client_tls->SetMessageCallback([this, weak_tsm](const std::string& topic, const std::string& payload) {
+        if (weak_tsm.expired()) {
+            BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 对象已销毁，忽略MQTTS消息";
+            return;
+        }
         this->on_mqtt_tls_message_arrived(topic, payload);
     });
 
@@ -1183,7 +1188,12 @@ bool Moonraker_Mqtt::ask_for_tls_info(const nlohmann::json& cn_params)
     if (!response_subscribed) {
         return false;
     }
-    m_mqtt_client->SetMessageCallback([this](const std::string& topic, const std::string& payload) {
+    std::weak_ptr<TimeSyncManager> weak_tsm_mqtt = time_sync_manager_;
+    m_mqtt_client->SetMessageCallback([this, weak_tsm_mqtt](const std::string& topic, const std::string& payload) {
+        if (weak_tsm_mqtt.expired()) {
+            BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 对象已销毁，忽略MQTT消息";
+            return;
+        }
         this->on_mqtt_message_arrived(topic, payload);
     });
 
@@ -1440,7 +1450,12 @@ bool Moonraker_Mqtt::connect(wxString& msg, const nlohmann::json& params) {
     BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 订阅主题结果 - 通知主题: " << (notification_subscribed ? "成功" : "失败")
                            << ", 响应主题: " << (response_subscribed ? "成功" : "失败");
     wcp_loger.add_log("订阅主题结果 - 通知主题: " + std::string((notification_subscribed ? "成功" : "失败")) + ", 响应主题: " + (response_subscribed ? "成功" : "失败"), false, "", "Moonraker_Mqtt", "info");
-    m_mqtt_client_tls->SetMessageCallback([this](const std::string& topic, const std::string& payload) {
+    std::weak_ptr<TimeSyncManager> weak_tsm = time_sync_manager_;
+    m_mqtt_client_tls->SetMessageCallback([this, weak_tsm](const std::string& topic, const std::string& payload) {
+        if (weak_tsm.expired()) {
+            BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 对象已销毁，忽略MQTTS消息";
+            return;
+        }
         this->on_mqtt_tls_message_arrived(topic, payload);
     });
 
@@ -1465,6 +1480,10 @@ bool Moonraker_Mqtt::disconnect(wxString& msg, const nlohmann::json& params) {
     bool flag = m_mqtt_client_tls->Disconnect(dc_msg);
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] MQTTS断开连接结果: " << (flag ? "成功" : "失败");
     wcp_loger.add_log("MQTTS断开连接结果: " + std::string((flag ? "成功" : "失败")), false, "", "Moonraker_Mqtt", "info");
+
+    // 先释放 time_sync_manager_，使回调中的 weak_ptr 立即失效，
+    // 确保后续不会再有回调线程访问已销毁的对象
+    time_sync_manager_.reset();
 
     if (flag) {
         m_status_cbs.clear();

--- a/src/slic3r/Utils/MoonRaker.cpp
+++ b/src/slic3r/Utils/MoonRaker.cpp
@@ -2967,6 +2967,11 @@ void Moonraker_Mqtt::on_response_arrived(const std::string& payload)
     try {
         json body = json::parse(payload);
 
+        // 更新时间同步状态
+        if (time_sync_manager_) {
+            time_sync_manager_->updateFromResponse(body);
+        }
+
         if (!body.count("id")) {
             BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 响应消息缺少ID字段";
             wcp_loger.add_log("响应消息缺少ID字段", false, "", "Moonraker_Mqtt", "warning");

--- a/src/slic3r/Utils/MoonRaker.cpp
+++ b/src/slic3r/Utils/MoonRaker.cpp
@@ -252,6 +252,7 @@ Moonraker::Moonraker(DynamicPrintConfig* config)
     , m_apikey(config->opt_string("printhost_apikey"))
     , m_cafile(config->opt_string("printhost_cafile"))
     , m_ssl_revoke_best_effort(config->opt_bool("printhost_ssl_ignore_revoke"))
+    , time_sync_manager_(std::make_unique<TimeSyncManager>())
 {
     auto& wcp_loger = GUI::WCP_Logger::getInstance();
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 初始化Moonraker实例，主机: " << m_host;
@@ -1140,6 +1141,12 @@ bool Moonraker_Mqtt::set_engine(const std::shared_ptr<MqttClient>& engine, std::
         this->on_mqtt_tls_message_arrived(topic, payload);
     });
 
+    // 重置时间同步状态
+    if (time_sync_manager_) {
+        time_sync_manager_->reset();
+        BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 时间同步状态已重置";
+    }
+
     BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] 引擎设置完成";
     msg = "success";
     return true;
@@ -1244,6 +1251,11 @@ bool Moonraker_Mqtt::ask_for_tls_info(const nlohmann::json& cn_params)
             return false;
     }
     body["id"] = seq_id;
+
+    // 添加时间同步字段
+    if (time_sync_manager_) {
+        time_sync_manager_->addTimeFields(body);
+    }
 
     std::string pub_msg = "";
     if(!m_mqtt_client->Publish(auth_code + m_auth_req_topic, body.dump(), 1, pub_msg)){
@@ -1401,6 +1413,11 @@ bool Moonraker_Mqtt::connect(wxString& msg, const nlohmann::json& params) {
     }
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] MQTTS连接成功";
     wcp_loger.add_log("MQTTS连接成功", false, "", "Moonraker_Mqtt", "info");
+
+    // 重置时间同步状态
+    if (time_sync_manager_) {
+        time_sync_manager_->reset();
+    }
 
     m_sn_mtx.lock();
     std::string tmp_sn = m_sn;
@@ -2748,6 +2765,12 @@ bool Moonraker_Mqtt::send_to_request(
         std::string topic = main_layer + m_request_topic;
         BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 发布到主题: " << topic;
         wcp_loger.add_log("发布到主题: " + topic, false, "", "Moonraker_Mqtt", "info");
+
+        // 添加时间同步字段
+        if (time_sync_manager_) {
+            time_sync_manager_->addTimeFields(body);
+        }
+
         std::string pub_msg = "success";
         bool res = m_mqtt_client_tls->Publish(topic, body.dump(), 1, pub_msg);
         if (!res) {
@@ -2900,6 +2923,11 @@ void Moonraker_Mqtt::on_auth_arrived(const std::string& payload) {
     wcp_loger.add_log("处理认证到达消息", false, "", "Moonraker_Mqtt", "info");
     try {
         json body = json::parse(payload);
+
+        // 更新时间同步状态
+        if (time_sync_manager_) {
+            time_sync_manager_->updateFromResponse(body);
+        }
 
         if(!body.count("id")){
             BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 认证响应缺少ID字段";

--- a/src/slic3r/Utils/MoonRaker.hpp
+++ b/src/slic3r/Utils/MoonRaker.hpp
@@ -12,6 +12,7 @@
 #include "PrintHost.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "slic3r/Utils/TimeoutMap.hpp"
+#include "TimeSyncManager.hpp"
 
 class MqttClient;
 
@@ -155,6 +156,9 @@ protected:
     std::string m_apikey;
     std::string m_cafile;
     bool        m_ssl_revoke_best_effort;
+
+    // Time synchronization manager
+    std::unique_ptr<TimeSyncManager> time_sync_manager_;
 
     // Helper methods
     virtual void set_auth(Http &http) const;

--- a/src/slic3r/Utils/MoonRaker.hpp
+++ b/src/slic3r/Utils/MoonRaker.hpp
@@ -158,7 +158,7 @@ protected:
     bool        m_ssl_revoke_best_effort;
 
     // Time synchronization manager
-    std::unique_ptr<TimeSyncManager> time_sync_manager_;
+    std::shared_ptr<TimeSyncManager> time_sync_manager_;
 
     // Helper methods
     virtual void set_auth(Http &http) const;

--- a/src/slic3r/Utils/TimeSyncManager.cpp
+++ b/src/slic3r/Utils/TimeSyncManager.cpp
@@ -14,7 +14,7 @@ void TimeSyncManager::addTimeFields(nlohmann::json& request) {
 
     int64_t current_time = getCurrentTimeSec();
 
-    // 检测时钟回拨
+    // Detect clock rollback
     if (last_cli_time_ > 0 && current_time < last_cli_time_) {
         BOOST_LOG_TRIVIAL(warning) << "[TimeSyncManager] Clock rollback detected, resetting sync state";
         clock_offset_ = 0;
@@ -38,7 +38,7 @@ void TimeSyncManager::addTimeFields(nlohmann::json& request) {
 void TimeSyncManager::updateFromResponse(const nlohmann::json& response) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
 
-    // 检查必需字段
+    // Check required fields
     if (!response.contains("cli_time") || !response.contains("dev_time")) {
         BOOST_LOG_TRIVIAL(warning) << "[TimeSyncManager] Response missing time fields";
         sync_fail_count_++;
@@ -50,7 +50,7 @@ void TimeSyncManager::updateFromResponse(const nlohmann::json& response) {
         return;
     }
 
-    // 检查字段类型
+    // Check field types
     if (!response["cli_time"].is_number() || !response["dev_time"].is_number()) {
         BOOST_LOG_TRIVIAL(error) << "[TimeSyncManager] Invalid time field types";
         sync_fail_count_++;
@@ -61,14 +61,14 @@ void TimeSyncManager::updateFromResponse(const nlohmann::json& response) {
         return;
     }
 
-    // NTP 式时间同步算法：
-    // cli_time1 = 发送请求时的客户端时间（上次 addTimeFields 记录）
-    // dev_time  = 设备处理请求时的设备时间（响应中携带，单位：秒）
-    // cli_time2 = 收到响应时的客户端时间
+    // NTP-style time synchronization algorithm:
+    // cli_time1 = client time when the request was sent (recorded by last addTimeFields call)
+    // dev_time  = device time when processing the request (carried in response, unit: seconds)
+    // cli_time2 = client time when the response was received
     // RTT = cli_time2 - cli_time1
-    // 单程延迟估算 = RTT / 2
+    // One-way delay estimate = RTT / 2
     // clock_offset = dev_time - (cli_time1 + RTT / 2)
-    // 推算设备当前时间 = current_cli_time + clock_offset
+    // Estimated current device time = current_cli_time + clock_offset
 
     int64_t cli_time1 = last_cli_time_;
     int64_t cli_time2 = getCurrentTimeSec();

--- a/src/slic3r/Utils/TimeSyncManager.cpp
+++ b/src/slic3r/Utils/TimeSyncManager.cpp
@@ -25,8 +25,13 @@ void TimeSyncManager::addTimeFields(nlohmann::json& request) {
         sync_fail_count_ = 0;
     }
 
+    int64_t dev_time_value = is_synced_ ? calculateDevTime() : -1;
     request["cli_time"] = current_time;
-    request["dev_time"] = is_synced_ ? calculateDevTime() : -1;
+    request["dev_time"] = dev_time_value;
+
+    BOOST_LOG_TRIVIAL(info) << "[TimeSyncManager] 添加时间字段: cli_time=" << current_time
+                            << ", dev_time=" << dev_time_value
+                            << ", is_synced=" << is_synced_;
 
     last_cli_time_ = current_time;
 }
@@ -67,8 +72,11 @@ void TimeSyncManager::updateFromResponse(const nlohmann::json& response) {
     is_synced_ = true;
     sync_fail_count_ = 0;
 
-    BOOST_LOG_TRIVIAL(debug) << "[TimeSyncManager] Sync updated: duration=" << duration_
-                             << "ms, delta=" << delta_time_ << "ms";
+    BOOST_LOG_TRIVIAL(info) << "[TimeSyncManager] 时间同步更新: duration=" << duration_
+                            << "ms, delta=" << delta_time_ << "ms"
+                            << ", cli_time1=" << cli_time1
+                            << ", cli_time2=" << cli_time2
+                            << ", dev_time=" << dev_time;
 }
 
 void TimeSyncManager::reset() {

--- a/src/slic3r/Utils/TimeSyncManager.cpp
+++ b/src/slic3r/Utils/TimeSyncManager.cpp
@@ -3,8 +3,8 @@
 
 namespace Slic3r {
 
-int64_t TimeSyncManager::getCurrentTimeMs() {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(
+int64_t TimeSyncManager::getCurrentTimeSec() {
+    return std::chrono::duration_cast<std::chrono::seconds>(
         std::chrono::system_clock::now().time_since_epoch()
     ).count();
 }
@@ -12,14 +12,13 @@ int64_t TimeSyncManager::getCurrentTimeMs() {
 void TimeSyncManager::addTimeFields(nlohmann::json& request) {
     std::unique_lock<std::shared_mutex> lock(mutex_);
 
-    int64_t current_time = getCurrentTimeMs();
+    int64_t current_time = getCurrentTimeSec();
 
     // 检测时钟回拨
     if (last_cli_time_ > 0 && current_time < last_cli_time_) {
         BOOST_LOG_TRIVIAL(warning) << "[TimeSyncManager] Clock rollback detected, resetting sync state";
-        // 直接重置，不需要释放锁
-        delta_time_ = 0;
-        duration_ = 0;
+        clock_offset_ = 0;
+        rtt_ = 0;
         last_cli_time_ = 0;
         is_synced_ = false;
         sync_fail_count_ = 0;
@@ -29,7 +28,7 @@ void TimeSyncManager::addTimeFields(nlohmann::json& request) {
     request["cli_time"] = current_time;
     request["dev_time"] = dev_time_value;
 
-    BOOST_LOG_TRIVIAL(info) << "[TimeSyncManager] 添加时间字段: cli_time=" << current_time
+    BOOST_LOG_TRIVIAL(info) << "[TimeSyncManager] addTimeFields: cli_time=" << current_time
                             << ", dev_time=" << dev_time_value
                             << ", is_synced=" << is_synced_;
 
@@ -62,18 +61,26 @@ void TimeSyncManager::updateFromResponse(const nlohmann::json& response) {
         return;
     }
 
+    // NTP 式时间同步算法：
+    // cli_time1 = 发送请求时的客户端时间（上次 addTimeFields 记录）
+    // dev_time  = 设备处理请求时的设备时间（响应中携带，单位：秒）
+    // cli_time2 = 收到响应时的客户端时间
+    // RTT = cli_time2 - cli_time1
+    // 单程延迟估算 = RTT / 2
+    // clock_offset = dev_time - (cli_time1 + RTT / 2)
+    // 推算设备当前时间 = current_cli_time + clock_offset
+
     int64_t cli_time1 = last_cli_time_;
-    int64_t cli_time2 = getCurrentTimeMs();
+    int64_t cli_time2 = getCurrentTimeSec();
     int64_t dev_time = response["dev_time"].get<int64_t>();
 
-    // 更新同步参数
-    duration_ = cli_time2 - cli_time1;
-    delta_time_ = cli_time2 - dev_time;
+    rtt_ = cli_time2 - cli_time1;
+    clock_offset_ = dev_time - (cli_time1 + rtt_ / 2);
     is_synced_ = true;
     sync_fail_count_ = 0;
 
-    BOOST_LOG_TRIVIAL(info) << "[TimeSyncManager] 时间同步更新: duration=" << duration_
-                            << "ms, delta=" << delta_time_ << "ms"
+    BOOST_LOG_TRIVIAL(info) << "[TimeSyncManager] Sync updated: rtt=" << rtt_
+                            << "s, offset=" << clock_offset_ << "s"
                             << ", cli_time1=" << cli_time1
                             << ", cli_time2=" << cli_time2
                             << ", dev_time=" << dev_time;
@@ -81,8 +88,8 @@ void TimeSyncManager::updateFromResponse(const nlohmann::json& response) {
 
 void TimeSyncManager::reset() {
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    delta_time_ = 0;
-    duration_ = 0;
+    clock_offset_ = 0;
+    rtt_ = 0;
     last_cli_time_ = 0;
     is_synced_ = false;
     sync_fail_count_ = 0;
@@ -95,8 +102,7 @@ bool TimeSyncManager::isSynced() const {
 }
 
 int64_t TimeSyncManager::calculateDevTime() const {
-    int64_t current_time = getCurrentTimeMs();
-    return current_time - delta_time_ + duration_;
+    return getCurrentTimeSec() + clock_offset_;
 }
 
 } // namespace Slic3r

--- a/src/slic3r/Utils/TimeSyncManager.cpp
+++ b/src/slic3r/Utils/TimeSyncManager.cpp
@@ -1,0 +1,94 @@
+#include "TimeSyncManager.hpp"
+#include <boost/log/trivial.hpp>
+
+namespace Slic3r {
+
+int64_t TimeSyncManager::getCurrentTimeMs() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch()
+    ).count();
+}
+
+void TimeSyncManager::addTimeFields(nlohmann::json& request) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+
+    int64_t current_time = getCurrentTimeMs();
+
+    // 检测时钟回拨
+    if (last_cli_time_ > 0 && current_time < last_cli_time_) {
+        BOOST_LOG_TRIVIAL(warning) << "[TimeSyncManager] Clock rollback detected, resetting sync state";
+        // 直接重置，不需要释放锁
+        delta_time_ = 0;
+        duration_ = 0;
+        last_cli_time_ = 0;
+        is_synced_ = false;
+        sync_fail_count_ = 0;
+    }
+
+    request["cli_time"] = current_time;
+    request["dev_time"] = is_synced_ ? calculateDevTime() : -1;
+
+    last_cli_time_ = current_time;
+}
+
+void TimeSyncManager::updateFromResponse(const nlohmann::json& response) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+
+    // 检查必需字段
+    if (!response.contains("cli_time") || !response.contains("dev_time")) {
+        BOOST_LOG_TRIVIAL(warning) << "[TimeSyncManager] Response missing time fields";
+        sync_fail_count_++;
+        if (sync_fail_count_ >= 3) {
+            BOOST_LOG_TRIVIAL(error) << "[TimeSyncManager] 3 consecutive sync failures, resetting";
+            is_synced_ = false;
+            sync_fail_count_ = 0;
+        }
+        return;
+    }
+
+    // 检查字段类型
+    if (!response["cli_time"].is_number() || !response["dev_time"].is_number()) {
+        BOOST_LOG_TRIVIAL(error) << "[TimeSyncManager] Invalid time field types";
+        sync_fail_count_++;
+        if (sync_fail_count_ >= 3) {
+            is_synced_ = false;
+            sync_fail_count_ = 0;
+        }
+        return;
+    }
+
+    int64_t cli_time1 = last_cli_time_;
+    int64_t cli_time2 = getCurrentTimeMs();
+    int64_t dev_time = response["dev_time"].get<int64_t>();
+
+    // 更新同步参数
+    duration_ = cli_time2 - cli_time1;
+    delta_time_ = cli_time2 - dev_time;
+    is_synced_ = true;
+    sync_fail_count_ = 0;
+
+    BOOST_LOG_TRIVIAL(debug) << "[TimeSyncManager] Sync updated: duration=" << duration_
+                             << "ms, delta=" << delta_time_ << "ms";
+}
+
+void TimeSyncManager::reset() {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    delta_time_ = 0;
+    duration_ = 0;
+    last_cli_time_ = 0;
+    is_synced_ = false;
+    sync_fail_count_ = 0;
+    BOOST_LOG_TRIVIAL(info) << "[TimeSyncManager] Sync state reset";
+}
+
+bool TimeSyncManager::isSynced() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return is_synced_;
+}
+
+int64_t TimeSyncManager::calculateDevTime() const {
+    int64_t current_time = getCurrentTimeMs();
+    return current_time - delta_time_ + duration_;
+}
+
+} // namespace Slic3r

--- a/src/slic3r/Utils/TimeSyncManager.hpp
+++ b/src/slic3r/Utils/TimeSyncManager.hpp
@@ -12,30 +12,30 @@ public:
     TimeSyncManager() = default;
     ~TimeSyncManager() = default;
 
-    // 为请求添加时间字段
+    // Add time fields to the request
     void addTimeFields(nlohmann::json& request);
 
-    // 处理响应，更新时间同步状态
+    // Process response and update time sync state
     void updateFromResponse(const nlohmann::json& response);
 
-    // 重置时间同步状态（用于重连）
+    // Reset time sync state (used for reconnection)
     void reset();
 
-    // 获取同步状态
+    // Get sync status
     bool isSynced() const;
 
-    // 获取当前系统时间（秒）
+    // Get current system time (seconds)
     static int64_t getCurrentTimeSec();
 
 private:
     mutable std::shared_mutex mutex_;
-    int64_t clock_offset_ = 0;     // 设备时钟相对客户端的偏移（秒），dev = cli + offset
-    int64_t rtt_ = 0;              // 最近一次往返时长（秒）
-    int64_t last_cli_time_ = 0;    // 上次请求的客户端时间（秒）
-    bool is_synced_ = false;       // 是否已完成首次同步
-    int sync_fail_count_ = 0;      // 连续同步失败次数
+    int64_t clock_offset_ = 0;     // Device clock offset relative to client (seconds), dev = cli + offset
+    int64_t rtt_ = 0;              // Latest round-trip time (seconds)
+    int64_t last_cli_time_ = 0;    // Client time of the last request (seconds)
+    bool is_synced_ = false;       // Whether the first sync has completed
+    int sync_fail_count_ = 0;      // Consecutive sync failure count
 
-    // 计算设备时间
+    // Calculate device time
     int64_t calculateDevTime() const;
 };
 

--- a/src/slic3r/Utils/TimeSyncManager.hpp
+++ b/src/slic3r/Utils/TimeSyncManager.hpp
@@ -24,14 +24,14 @@ public:
     // 获取同步状态
     bool isSynced() const;
 
-    // 获取当前系统时间（毫秒）
-    static int64_t getCurrentTimeMs();
+    // 获取当前系统时间（秒）
+    static int64_t getCurrentTimeSec();
 
 private:
     mutable std::shared_mutex mutex_;
-    int64_t delta_time_ = 0;      // 客户端与设备的时间差（ms）
-    int64_t duration_ = 0;         // 消息往返时长（ms）
-    int64_t last_cli_time_ = 0;    // 上次请求的客户端时间
+    int64_t clock_offset_ = 0;     // 设备时钟相对客户端的偏移（秒），dev = cli + offset
+    int64_t rtt_ = 0;              // 最近一次往返时长（秒）
+    int64_t last_cli_time_ = 0;    // 上次请求的客户端时间（秒）
     bool is_synced_ = false;       // 是否已完成首次同步
     int sync_fail_count_ = 0;      // 连续同步失败次数
 

--- a/src/slic3r/Utils/TimeSyncManager.hpp
+++ b/src/slic3r/Utils/TimeSyncManager.hpp
@@ -1,0 +1,44 @@
+#ifndef slic3r_TimeSyncManager_hpp_
+#define slic3r_TimeSyncManager_hpp_
+
+#include <shared_mutex>
+#include <chrono>
+#include <nlohmann/json.hpp>
+
+namespace Slic3r {
+
+class TimeSyncManager {
+public:
+    TimeSyncManager() = default;
+    ~TimeSyncManager() = default;
+
+    // 为请求添加时间字段
+    void addTimeFields(nlohmann::json& request);
+
+    // 处理响应，更新时间同步状态
+    void updateFromResponse(const nlohmann::json& response);
+
+    // 重置时间同步状态（用于重连）
+    void reset();
+
+    // 获取同步状态
+    bool isSynced() const;
+
+    // 获取当前系统时间（毫秒）
+    static int64_t getCurrentTimeMs();
+
+private:
+    mutable std::shared_mutex mutex_;
+    int64_t delta_time_ = 0;      // 客户端与设备的时间差（ms）
+    int64_t duration_ = 0;         // 消息往返时长（ms）
+    int64_t last_cli_time_ = 0;    // 上次请求的客户端时间
+    bool is_synced_ = false;       // 是否已完成首次同步
+    int sync_fail_count_ = 0;      // 连续同步失败次数
+
+    // 计算设备时间
+    int64_t calculateDevTime() const;
+};
+
+} // namespace Slic3r
+
+#endif // slic3r_TimeSyncManager_hpp_


### PR DESCRIPTION
# Change Description

Implemented NTP device time synchronization to prevent firmware from being flooded with messages due to server-side message accumulation.

# Change Type

Bug Fix

# Test Steps

1. Local network and cloud-connected devices: Normal connection processes remain unaffected.
2. Adjust log level to "info" and search for the keyword "dev_time" to verify the time synchronization process of sending and receiving messages.
3. Firmware-side validation

# Business Impact Scope

1. Snapmaker device connectivity



# 改动说明
实现NTP设备时间同步，避免服务端消息积攒导致固件端收到洪范消息的问题

# 改动类型
Bug 修复

# 测试步骤
1. 局域网、云联设备，正常联机流程不受影响
3. 日志级别调整成info，搜索dev_time关键词，验证发送消息和接受消息的时间同步流程
4. 固件端校验

# 业务影响范围
1. Snapmaker 设备联机
