### PR TITLE
Feat：1.4.0版本-顶盖功能需求-B0.2

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -897,7 +897,7 @@ static std::vector<std::string> s_Preset_filament_options {
     "graphic_effect_plate_temp", "graphic_effect_plate_temp_initial_layer",
     // "bed_type",
     //BBS:temperature_vitrification
-    "temperature_vitrification", "reduce_fan_stop_start_freq","dont_slow_down_outer_wall", "slow_down_for_layer_cooling", "fan_min_speed",
+    "temperature_vitrification", "filament_is_high_temp", "reduce_fan_stop_start_freq","dont_slow_down_outer_wall", "slow_down_for_layer_cooling", "fan_min_speed",
     "fan_max_speed", "enable_overhang_bridge_fan", "overhang_fan_speed", "overhang_fan_threshold", "close_fan_the_first_x_layers", "full_fan_speed_layer", "fan_cooling_layer_time", "slow_down_layer_time", "slow_down_min_speed",
     "filament_start_gcode", "filament_end_gcode",
     //exhaust fan control

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2391,6 +2391,12 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBools { false });
 
+    def = this->add("filament_is_high_temp", coBools);
+    def->label   = L("Is high-temperature filament");
+    def->tooltip = L("Indicates whether this is a high-temperature filament that requires elevated printing temperatures.");
+    def->mode    = comSimple;
+    def->set_default_value(new ConfigOptionBools{false});
+
     // BBS
     def = this->add("temperature_vitrification", coInts);
     def->label = L("Softening temperature");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1180,6 +1180,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloats,              filament_cost))
     ((ConfigOptionStrings,             default_filament_colour))
     ((ConfigOptionInts,                temperature_vitrification))  //BBS
+    ((ConfigOptionBools,               filament_is_high_temp))
     ((ConfigOptionFloats,              filament_max_volumetric_speed))
     ((ConfigOptionInts,                required_nozzle_HRC))
     // BBS

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3580,6 +3580,7 @@ void TabFilament::build()
         optgroup->append_single_option_line("filament_cost");
         //BBS
         optgroup->append_single_option_line("temperature_vitrification");
+        optgroup->append_single_option_line("filament_is_high_temp");
         optgroup->append_single_option_line("idle_temperature");
         Line line = { L("Recommended nozzle temperature"), L("Recommended nozzle temperature range of this filament. 0 means no set") };
         line.append_option(optgroup->get_option("nozzle_temperature_range_low"));


### PR DESCRIPTION
参考文档：https://snapmaker.feishu.cn/wiki/MbmQwPeyUiwjNqkCJlXc9xzOnDd。

### 背景
通过顶盖保温/冷却提升打印质量，需要pc客户端根据固件接入顶盖后针对顶盖增加一些打印功能的一些支持，具体体现在不同的耗材(高温耗材，低温耗材)配置。

### 修改内容
1.PrintConfig.cpp — 定义配置项本身，注册到配置系统，设置标签、tooltip、默认值 false，类型为 coBools（每个挤出头一个值的布尔数组）。          
2.PrintConfig.hpp — 在 GCodeConfig 的 Boost.PP 宏展开表中添加字段声明，使 C++ 代码可以通过 config.filament_is_high_temp直接访问该值（强类型访问，而非字符串 key 查找）。         
3.Preset.cpp — 将 "filament_is_high_temp" 加入 s_Preset_filament_options 白名单，这是决定哪些 key 会被序列化到%appdata%\Snapmaker_Orca\user\defaultfilament\ 下JSON 文件的列表。没有这一步，前两个文件的修改只存在于内存中，不会持久化。
4.Tab.cpp — 在耗材设置 Tab 的 UI 中插入该选项的控件行，让用户在界面上能看到并编辑这个开关，位置在 temperature_vitrification之后、idle_temperature 之前。

### 影响范围
影响 GUI 与输出的json文件。
1.在材料设置界面-耗材丝标签页-基础信息栏中，增加了一个复选框；
2.在保存预设的json文件中增加了一项记录信息；
[
<img width="857" height="372" alt="1280X1280 (1)" src="https://github.com/user-attachments/assets/dc997027-1ff7-4183-a49c-7ccef3d2981a" />
<img width="1002" height="441" alt="1280X1280 (2)" src="https://github.com/user-attachments/assets/2ba076f8-f87d-4363-9f42-fe8b8229a735" />
<img width="1252" height="1009" alt="1280X1280" src="https://github.com/user-attachments/assets/bc7a2e16-041c-40c2-bee1-6940e7c8cf83" />
](url)


### 测试方式
- 检查gui上是否有相应配置项
- 检查修改该配置项是否会记录在输出的json文件中
- 检查是否会影响切片引擎生成的GCode代码

### 风险评估
低风险，仅涉及gui和序列化内容，不涉及切片引擎与GCode代码生成。
