### PR TITLE
fix(macos): add NSLocalNetworkUsageDescription for macOS 26 webview blank tabs

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -132,12 +132,22 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
-	<key>NSAppTransportSecurity</key>  
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Snapmaker Orca needs access to your local network to discover and connect to your 3D printer(s), and to serve the app's device interface on localhost.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_http._tcp</string>
+		<string>_printer._tcp</string>
+	</array>
+	<key>NSAppTransportSecurity</key>
 	<dict>
 		<!-- Disable App Transport Security. Resolves https://github.com/SoftFever/OrcaSlicer/issues/791 -->
 		<key>NSAllowsArbitraryLoads</key>
-		<true/>  
+		<true/>
 		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
+		<!-- Allow HTTP connections to localhost for local web server (required for macOS 26+) -->
+		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
 </dict>


### PR DESCRIPTION
## Problem

On macOS 26 (Tahoe), the **Print Preprocessing** window show a blank white screen. The **Prep** and **Preview** tabs work fine.

![Screenshot 2026-04-10 at 12 19 38](https://github.com/user-attachments/assets/63c5184c-0027-4fab-b0ce-2129103c68dc)

Root cause: macOS 26 tightened Local Network access controls for WKWebView. The app serves its Flutter-based UI on `http://127.0.0.1:13619`, but the embedded WebKit webview is blocked from fetching it before the app can even request Local Network permission. Without `NSLocalNetworkUsageDescription` in `Info.plist`, the OS silently denies access, no dialog is shown, no fallback.

This was reported in issues #58 and #167, and also discussed on Reddit:
https://www.reddit.com/r/snapmaker/comments/1pr5icl/snapmaker_orca_mac_problem/

## Root cause of the fix being missing in 2.3.0

`src/dev-utils/platform/osx/Info.plist.in` already contains these keys (added in Feb 2026), but it is **not** wired to `MACOSX_BUNDLE_INFO_PLIST` in CMake. The actual bundle Info.plist is generated from `cmake/modules/MacOSXBundleInfo.plist.in`. This PR fixes the correct file.

## Changes

Single file changed: `cmake/modules/MacOSXBundleInfo.plist.in`

Three keys added:
- `NSLocalNetworkUsageDescription` which triggers the macOS "Allow Local Network Access" permission dialog on first launch
- `NSBonjourServices` required alongside the usage description to declare service types
- `NSAllowsLocalNetworking: true` which explicitly permits HTTP to `localhost` within WebViews

## Testing

Tested on macOS 26.x (Tahoe) with a local build. After granting Local Network permission on first launch, the Print Preprocessing window loads correctly.

Fixes #58
Fixes #167