### PR TITLE
Apply upstream bool fix for MQTTPacket.h

### DIFF
--- a/src/mqtt/externals/paho-mqtt-c/src/MQTTPacket.h
+++ b/src/mqtt/externals/paho-mqtt-c/src/MQTTPacket.h
@@ -28,7 +28,7 @@
 #include "LinkedList.h"
 #include "Clients.h"
 
-typedef unsigned int bool;
+typedef unsigned int bit;
 typedef void* (*pf)(int, unsigned char, char*, size_t);
 
 #include "MQTTProperties.h"
@@ -67,16 +67,16 @@ typedef union
 	struct
 	{
 		unsigned int type : 4;	/**< message type nibble */
-		bool dup : 1;			/**< DUP flag bit */
+		bit dup : 1;			/**< DUP flag bit */
 		unsigned int qos : 2;	/**< QoS value, 0, 1 or 2 */
-		bool retain : 1;		/**< retained flag bit */
+		bit retain : 1;		/**< retained flag bit */
 	} bits;
 #else
 	struct
 	{
-		bool retain : 1;		/**< retained flag bit */
+		bit retain : 1;		/**< retained flag bit */
 		unsigned int qos : 2;	/**< QoS value, 0, 1 or 2 */
-		bool dup : 1;			/**< DUP flag bit */
+		bit dup : 1;			/**< DUP flag bit */
 		unsigned int type : 4;	/**< message type nibble */
 	} bits;
 #endif
@@ -95,24 +95,24 @@ typedef struct
 #if defined(REVERSED)
 		struct
 		{
-			bool username : 1;			/**< 3.1 user name */
-			bool password : 1; 			/**< 3.1 password */
-			bool willRetain : 1;		/**< will retain setting */
+			bit username : 1;			/**< 3.1 user name */
+			bit password : 1; 			/**< 3.1 password */
+			bit willRetain : 1;		/**< will retain setting */
 			unsigned int willQoS : 2;	/**< will QoS value */
-			bool will : 1;			/**< will flag */
-			bool cleanstart : 1;	/**< cleansession flag */
+			bit will : 1;			/**< will flag */
+			bit cleanstart : 1;	/**< cleansession flag */
 			int : 1;	/**< unused */
 		} bits;
 #else
 		struct
 		{
 			int : 1;	/**< unused */
-			bool cleanstart : 1;	/**< cleansession flag */
-			bool will : 1;			/**< will flag */
+			bit cleanstart : 1;	/**< cleansession flag */
+			bit will : 1;			/**< will flag */
 			unsigned int willQoS : 2;	/**< will QoS value */
-			bool willRetain : 1;		/**< will retain setting */
-			bool password : 1; 			/**< 3.1 password */
-			bool username : 1;			/**< 3.1 user name */
+			bit willRetain : 1;		/**< will retain setting */
+			bit password : 1; 			/**< 3.1 password */
+			bit username : 1;			/**< 3.1 user name */
 		} bits;
 #endif
 	} flags;	/**< connect flags byte */
@@ -140,12 +140,12 @@ typedef struct
 		struct
 		{
 			unsigned int reserved : 7;	/**< message type nibble */
-			bool sessionPresent : 1;    /**< was a session found on the server? */
+			bit sessionPresent : 1;    /**< was a session found on the server? */
 		} bits;
 #else
 		struct
 		{
-			bool sessionPresent : 1;    /**< was a session found on the server? */
+			bit sessionPresent : 1;    /**< was a session found on the server? */
 			unsigned int reserved : 7;	/**< message type nibble */
 		} bits;
 #endif


### PR DESCRIPTION
I'm getting build errors on Fedora 42, because MQTTPacket.h tries to redefine "bool" which is a reserved name in C23.

This is fixed upstream by:
https://github.com/eclipse-paho/paho.mqtt.c/commit/9ff08fa5a78f4fd378244ea7e2f30b24298d61c8

So, lets do the same here.