### PR TITLE
feat(gui): Add mixed filament color mix dialog with ratio/cycle/match/gradient modes

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -311,6 +311,13 @@ set(SLIC3R_GUI_SOURCES
     GUI/NotificationManager.hpp
     GUI/OAuthDialog.cpp
     GUI/OAuthDialog.hpp
+    GUI/AddColorMixDialog.cpp
+    GUI/AddColorMixDialog.hpp
+    GUI/MixedGradientSelector.hpp
+    GUI/MixedColorMatchPanel.cpp
+    GUI/MixedColorMatchPanel.hpp
+    GUI/MixedColorMatchHelpers.hpp
+    GUI/MixedFilamentColorMapPanel.hpp
     GUI/ObjColorDialog.cpp
     GUI/ObjColorDialog.hpp
     GUI/ObjectDataViewModel.cpp

--- a/src/slic3r/GUI/AddColorMixDialog.cpp
+++ b/src/slic3r/GUI/AddColorMixDialog.cpp
@@ -1,0 +1,1033 @@
+#include "AddColorMixDialog.hpp"
+#include "GUI_App.hpp"
+#include "I18N.hpp"
+#include "MixedColorMatchHelpers.hpp"
+#include "libslic3r/MixedFilament.hpp"
+
+#include <wx/dcbuffer.h>
+#include <wx/statline.h>
+#include <wx/sizer.h>
+#include <wx/bmpbuttn.h>
+
+#include <algorithm>
+
+namespace Slic3r { namespace GUI {
+
+static constexpr int SWATCH_SIZE  = 16;
+static constexpr int PREVIEW_SIZE = 80;
+static constexpr int STRIP_HEIGHT = 24;
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+AddColorMixDialog::AddColorMixDialog(wxWindow* parent,
+                                     const std::vector<std::string>& filament_colours)
+    : DPIDialog(parent, wxID_ANY, _L("Add Color Mix"),
+                wxDefaultPosition, wxDefaultSize,
+                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+    , m_filament_colours(filament_colours)
+{
+    m_result.component_a   = 1;
+    m_result.component_b   = 2;
+    m_result.mix_b_percent = 50;
+    build_ui();
+}
+
+AddColorMixDialog::AddColorMixDialog(wxWindow* parent,
+                                     const std::vector<std::string>& filament_colours,
+                                     const Slic3r::MixedFilament& existing)
+    : DPIDialog(parent, wxID_ANY, _L("Edit Color Mix"),
+                wxDefaultPosition, wxDefaultSize,
+                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+    , m_filament_colours(filament_colours)
+    , m_result(existing)
+{
+    if (!MixedFilamentManager::normalize_manual_pattern(existing.manual_pattern).empty())
+        m_current_mode = MODE_CYCLE;
+    else if (!existing.gradient_component_ids.empty() &&
+             existing.distribution_mode == int(MixedFilament::Simple))
+        m_current_mode = MODE_MATCH;
+    else if (!existing.gradient_component_ids.empty() &&
+             existing.distribution_mode == int(MixedFilament::LayerCycle) &&
+             !existing.gradient_component_weights.empty())
+        m_current_mode = MODE_RATIO;
+    else if (!existing.gradient_component_ids.empty() &&
+             existing.distribution_mode == int(MixedFilament::LayerCycle))
+        m_current_mode = MODE_GRADIENT;
+    else
+        m_current_mode = MODE_RATIO;
+
+    // Restore tri-picker weights from slash-separated weight string
+    if (m_current_mode == MODE_RATIO && !existing.gradient_component_weights.empty()) {
+        std::vector<int> vals;
+        const char *p = existing.gradient_component_weights.c_str();
+        while (*p) {
+            char *end;
+            int v = (int)std::strtol(p, &end, 10);
+            if (end == p) break;
+            vals.push_back(v);
+            p = end;
+            if (*p == '/') ++p;
+        }
+        if (vals.size() >= 3) {
+            int total = 0;
+            for (int v : vals) total += v;
+            if (total > 0) {
+                m_tri_wx = vals[0] / (double)total;
+                m_tri_wy = vals[1] / (double)total;
+                m_tri_wz = vals[2] / (double)total;
+            }
+        }
+    }
+
+    build_ui();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+wxBitmap AddColorMixDialog::make_color_bitmap(const wxColour& c, int size)
+{
+    wxBitmap bmp(size, size);
+    wxMemoryDC dc(bmp);
+    dc.SetBackground(wxBrush(c));
+    dc.Clear();
+    return bmp;
+}
+
+int AddColorMixDialog::max_filaments_for_mode(int mode) const
+{
+    return (mode == MODE_RATIO) ? 3 : 4;
+}
+
+// ---------------------------------------------------------------------------
+// UI construction
+// ---------------------------------------------------------------------------
+
+void AddColorMixDialog::build_ui()
+{
+    SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
+
+    auto* top_sizer = new wxBoxSizer(wxVERTICAL);
+    const int M = FromDIP(8);
+
+    // Mode radio
+    m_mode_radio = new RadioGroup(this,
+        { _L("Ratio"), _L("Cycle"), _L("Match"), _L("Gradient") },
+        wxHORIZONTAL);
+    m_mode_radio->SetSelection(m_current_mode);
+    top_sizer->Add(m_mode_radio, 0, wxEXPAND | wxALL, M);
+    top_sizer->Add(new wxStaticLine(this), 0, wxEXPAND | wxLEFT | wxRIGHT, M);
+
+    // "Mixed Filament" section title (hidden in match mode)
+    m_filament_title = new wxStaticText(this, wxID_ANY, _L("Mixed Filament"));
+    top_sizer->Add(m_filament_title, 0, wxLEFT | wxTOP, M);
+
+    // Filament rows + preview
+    auto* mid_sizer = new wxBoxSizer(wxHORIZONTAL);
+
+    m_filament_rows_panel = new wxPanel(this);
+    m_filament_rows_sizer = new wxBoxSizer(wxVERTICAL);
+    m_filament_rows_panel->SetSizer(m_filament_rows_sizer);
+    mid_sizer->Add(m_filament_rows_panel, 1, wxEXPAND | wxRIGHT, M);
+
+    auto* preview_col = new wxBoxSizer(wxVERTICAL);
+    m_preview_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition,
+                                  wxSize(FromDIP(PREVIEW_SIZE), FromDIP(PREVIEW_SIZE)));
+    m_preview_panel->SetMinSize(wxSize(FromDIP(PREVIEW_SIZE), FromDIP(PREVIEW_SIZE)));
+    m_preview_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
+    m_preview_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
+        wxAutoBufferedPaintDC dc(m_preview_panel);
+        if (m_current_mode == MODE_GRADIENT && m_filament_rows.size() >= 2) {
+            wxSize sz = m_preview_panel->GetClientSize();
+            int ia = std::max(0, std::min(m_filament_rows[0].combo->GetSelection(), (int)m_filament_colours.size()-1));
+            int ib = std::max(0, std::min(m_filament_rows[1].combo->GetSelection(), (int)m_filament_colours.size()-1));
+            wxColour ca = parse_mixed_color(m_filament_colours[ia]);
+            wxColour cb = parse_mixed_color(m_filament_colours[ib]);
+            wxImage img(sz.GetWidth(), sz.GetHeight());
+            unsigned char* data = img.GetData();
+            for (int y = 0; y < sz.GetHeight(); ++y) {
+                for (int x = 0; x < sz.GetWidth(); ++x) {
+                    float t = (sz.GetWidth() + sz.GetHeight() > 2)
+                        ? float(x + y) / float(sz.GetWidth() + sz.GetHeight() - 2) : 0.5f;
+                    wxColour c = blend_pair_filament_mixer(ca, cb, t);
+                    int idx = (y * sz.GetWidth() + x) * 3;
+                    data[idx]   = c.Red();
+                    data[idx+1] = c.Green();
+                    data[idx+2] = c.Blue();
+                }
+            }
+            dc.DrawBitmap(wxBitmap(img), 0, 0, false);
+        } else {
+            dc.SetBackground(wxBrush(parse_mixed_color(compute_preview_color())));
+            dc.Clear();
+        }
+    });
+    preview_col->Add(m_preview_panel, 0, wxALIGN_CENTER);
+    m_preview_label = new wxStaticText(this, wxID_ANY, _L("Mix Color Effect"));
+    preview_col->Add(m_preview_label, 0, wxALIGN_CENTER | wxTOP, FromDIP(4));
+    mid_sizer->Add(preview_col, 0, wxALIGN_TOP);
+
+    top_sizer->Add(mid_sizer, 0, wxEXPAND | wxALL, M);
+    m_line_below_mid = new wxStaticLine(this);
+    top_sizer->Add(m_line_below_mid, 0, wxEXPAND | wxLEFT | wxRIGHT, M);
+
+    // Gradient selector (2-filament ratio mode)
+    int initial_val = m_result.mix_b_percent;
+    if (m_current_mode == MODE_RATIO && m_result.gradient_component_ids.empty()) {
+        int total = m_result.ratio_a + m_result.ratio_b;
+        if (total > 0) initial_val = m_result.ratio_b * 100 / total;
+    }
+    wxColour col_a = (!m_filament_colours.empty())
+        ? parse_mixed_color(m_filament_colours[std::max(0, (int)m_result.component_a - 1)])
+        : wxColour(128, 128, 128);
+    wxColour col_b = (m_filament_colours.size() > 1)
+        ? parse_mixed_color(m_filament_colours[std::max(0, (int)m_result.component_b - 1)])
+        : col_a;
+    m_gradient_selector = new MixedGradientSelector(this, col_a, col_b, initial_val);
+    m_ratio_label_a = new wxStaticText(this, wxID_ANY, wxString::Format("%d%%", 100 - initial_val));
+    m_ratio_label_b = new wxStaticText(this, wxID_ANY, wxString::Format("%d%%", initial_val));
+    m_ratio_label_sizer = new wxBoxSizer(wxHORIZONTAL);
+    m_ratio_label_sizer->Add(m_ratio_label_a, 0);
+    m_ratio_label_sizer->AddStretchSpacer();
+    m_ratio_label_sizer->Add(m_ratio_label_b, 0);
+
+    // Strip preview panel — shown in 2-color ratio mode
+    m_strip_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition,
+                                wxSize(-1, FromDIP(STRIP_HEIGHT)));
+    m_strip_panel->SetMinSize(wxSize(-1, FromDIP(STRIP_HEIGHT)));
+    m_strip_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
+    m_strip_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
+        wxAutoBufferedPaintDC dc(m_strip_panel);
+        draw_strip(dc, m_strip_panel);
+    });
+
+    const int LABEL_W = FromDIP(60);
+    m_gradient_bar_sizer = new wxBoxSizer(wxVERTICAL);
+    {
+        auto* ratio_row = new wxBoxSizer(wxHORIZONTAL);
+        auto* ratio_lbl = new wxStaticText(this, wxID_ANY, _L("Mix Ratio"),
+                                           wxDefaultPosition, wxSize(LABEL_W, -1));
+        auto* ratio_right = new wxBoxSizer(wxVERTICAL);
+        ratio_right->Add(m_ratio_label_sizer, 0, wxEXPAND | wxBOTTOM, FromDIP(2));
+        ratio_right->Add(m_gradient_selector, 0, wxEXPAND);
+        ratio_row->Add(ratio_lbl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, M);
+        ratio_row->Add(ratio_right, 1, wxEXPAND);
+        m_gradient_bar_sizer->Add(ratio_row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, M);
+    }
+    {
+        // Preview strip row — 2-color only; strip panel lives here
+        auto* preview_row = new wxBoxSizer(wxHORIZONTAL);
+        auto* preview_lbl = new wxStaticText(this, wxID_ANY, _L("Preview"),
+                                             wxDefaultPosition, wxSize(LABEL_W, -1));
+        preview_row->Add(preview_lbl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, M);
+        preview_row->Add(m_strip_panel, 1, wxEXPAND);
+        m_gradient_bar_sizer->Add(preview_row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP | wxBOTTOM, M);
+    }
+    top_sizer->Add(m_gradient_bar_sizer, 0, wxEXPAND);
+
+    // Triangle picker (3-filament ratio mode) — triangle left, preview strip right
+    build_tri_picker();
+    {
+        m_tri_strip_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize);
+        m_tri_strip_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
+        m_tri_strip_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
+            wxAutoBufferedPaintDC dc(m_tri_strip_panel);
+            draw_strip(dc, m_tri_strip_panel);
+        });
+
+        m_tri_picker_sizer = new wxBoxSizer(wxVERTICAL);
+        auto* tri_cols = new wxBoxSizer(wxHORIZONTAL);
+
+        auto* tri_left = new wxBoxSizer(wxVERTICAL);
+        tri_left->Add(new wxStaticText(this, wxID_ANY, _L("Mix Ratio")),
+                      0, wxALIGN_CENTER | wxBOTTOM, FromDIP(2));
+        tri_left->Add(m_tri_picker, 0, wxALIGN_CENTER);
+
+        auto* tri_right = new wxBoxSizer(wxVERTICAL);
+        tri_right->Add(new wxStaticText(this, wxID_ANY, _L("Preview")),
+                       0, wxALIGN_CENTER | wxBOTTOM, FromDIP(2));
+        tri_right->Add(m_tri_strip_panel, 1, wxEXPAND);
+
+        tri_cols->Add(tri_left, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, M * 2);
+        tri_cols->Add(tri_right, 1, wxEXPAND);
+        m_tri_picker_sizer->Add(tri_cols, 0, wxEXPAND | wxALL, M);
+    }
+    top_sizer->Add(m_tri_picker_sizer, 0, wxEXPAND);
+
+    // Match mode panel
+    {
+        m_match_panel_sizer = new wxBoxSizer(wxVERTICAL);
+        wxColour initial = (m_current_mode == MODE_MATCH && !m_result.display_color.empty())
+            ? parse_mixed_color(m_result.display_color)
+            : wxColour("#26A69A");
+        m_match_panel = new MixedColorMatchPanel(this, m_filament_colours, initial);
+        m_match_panel_sizer->Add(m_match_panel, 0, wxEXPAND | wxALL, M);
+        top_sizer->Add(m_match_panel_sizer, 0, wxEXPAND);
+    }
+
+    // Pattern editor (cycle mode) — strip panel is added here for cycle/gradient modes
+    {
+        const std::string init_pattern = MixedFilamentManager::normalize_manual_pattern(
+            m_current_mode == MODE_CYCLE ? m_result.manual_pattern : std::string());
+        m_pattern_panel_sizer = new wxBoxSizer(wxVERTICAL);
+
+        auto* pattern_row = new wxBoxSizer(wxHORIZONTAL);
+        pattern_row->Add(new wxStaticText(this, wxID_ANY, _L("Pattern")), 0,
+                         wxALIGN_CENTER_VERTICAL | wxRIGHT, M);
+        m_pattern_ctrl = new wxTextCtrl(this, wxID_ANY,
+                                        from_u8(init_pattern.empty() ? "12" : init_pattern),
+                                        wxDefaultPosition, wxSize(FromDIP(200), -1),
+                                        wxTE_PROCESS_ENTER);
+        m_pattern_ctrl->SetToolTip(_L("Repeating layer pattern. Use 1/2 or A/B for the two filaments, "
+                                      "3..9 for direct physical filament IDs. "
+                                      "Comma-separated groups set per-perimeter patterns, e.g. 12,21. "
+                                      "Examples: 1/1/2/2, 12,21, 1/2/3."));
+        pattern_row->Add(m_pattern_ctrl, 1, wxALIGN_CENTER_VERTICAL);
+        m_pattern_ctrl->Bind(wxEVT_TEXT, [this](wxCommandEvent&) {
+            if (m_cycle_strip_panel) m_cycle_strip_panel->Refresh();
+        });
+        m_pattern_panel_sizer->Add(pattern_row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, M);
+
+        auto* btn_row = new wxBoxSizer(wxHORIZONTAL);
+        btn_row->Add(new wxStaticText(this, wxID_ANY, _L("Filaments")), 0,
+                     wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+        for (int fid = 0; fid < (int)m_filament_colours.size(); ++fid) {
+            auto* btn = new wxButton(this, wxID_ANY, wxString::Format("%d", fid + 1),
+                                     wxDefaultPosition, wxSize(FromDIP(24), FromDIP(22)),
+                                     wxBU_EXACTFIT);
+            btn->SetBackgroundColour(parse_mixed_color(m_filament_colours[fid]));
+            btn->SetToolTip(wxString::Format(_L("Append filament %d to pattern"), fid + 1));
+            btn->Bind(wxEVT_BUTTON, [this, fid](wxCommandEvent&) {
+                if (m_pattern_ctrl)
+                    m_pattern_ctrl->AppendText(wxString::Format("%d", fid + 1));
+            });
+            btn_row->Add(btn, 0, wxRIGHT, FromDIP(4));
+            m_pattern_quick_buttons.push_back(btn);
+        }
+        m_pattern_panel_sizer->Add(btn_row, 0, wxLEFT | wxRIGHT | wxTOP, M);
+
+        m_cycle_strip_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition,
+                                          wxSize(-1, FromDIP(STRIP_HEIGHT)));
+        m_cycle_strip_panel->SetMinSize(wxSize(-1, FromDIP(STRIP_HEIGHT)));
+        m_cycle_strip_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
+        m_cycle_strip_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
+            wxAutoBufferedPaintDC dc(m_cycle_strip_panel);
+            draw_strip(dc, m_cycle_strip_panel);
+        });
+        m_pattern_ctrl->Bind(wxEVT_TEXT, [this](wxCommandEvent&) {
+            if (m_cycle_strip_panel) m_cycle_strip_panel->Refresh();
+        });
+        m_pattern_panel_sizer->Add(m_cycle_strip_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, M);
+
+        top_sizer->Add(m_pattern_panel_sizer, 0, wxEXPAND);
+    }
+
+    m_line_above_swatch = new wxStaticLine(this);
+    top_sizer->Add(m_line_above_swatch, 0, wxEXPAND | wxLEFT | wxRIGHT, M);
+
+    // Recommended swatches
+    m_recommended_label = new wxStaticText(this, wxID_ANY, _L("Recommended"));
+    top_sizer->Add(m_recommended_label, 0, wxLEFT | wxTOP, M);
+    m_swatch_grid_panel = new wxPanel(this);
+    build_swatch_grid();
+    top_sizer->Add(m_swatch_grid_panel, 0, wxEXPAND | wxALL, M);
+    m_line_below_swatch = new wxStaticLine(this);
+    top_sizer->Add(m_line_below_swatch, 0, wxEXPAND | wxLEFT | wxRIGHT, M);
+
+    // Buttons
+    auto* btn_sizer = new wxBoxSizer(wxHORIZONTAL);
+    m_btn_cancel  = new Button(this, _L("Cancel"));
+    m_btn_confirm = new Button(this, _L("Confirm"));
+    m_btn_confirm->SetStyle(ButtonStyle::Confirm, ButtonType::Window);
+    btn_sizer->AddStretchSpacer();
+    btn_sizer->Add(m_btn_cancel,  0, wxRIGHT, FromDIP(8));
+    btn_sizer->Add(m_btn_confirm, 0);
+    top_sizer->Add(btn_sizer, 0, wxEXPAND | wxALL, M);
+
+    SetSizer(top_sizer);
+
+    rebuild_filament_rows();
+
+    // RadioGroup fires wxEVT_BUTTON on its internal label buttons; bind at panel level
+    m_mode_radio->Bind(wxEVT_COMMAND_RADIOBOX_SELECTED, [this](wxCommandEvent&) {
+        on_mode_changed(m_mode_radio->GetSelection());
+    });
+    m_gradient_selector->Bind(wxEVT_SLIDER, [this](wxCommandEvent&) {
+        int val = m_gradient_selector->value();
+        if (m_ratio_label_a) m_ratio_label_a->SetLabel(wxString::Format("%d%%", 100 - val));
+        if (m_ratio_label_b) m_ratio_label_b->SetLabel(wxString::Format("%d%%", val));
+        if (m_ratio_label_sizer) m_ratio_label_sizer->Layout();
+        if (m_preview_panel) m_preview_panel->Refresh();
+        if (m_strip_panel)   m_strip_panel->Refresh();
+    });
+    m_btn_cancel->Bind(wxEVT_BUTTON,  [this](wxCommandEvent&) { EndModal(wxID_CANCEL); });
+    m_btn_confirm->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+        collect_result();
+        EndModal(wxID_OK);
+    });
+
+    Fit();
+    CentreOnParent();
+
+    // Trigger after Fit() so the panel has a real size when the async result arrives.
+    if (m_current_mode == MODE_MATCH && m_match_panel)
+        m_match_panel->begin_initial_recipe_load();
+}
+
+// ---------------------------------------------------------------------------
+// Barycentric triangle utilities
+// ---------------------------------------------------------------------------
+
+struct TriPt { double x, y; };
+
+static double tri_area2(TriPt a, TriPt b, TriPt c)
+{
+    return (b.x - a.x) * (c.y - a.y) - (c.x - a.x) * (b.y - a.y);
+}
+
+static void tri_bary(TriPt p, TriPt v0, TriPt v1, TriPt v2,
+                     double& w0, double& w1, double& w2)
+{
+    double total = std::abs(tri_area2(v0, v1, v2));
+    if (total < 1e-9) { w0 = w1 = w2 = 1.0 / 3.0; return; }
+    w0 = std::abs(tri_area2(p, v1, v2)) / total;
+    w1 = std::abs(tri_area2(v0, p, v2)) / total;
+    w2 = 1.0 - w0 - w1;
+    w0 = std::clamp(w0, 0.0, 1.0);
+    w1 = std::clamp(w1, 0.0, 1.0);
+    w2 = std::clamp(w2, 0.0, 1.0);
+    double s = w0 + w1 + w2;
+    if (s > 0) { w0 /= s; w1 /= s; w2 /= s; }
+}
+
+static TriPt tri_clamp_pt(TriPt p, TriPt v0, TriPt v1, TriPt v2)
+{
+    double w0, w1, w2;
+    tri_bary(p, v0, v1, v2, w0, w1, w2);
+    return { w0 * v0.x + w1 * v1.x + w2 * v2.x,
+             w0 * v0.y + w1 * v1.y + w2 * v2.y };
+}
+
+// ---------------------------------------------------------------------------
+
+void AddColorMixDialog::rebuild_filament_rows()
+{
+    m_filament_rows_sizer->Clear(true);
+    m_filament_rows.clear();
+
+    const int max_idx = std::max(0, (int)m_filament_colours.size() - 1);
+    std::vector<int> sels;
+
+    // Detect "all-ids" format (match recipe): gradient_component_ids contains
+    // component_a as its first entry, meaning all filaments are listed there.
+    const std::string &ids = m_result.gradient_component_ids;
+    const bool all_ids_format = !ids.empty() &&
+        (ids[0] - '0') == (int)m_result.component_a;
+
+    if (all_ids_format) {
+        for (char c : ids)
+            sels.push_back(std::clamp(int(c - '1'), 0, max_idx));
+    } else {
+        sels.push_back(std::clamp((int)m_result.component_a - 1, 0, max_idx));
+        sels.push_back(std::clamp((int)m_result.component_b - 1, 0, max_idx));
+        for (char c : ids) {
+            int idx = c - '1';
+            sels.push_back(std::clamp(idx, 0, max_idx));
+        }
+    }
+
+    int count = (int)sels.size();
+    count = std::max(2, std::min(count, max_filaments_for_mode(m_current_mode)));
+
+    for (int i = 0; i < count; ++i) {
+        auto* row = new wxBoxSizer(wxHORIZONTAL);
+
+        auto* row_lbl = new wxStaticText(m_filament_rows_panel, wxID_ANY,
+                                         wxString::Format(_L("Filament %d"), i + 1),
+                                         wxDefaultPosition, wxSize(FromDIP(60), -1));
+        row->Add(row_lbl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+
+        auto* sw = new wxPanel(m_filament_rows_panel, wxID_ANY, wxDefaultPosition,
+                               wxSize(FromDIP(SWATCH_SIZE), FromDIP(SWATCH_SIZE)));
+        sw->SetMinSize(wxSize(FromDIP(SWATCH_SIZE), FromDIP(SWATCH_SIZE)));
+        sw->SetBackgroundStyle(wxBG_STYLE_PAINT);
+
+        auto* cb = new ComboBox(m_filament_rows_panel, wxID_ANY, wxEmptyString,
+                                wxDefaultPosition, wxSize(FromDIP(120), -1),
+                                0, nullptr, wxCB_READONLY);
+        for (int j = 0; j < (int)m_filament_colours.size(); ++j)
+            cb->Append(wxString::Format("F%d", j + 1),
+                       make_color_bitmap(parse_mixed_color(m_filament_colours[j]), FromDIP(SWATCH_SIZE)));
+
+        int sel = (i < (int)sels.size()) ? sels[i] : i;
+        sel = std::max(0, std::min(sel, (int)m_filament_colours.size() - 1));
+        cb->SetSelection(sel);
+
+        wxColour init_col = parse_mixed_color(m_filament_colours[sel]);
+        sw->Bind(wxEVT_PAINT, [sw, init_col](wxPaintEvent&) mutable {
+            wxAutoBufferedPaintDC dc(sw);
+            dc.SetBackground(wxBrush(init_col));
+            dc.Clear();
+        });
+
+        cb->Bind(wxEVT_COMBOBOX, [this, sw, cb](wxCommandEvent&) {
+            int s = cb->GetSelection();
+            if (s >= 0 && s < (int)m_filament_colours.size()) {
+                wxColour nc = parse_mixed_color(m_filament_colours[s]);
+                sw->Bind(wxEVT_PAINT, [sw, nc](wxPaintEvent&) mutable {
+                    wxAutoBufferedPaintDC dc(sw);
+                    dc.SetBackground(wxBrush(nc));
+                    dc.Clear();
+                });
+                sw->Refresh();
+            }
+            if (m_tri_picker) m_tri_picker->Refresh();
+            update_preview();
+        });
+
+        row->Add(sw, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+        row->Add(cb, 1, wxALIGN_CENTER_VERTICAL);
+
+        if (m_current_mode == MODE_GRADIENT && i > 0) {
+            auto* btn_up = new wxButton(m_filament_rows_panel, wxID_ANY, wxString::FromUTF8("\xe2\x86\x91"),
+                                        wxDefaultPosition, wxSize(FromDIP(24), FromDIP(24)));
+            btn_up->Bind(wxEVT_BUTTON, [this, i](wxCommandEvent&) {
+                if (i < 1 || i >= (int)m_filament_rows.size()) return;
+                int sel_a = m_filament_rows[i - 1].combo->GetSelection();
+                int sel_b = m_filament_rows[i].combo->GetSelection();
+                m_filament_rows[i - 1].combo->SetSelection(sel_b);
+                m_filament_rows[i].combo->SetSelection(sel_a);
+                wxColour ca = sel_b >= 0 && sel_b < (int)m_filament_colours.size()
+                    ? parse_mixed_color(m_filament_colours[sel_b]) : wxColour(128,128,128);
+                wxColour cb2 = sel_a >= 0 && sel_a < (int)m_filament_colours.size()
+                    ? parse_mixed_color(m_filament_colours[sel_a]) : wxColour(128,128,128);
+                m_filament_rows[i - 1].swatch->Bind(wxEVT_PAINT, [sw0 = m_filament_rows[i-1].swatch, ca](wxPaintEvent&) mutable {
+                    wxAutoBufferedPaintDC dc(sw0); dc.SetBackground(wxBrush(ca)); dc.Clear();
+                });
+                m_filament_rows[i].swatch->Bind(wxEVT_PAINT, [sw1 = m_filament_rows[i].swatch, cb2](wxPaintEvent&) mutable {
+                    wxAutoBufferedPaintDC dc(sw1); dc.SetBackground(wxBrush(cb2)); dc.Clear();
+                });
+                m_filament_rows[i - 1].swatch->Refresh();
+                m_filament_rows[i].swatch->Refresh();
+                update_preview();
+            });
+            row->Add(btn_up, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(4));
+        }
+
+        if (i == count - 1) {
+            auto* btn_rm = new wxButton(m_filament_rows_panel, wxID_ANY, "-",
+                                        wxDefaultPosition, wxSize(FromDIP(24), FromDIP(24)));
+            auto* btn_ad = new wxButton(m_filament_rows_panel, wxID_ANY, "+",
+                                        wxDefaultPosition, wxSize(FromDIP(24), FromDIP(24)));
+            btn_rm->Enable(count > 2);
+            btn_ad->Enable(count < max_filaments_for_mode(m_current_mode));
+
+            btn_rm->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+                sync_rows_to_result();
+                int new_count = std::max(2, (int)m_filament_rows.size() - 1);
+                if (new_count == 2) {
+                    m_tri_wx = 1.0/3.0; m_tri_wy = 1.0/3.0; m_tri_wz = 1.0/3.0;
+                }
+                resize_gradient_ids(new_count);
+                wxTheApp->CallAfter([this]() {
+                    rebuild_filament_rows();
+                    Layout(); Fit();
+                });
+            });
+            btn_ad->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+                sync_rows_to_result();
+                resize_gradient_ids((int)m_filament_rows.size() + 1);
+                wxTheApp->CallAfter([this]() {
+                    rebuild_filament_rows();
+                    Layout(); Fit();
+                });
+            });
+
+            row->Add(btn_rm, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(4));
+            row->Add(btn_ad, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(2));
+        }
+
+        m_filament_rows_sizer->Add(row, 0, wxEXPAND | wxBOTTOM, FromDIP(4));
+        m_filament_rows.push_back({ sw, cb });
+    }
+
+    m_filament_rows_panel->Layout();
+    update_ratio_or_tri_visibility();
+    update_preview();
+}
+
+void AddColorMixDialog::build_tri_picker()
+{
+    static constexpr int TRI_SIZE = 160;
+    m_tri_picker = new wxPanel(this, wxID_ANY, wxDefaultPosition,
+                               wxSize(FromDIP(TRI_SIZE), FromDIP(TRI_SIZE)));
+    m_tri_picker->SetMinSize(wxSize(FromDIP(TRI_SIZE), FromDIP(TRI_SIZE)));
+    m_tri_picker->SetBackgroundStyle(wxBG_STYLE_PAINT);
+
+    auto get_verts = [this]() -> std::tuple<TriPt, TriPt, TriPt> {
+        wxSize sz = m_tri_picker->GetClientSize();
+        double pw = sz.GetWidth(), ph = sz.GetHeight();
+        double margin = FromDIP(20);
+        double side = std::min(pw, ph) - 2 * margin;
+        double tri_h = side * std::sqrt(3.0) / 2.0;
+        double cx = pw / 2.0;
+        double top_y = (ph - tri_h) / 2.0;
+        double bot_y = top_y + tri_h;
+        return { {cx, top_y}, {cx - side / 2.0, bot_y}, {cx + side / 2.0, bot_y} };
+    };
+
+    m_tri_picker->Bind(wxEVT_PAINT, [this, get_verts](wxPaintEvent&) {
+        wxAutoBufferedPaintDC dc(m_tri_picker);
+        wxSize sz = m_tri_picker->GetClientSize();
+        auto [v0, v1, v2] = get_verts();
+
+        dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW)));
+        dc.Clear();
+
+        // get the 3 filament colours (rows 0,1,2)
+        auto safe_col = [&](int row) -> wxColour {
+            if (row >= (int)m_filament_rows.size()) return wxColour(128,128,128);
+            int s = m_filament_rows[row].combo->GetSelection();
+            s = std::max(0, std::min(s, (int)m_filament_colours.size()-1));
+            return parse_mixed_color(m_filament_colours[s]);
+        };
+        wxColour c0 = safe_col(0), c1 = safe_col(1), c2 = safe_col(2);
+
+        int min_y = (int)std::min({v0.y, v1.y, v2.y});
+        int max_y = (int)std::max({v0.y, v1.y, v2.y});
+        int min_x = (int)std::min({v0.x, v1.x, v2.x});
+        int max_x = (int)std::max({v0.x, v1.x, v2.x});
+
+        const int img_w = sz.GetWidth(), img_h = sz.GetHeight();
+        wxImage img(img_w, img_h);
+        const wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+        img.SetRGB(wxRect(0, 0, img_w, img_h), bg.Red(), bg.Green(), bg.Blue());
+        unsigned char *data = img.GetData();
+
+        wxPoint clip_pts[3] = {{(int)v0.x,(int)v0.y},{(int)v1.x,(int)v1.y},{(int)v2.x,(int)v2.y}};
+
+        for (int py = min_y; py <= max_y; ++py) {
+            for (int px = min_x; px <= max_x; ++px) {
+                TriPt p = {(double)px, (double)py};
+                double w0, w1, w2;
+                tri_bary(p, v0, v1, v2, w0, w1, w2);
+                if (w0 < -0.001 || w1 < -0.001 || w2 < -0.001) continue;
+                if (px < 0 || px >= img_w || py < 0 || py >= img_h) continue;
+                const int idx = (py * img_w + px) * 3;
+                data[idx]     = (unsigned char)std::clamp((int)(c0.Red()  *w0 + c1.Red()  *w1 + c2.Red()  *w2), 0, 255);
+                data[idx + 1] = (unsigned char)std::clamp((int)(c0.Green()*w0 + c1.Green()*w1 + c2.Green()*w2), 0, 255);
+                data[idx + 2] = (unsigned char)std::clamp((int)(c0.Blue() *w0 + c1.Blue() *w1 + c2.Blue() *w2), 0, 255);
+            }
+        }
+
+        wxBitmap bmp(img);
+        wxMemoryDC mdc(bmp);
+
+        // outline
+        mdc.SetPen(wxPen(wxColour(180,180,180), 1));
+        mdc.SetBrush(*wxTRANSPARENT_BRUSH);
+        mdc.DrawPolygon(3, clip_pts);
+
+        // drag handle
+        double hx = m_tri_wx*v0.x + m_tri_wy*v1.x + m_tri_wz*v2.x;
+        double hy = m_tri_wx*v0.y + m_tri_wy*v1.y + m_tri_wz*v2.y;
+        mdc.SetBrush(*wxWHITE_BRUSH);
+        mdc.SetPen(wxPen(wxColour(40,40,40), FromDIP(2)));
+        mdc.DrawCircle((int)hx, (int)hy, FromDIP(5));
+
+        mdc.SelectObject(wxNullBitmap);
+        dc.DrawBitmap(bmp, 0, 0);
+
+        // percentage labels at vertices
+        dc.SetFont(wxFont(wxFontInfo(8)));
+        dc.SetTextForeground(wxColour(60,60,60));
+        int r0 = (int)(m_tri_wx * 100 + 0.5);
+        int r1 = (int)(m_tri_wy * 100 + 0.5);
+        int r2 = 100 - r0 - r1;
+        auto draw_label = [&](TriPt v, int pct, int dx, int dy) {
+            wxString s = wxString::Format("%d%%", pct);
+            wxSize ts = dc.GetTextExtent(s);
+            dc.DrawText(s, (int)v.x - ts.GetWidth()/2 + dx, (int)v.y + dy);
+        };
+        draw_label(v0, r0, 0, -FromDIP(14));
+        draw_label(v1, r1, -FromDIP(4), FromDIP(3));
+        draw_label(v2, r2,  FromDIP(4), FromDIP(3));
+    });
+
+    auto handle_mouse = [this, get_verts](wxMouseEvent& e, bool is_down) {
+        auto [v0, v1, v2] = get_verts();
+        TriPt p = {(double)e.GetX(), (double)e.GetY()};
+        if (is_down) {
+            m_tri_dragging = true;
+            m_tri_picker->CaptureMouse();
+        }
+        if (!m_tri_dragging) return;
+        TriPt clamped = tri_clamp_pt(p, v0, v1, v2);
+        tri_bary(clamped, v0, v1, v2, m_tri_wx, m_tri_wy, m_tri_wz);
+        update_preview();
+        m_tri_picker->Refresh();
+    };
+
+    m_tri_picker->Bind(wxEVT_LEFT_DOWN, [handle_mouse](wxMouseEvent& e) { handle_mouse(e, true); });
+    m_tri_picker->Bind(wxEVT_MOTION,    [handle_mouse](wxMouseEvent& e) { handle_mouse(e, false); });
+    m_tri_picker->Bind(wxEVT_LEFT_UP,   [this](wxMouseEvent&) {
+        if (m_tri_dragging) {
+            m_tri_dragging = false;
+            if (m_tri_picker->HasCapture()) m_tri_picker->ReleaseMouse();
+        }
+    });
+    m_tri_picker->Bind(wxEVT_MOUSE_CAPTURE_LOST, [this](wxMouseCaptureLostEvent&) {
+        m_tri_dragging = false;
+    });
+}
+
+void AddColorMixDialog::update_ratio_or_tri_visibility()
+{
+    bool is_ratio_mode = (m_current_mode == MODE_RATIO);
+    bool is_cycle_mode = (m_current_mode == MODE_CYCLE);
+    bool is_match_mode = (m_current_mode == MODE_MATCH);
+    int  n             = (int)m_filament_rows.size();
+    bool show_slider   = is_ratio_mode && (n == 2);
+    bool show_tri      = is_ratio_mode && (n == 3);
+
+    if (m_filament_title)      m_filament_title->Show(!is_match_mode);
+    if (m_filament_rows_panel) m_filament_rows_panel->Show(!is_match_mode);
+    if (m_preview_panel)       m_preview_panel->Show(!is_match_mode);
+    if (m_preview_label)       m_preview_label->Show(!is_match_mode);
+    if (m_swatch_grid_panel)   m_swatch_grid_panel->Show(!is_match_mode);
+    if (m_recommended_label)   m_recommended_label->Show(!is_match_mode);
+    if (m_line_below_mid)      m_line_below_mid->Show(!is_match_mode);
+    if (m_line_above_swatch)   m_line_above_swatch->Show(!is_match_mode);
+    if (m_line_below_swatch)   m_line_below_swatch->Show(!is_match_mode);
+
+    if (m_gradient_bar_sizer)  m_gradient_bar_sizer->ShowItems(show_slider && !is_match_mode);
+    if (m_tri_picker_sizer)    m_tri_picker_sizer->ShowItems(show_tri && !is_match_mode);
+    if (m_pattern_panel_sizer) m_pattern_panel_sizer->ShowItems(is_cycle_mode);
+    if (m_match_panel_sizer)   m_match_panel_sizer->ShowItems(is_match_mode);
+}
+
+void AddColorMixDialog::resize_gradient_ids(int target_count)
+{
+    int extra = target_count - 2;
+    if (extra <= 0) { m_result.gradient_component_ids.clear(); return; }
+    std::string ids = m_result.gradient_component_ids;
+    while ((int)ids.size() < extra)
+        ids += char('1' + (int)m_result.component_b - 1);
+    ids.resize((size_t)extra);
+    m_result.gradient_component_ids = ids;
+}
+
+void AddColorMixDialog::sync_rows_to_result()
+{
+    if (m_filament_rows.empty()) return;
+    int a = m_filament_rows[0].combo->GetSelection();
+    int b = (m_filament_rows.size() > 1) ? m_filament_rows[1].combo->GetSelection() : a;
+    m_result.component_a = (unsigned int)(std::max(0, a) + 1);
+    m_result.component_b = (unsigned int)(std::max(0, b) + 1);
+    std::string ids;
+    for (int i = 2; i < (int)m_filament_rows.size(); ++i) {
+        int s = m_filament_rows[i].combo->GetSelection();
+        ids += char('1' + std::max(0, s));
+    }
+    m_result.gradient_component_ids = ids;
+}
+
+std::string AddColorMixDialog::compute_preview_color()
+{
+    if (m_filament_colours.empty() || m_filament_rows.empty()) return "#808080";
+
+    int n   = (int)m_filament_rows.size();
+    int val = m_gradient_selector ? m_gradient_selector->value() : 50;
+
+    auto safe_idx = [&](int raw) {
+        return std::max(0, std::min(raw, (int)m_filament_colours.size() - 1));
+    };
+
+    if (n == 2) {
+        int ia = safe_idx(m_filament_rows[0].combo->GetSelection());
+        int ib = safe_idx(m_filament_rows[1].combo->GetSelection());
+        int w = (m_current_mode == MODE_RATIO) ? val : 50;
+        return MixedFilamentManager::blend_color(
+            m_filament_colours[ia], m_filament_colours[ib], 100 - w, w);
+    }
+
+    // 3-filament ratio mode: linear weighted average matching tri picker rendering
+    if (n == 3 && m_current_mode == MODE_RATIO) {
+        auto get_col = [&](int row) {
+            return parse_mixed_color(m_filament_colours[safe_idx(m_filament_rows[row].combo->GetSelection())]);
+        };
+        wxColour c0 = get_col(0), c1 = get_col(1), c2 = get_col(2);
+        int r = (int)(c0.Red()   * m_tri_wx + c1.Red()   * m_tri_wy + c2.Red()   * m_tri_wz + 0.5);
+        int g = (int)(c0.Green() * m_tri_wx + c1.Green() * m_tri_wy + c2.Green() * m_tri_wz + 0.5);
+        int b = (int)(c0.Blue()  * m_tri_wx + c1.Blue()  * m_tri_wy + c2.Blue()  * m_tri_wz + 0.5);
+        return wxString::Format("#%02X%02X%02X",
+            std::clamp(r, 0, 255), std::clamp(g, 0, 255), std::clamp(b, 0, 255)).ToStdString();
+    }
+
+    int per = 100 / n;
+    int rem = 100 - per * n;
+    std::vector<std::pair<std::string, int>> cp;
+    for (int i = 0; i < n; ++i) {
+        int idx = safe_idx(m_filament_rows[i].combo->GetSelection());
+        cp.push_back(std::make_pair(m_filament_colours[idx], per + (i == 0 ? rem : 0)));
+    }
+    return MixedFilamentManager::blend_color_multi(cp);
+}
+
+void AddColorMixDialog::draw_strip(wxDC& dc, wxPanel* panel)
+{
+    wxSize sz = panel->GetClientSize();
+    if (sz.x <= 0 || sz.y <= 0 || m_filament_rows.empty()) {
+        dc.SetBackground(*wxGREY_BRUSH); dc.Clear(); return;
+    }
+    int n = (int)m_filament_rows.size();
+    int seg = FromDIP(12), x = 0;
+
+    // In 2-color ratio mode, build a pattern reflecting the A:B ratio
+    std::vector<int> pattern;
+    if (m_current_mode == MODE_RATIO && n == 2 && m_gradient_selector) {
+        int val = m_gradient_selector->value();
+        int steps_a = std::max(1, (100 - val) / 10);
+        int steps_b = std::max(1, val / 10);
+        for (int i = 0; i < steps_a; ++i) pattern.push_back(0);
+        for (int i = 0; i < steps_b; ++i) pattern.push_back(1);
+    } else if (m_current_mode == MODE_RATIO && n == 3) {
+        int s0 = std::max(1, (int)(m_tri_wx * 10 + 0.5));
+        int s1 = std::max(1, (int)(m_tri_wy * 10 + 0.5));
+        int s2 = std::max(1, (int)(m_tri_wz * 10 + 0.5));
+        for (int i = 0; i < s0; ++i) pattern.push_back(0);
+        for (int i = 0; i < s1; ++i) pattern.push_back(1);
+        for (int i = 0; i < s2; ++i) pattern.push_back(2);
+    } else if (m_current_mode == MODE_CYCLE && m_pattern_ctrl) {
+        // Mirror physical_filament_from_pattern_step():
+        //   '1' → component_a (row 0), '2' → component_b (row 1),
+        //   '3'..'9' → direct physical filament ID (1-based, not a row index).
+        // Store as negative -(id) to distinguish direct IDs from row indices.
+        std::string raw = into_u8(m_pattern_ctrl->GetValue());
+        for (char c : raw) {
+            if (c == ',' ) continue;
+            if (c == '1' || c == 'A' || c == 'a') pattern.push_back(0);
+            else if (c == '2' || c == 'B' || c == 'b') pattern.push_back(1);
+            else if (c >= '3' && c <= '9') pattern.push_back(-(c - '0'));
+        }
+        if (pattern.empty())
+            for (int i = 0; i < n; ++i) pattern.push_back(i);
+    } else {
+        for (int i = 0; i < n; ++i) pattern.push_back(i);
+    }
+
+    bool vertical = (m_current_mode == MODE_RATIO && n == 3);
+    int fi = 0, pos = 0;
+    int total = vertical ? sz.y : sz.x;
+    while (pos < total) {
+        int entry = pattern[fi % (int)pattern.size()];
+        int idx;
+        if (entry < 0) {
+            idx = std::max(0, std::min(-entry - 1, (int)m_filament_colours.size() - 1));
+        } else {
+            int row = std::min(entry, n - 1);
+            idx = m_filament_rows[row].combo->GetSelection();
+            idx = std::max(0, std::min(idx, (int)m_filament_colours.size() - 1));
+        }
+        dc.SetBrush(wxBrush(parse_mixed_color(m_filament_colours[idx])));
+        dc.SetPen(*wxTRANSPARENT_PEN);
+        if (vertical)
+            dc.DrawRectangle(0, pos, sz.x, std::min(seg, sz.y - pos));
+        else
+            dc.DrawRectangle(pos, 0, std::min(seg, sz.x - pos), sz.y);
+        pos += seg; ++fi;
+    }
+}
+
+void AddColorMixDialog::build_swatch_grid()
+{
+    int n = (int)m_filament_colours.size();
+    if (n < 2) return;
+
+    std::vector<std::pair<int,int>> pairs;
+    for (int i = 0; i < n; ++i)
+        for (int j = i + 1; j < n; ++j)
+            pairs.push_back(std::make_pair(i, j));
+
+    int cols = std::min((int)pairs.size(), 8);
+    if (cols == 0) return;
+    auto* grid = new wxGridSizer(0, cols, FromDIP(4), FromDIP(4));
+
+    for (int pi = 0; pi < (int)pairs.size(); ++pi) {
+        int ia = pairs[pi].first;
+        int ib = pairs[pi].second;
+        std::string blended = MixedFilamentManager::blend_color(
+            m_filament_colours[ia], m_filament_colours[ib], 50, 50);
+        auto* btn = new wxBitmapButton(m_swatch_grid_panel, wxID_ANY,
+                                       make_color_bitmap(parse_mixed_color(blended), FromDIP(20)),
+                                       wxDefaultPosition, wxSize(FromDIP(24), FromDIP(24)));
+        btn->SetToolTip(wxString::Format("F%d + F%d", ia + 1, ib + 1));
+        btn->Bind(wxEVT_BUTTON, [this, ia, ib](wxCommandEvent&) {
+            if (!m_filament_rows.empty()) {
+                m_filament_rows[0].combo->SetSelection(ia);
+                wxColour ca = parse_mixed_color(m_filament_colours[ia]);
+                m_filament_rows[0].swatch->Bind(wxEVT_PAINT, [sw0 = m_filament_rows[0].swatch, ca](wxPaintEvent&) {
+                    wxAutoBufferedPaintDC dc(sw0);
+                    dc.SetBackground(wxBrush(ca)); dc.Clear();
+                });
+                m_filament_rows[0].swatch->Refresh();
+            }
+            if (m_filament_rows.size() > 1) {
+                m_filament_rows[1].combo->SetSelection(ib);
+                wxColour cb = parse_mixed_color(m_filament_colours[ib]);
+                m_filament_rows[1].swatch->Bind(wxEVT_PAINT, [sw1 = m_filament_rows[1].swatch, cb](wxPaintEvent&) {
+                    wxAutoBufferedPaintDC dc(sw1);
+                    dc.SetBackground(wxBrush(cb)); dc.Clear();
+                });
+                m_filament_rows[1].swatch->Refresh();
+            }
+            update_preview();
+        });
+        grid->Add(btn);
+    }
+
+    m_swatch_grid_panel->SetSizer(grid);
+    m_swatch_grid_panel->Layout();
+}
+
+void AddColorMixDialog::on_mode_changed(int mode_index)
+{
+    sync_rows_to_result();
+    m_current_mode = mode_index;
+    int max_f = max_filaments_for_mode(mode_index);
+    if ((int)m_filament_rows.size() > max_f)
+        resize_gradient_ids(max_f);
+    bool locked = (mode_index == MODE_MATCH);
+    m_gradient_selector->Enable(!locked);
+    if (locked) m_gradient_selector->set_colors(
+        parse_mixed_color(m_filament_colours[std::max(0,(int)m_result.component_a-1)]),
+        parse_mixed_color(m_filament_colours[std::max(0,(int)m_result.component_b-1)]));
+    if (mode_index == MODE_CYCLE && m_pattern_ctrl) {
+        const std::string norm = MixedFilamentManager::normalize_manual_pattern(m_result.manual_pattern);
+        m_pattern_ctrl->SetValue(from_u8(norm.empty() ? "12" : norm));
+    }
+    if (mode_index == MODE_MATCH && m_match_panel)
+        m_match_panel->begin_initial_recipe_load();
+    rebuild_filament_rows();
+    update_ratio_or_tri_visibility();
+    update_preview();
+    Layout(); Fit();
+}
+
+void AddColorMixDialog::update_gradient_selector_colors()
+{
+    if (!m_gradient_selector || m_filament_rows.size() < 2) return;
+    int ia = m_filament_rows[0].combo->GetSelection();
+    int ib = m_filament_rows[1].combo->GetSelection();
+    ia = std::max(0, std::min(ia, (int)m_filament_colours.size()-1));
+    ib = std::max(0, std::min(ib, (int)m_filament_colours.size()-1));
+    m_gradient_selector->set_colors(parse_mixed_color(m_filament_colours[ia]),
+                                    parse_mixed_color(m_filament_colours[ib]));
+    int val = m_gradient_selector->value();
+    if (m_ratio_label_a)
+        m_ratio_label_a->SetLabel(wxString::Format("%d%%", 100 - val));
+    if (m_ratio_label_b)
+        m_ratio_label_b->SetLabel(wxString::Format("%d%%", val));
+    if (m_ratio_label_sizer)
+        m_ratio_label_sizer->Layout();
+}
+
+void AddColorMixDialog::update_preview()
+{
+    if ((int)m_filament_rows.size() == 2)
+        update_gradient_selector_colors();
+    if (m_preview_panel)    m_preview_panel->Refresh();
+    if (m_strip_panel)      m_strip_panel->Refresh();
+    if (m_tri_strip_panel)  m_tri_strip_panel->Refresh();
+    if (m_tri_picker)       m_tri_picker->Refresh();
+}
+
+void AddColorMixDialog::collect_result()
+{
+    sync_rows_to_result();
+    int val = m_gradient_selector ? m_gradient_selector->value() : 50;
+    m_result.mix_b_percent = val;
+    switch (m_current_mode) {
+    case MODE_RATIO:
+        m_result.gradient_component_weights.clear();
+        if ((int)m_filament_rows.size() == 3) {
+            m_result.distribution_mode = int(MixedFilament::LayerCycle);
+            m_result.manual_pattern.clear();
+            // Store all 3 filament ids so gradient_component_ids.size() >= 3,
+            // which lets resolve() enter the weighted gradient branch.
+            {
+                std::string all_ids;
+                for (int i = 0; i < 3; ++i) {
+                    int s = m_filament_rows[i].combo->GetSelection();
+                    all_ids += char('1' + std::max(0, s));
+                }
+                m_result.gradient_component_ids = all_ids;
+            }
+            int r0 = (int)(m_tri_wx * 100 + 0.5);
+            int r1 = (int)(m_tri_wy * 100 + 0.5);
+            int r2 = 100 - r0 - r1;
+            m_result.gradient_component_weights =
+                std::to_string(r0) + "/" + std::to_string(r1) + "/" + std::to_string(r2);
+        } else {
+            m_result.distribution_mode = int(MixedFilament::Simple);
+            m_result.gradient_component_ids.clear();
+            m_result.manual_pattern.clear();
+            int steps_a = std::max(1, (100 - val) / 10);
+            int steps_b = std::max(1, val / 10);
+            m_result.ratio_a = steps_a;
+            m_result.ratio_b = steps_b;
+        }
+        break;
+    case MODE_CYCLE: {
+        const std::string raw = m_pattern_ctrl ? into_u8(m_pattern_ctrl->GetValue()) : std::string();
+        const std::string norm = MixedFilamentManager::normalize_manual_pattern(raw);
+        m_result.distribution_mode = int(MixedFilament::Simple);
+        m_result.manual_pattern = norm.empty() ? "12" : norm;
+        m_result.gradient_component_ids.clear();
+        m_result.gradient_component_weights.clear();
+        break;
+    }
+    case MODE_MATCH: {
+        const MixedColorMatchRecipeResult recipe = m_match_panel ? m_match_panel->selected_recipe() : MixedColorMatchRecipeResult{};
+        if (recipe.valid) {
+            m_result.distribution_mode          = recipe.gradient_component_ids.empty()
+                                                    ? int(MixedFilament::Simple)
+                                                    : int(MixedFilament::LayerCycle);
+            m_result.component_a                = recipe.component_a;
+            m_result.component_b                = recipe.component_b;
+            m_result.mix_b_percent              = recipe.mix_b_percent;
+            m_result.manual_pattern             = recipe.manual_pattern;
+            m_result.gradient_component_ids     = recipe.gradient_component_ids;
+            m_result.gradient_component_weights = recipe.gradient_component_weights;
+        } else {
+            m_result.distribution_mode = int(MixedFilament::Simple);
+            m_result.mix_b_percent = 50;
+            m_result.manual_pattern.clear();
+            m_result.gradient_component_ids.clear();
+            m_result.gradient_component_weights.clear();
+            m_result.ratio_a = 1;
+            m_result.ratio_b = 1;
+        }
+        break;
+    }
+    case MODE_GRADIENT:
+        m_result.distribution_mode = int(MixedFilament::LayerCycle);
+        // gradient_component_ids already set by sync_rows_to_result(); keep it
+        m_result.gradient_component_weights.clear();
+        m_result.manual_pattern.clear();
+        break;
+    }
+    m_result.custom = true;
+}
+
+void AddColorMixDialog::on_dpi_changed(const wxRect& /*suggested_rect*/)
+{
+    m_preview_panel->SetMinSize(wxSize(FromDIP(PREVIEW_SIZE), FromDIP(PREVIEW_SIZE)));
+    m_strip_panel->SetMinSize(wxSize(-1, FromDIP(STRIP_HEIGHT)));
+    Layout(); Fit();
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/AddColorMixDialog.hpp
+++ b/src/slic3r/GUI/AddColorMixDialog.hpp
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "GUI_Utils.hpp"
+#include "MixedGradientSelector.hpp"
+#include "MixedColorMatchPanel.hpp"
+#include "libslic3r/MixedFilament.hpp"
+#include "Widgets/RadioGroup.hpp"
+#include "Widgets/Button.hpp"
+#include "Widgets/ComboBox.hpp"
+#include "Widgets/Label.hpp"
+
+#include <wx/wx.h>
+#include <wx/statline.h>
+#include <wx/dcbuffer.h>
+
+#include <vector>
+#include <string>
+
+#include "MixedColorMatchHelpers.hpp"
+
+namespace Slic3r { namespace GUI {
+
+class AddColorMixDialog : public DPIDialog
+{
+public:
+    AddColorMixDialog(wxWindow* parent, const std::vector<std::string>& filament_colours);
+    AddColorMixDialog(wxWindow* parent, const std::vector<std::string>& filament_colours,
+                      const Slic3r::MixedFilament& existing);
+
+    const Slic3r::MixedFilament& GetResult() const { return m_result; }
+    void on_dpi_changed(const wxRect& suggested_rect) override;
+
+private:
+    void build_ui();
+    void rebuild_filament_rows();
+    void on_mode_changed(int mode_index);
+    void update_preview();
+    void update_gradient_selector_colors();
+    void build_swatch_grid();
+    void sync_rows_to_result();
+    void resize_gradient_ids(int target_count);
+    std::string compute_preview_color();
+    wxBitmap make_color_bitmap(const wxColour& c, int size);
+    int max_filaments_for_mode(int mode_index) const;
+    void collect_result();
+    void draw_strip(wxDC& dc, wxPanel* panel);
+
+    static constexpr int MODE_RATIO    = 0;
+    static constexpr int MODE_CYCLE    = 1;
+    static constexpr int MODE_MATCH    = 2;
+    static constexpr int MODE_GRADIENT = 3;
+
+    RadioGroup*             m_mode_radio          = nullptr;
+    wxStaticText*           m_filament_title      = nullptr;
+    wxPanel*                m_filament_rows_panel = nullptr;
+    wxBoxSizer*             m_filament_rows_sizer = nullptr;
+    wxPanel*                m_preview_panel       = nullptr;
+    wxStaticText*           m_preview_label       = nullptr;
+    MixedGradientSelector*  m_gradient_selector   = nullptr;
+    wxStaticText*           m_ratio_label_a       = nullptr;
+    wxStaticText*           m_ratio_label_b       = nullptr;
+    wxBoxSizer*             m_ratio_label_sizer   = nullptr;
+    wxBoxSizer*             m_gradient_bar_sizer  = nullptr;
+    wxPanel*                m_tri_picker          = nullptr;
+    wxBoxSizer*             m_tri_picker_sizer    = nullptr;
+    wxPanel*                m_strip_panel         = nullptr;
+    wxPanel*                m_tri_strip_panel     = nullptr;
+    wxPanel*                m_cycle_strip_panel   = nullptr;
+    wxPanel*                m_swatch_grid_panel   = nullptr;
+    wxStaticLine*           m_line_below_mid      = nullptr;
+    wxStaticLine*           m_line_above_swatch   = nullptr;
+    wxStaticLine*           m_line_below_swatch   = nullptr;
+    wxStaticText*           m_recommended_label   = nullptr;
+    Button*                 m_btn_cancel          = nullptr;
+    Button*                 m_btn_confirm         = nullptr;
+    wxTextCtrl*             m_pattern_ctrl        = nullptr;
+    wxBoxSizer*             m_pattern_panel_sizer = nullptr;
+    std::vector<wxButton*>  m_pattern_quick_buttons;
+
+    // Match mode
+    wxBoxSizer*             m_match_panel_sizer   = nullptr;
+    MixedColorMatchPanel*   m_match_panel         = nullptr;
+
+    double m_tri_wx{1.0/3.0}, m_tri_wy{1.0/3.0}, m_tri_wz{1.0/3.0};
+    bool   m_tri_dragging{false};
+
+    void build_tri_picker();
+    void update_ratio_or_tri_visibility();
+
+    struct FilamentRow {
+        wxPanel*  swatch = nullptr;
+        ComboBox* combo  = nullptr;
+    };
+    std::vector<FilamentRow> m_filament_rows;
+
+    const std::vector<std::string>& m_filament_colours;
+    Slic3r::MixedFilament            m_result;
+    int                              m_current_mode = MODE_RATIO;
+};
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedColorMatchHelpers.hpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+// Shared declarations for color-match helpers used by both Plater.cpp and
+// MixedColorMatchPanel.cpp. Implementations live in Plater.cpp.
+
+#include "libslic3r/MixedFilament.hpp"
+
+#include <wx/wx.h>
+#include <wx/bitmap.h>
+
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace Slic3r { namespace GUI {
+
+struct MixedColorMatchRecipeResult
+{
+    bool         cancelled     = false;
+    bool         valid         = false;
+    unsigned int component_a   = 1;
+    unsigned int component_b   = 2;
+    int          mix_b_percent = 50;
+    std::string  manual_pattern;
+    std::string  gradient_component_ids;
+    std::string  gradient_component_weights;
+    wxColour     preview_color = wxColour("#26A69A");
+    double       delta_e       = std::numeric_limits<double>::infinity();
+};
+
+// ---- small pure helpers (defined here, used everywhere) ----
+
+wxColour parse_mixed_color(const std::string &value);
+wxString normalize_color_match_hex(const wxString &value);
+bool     try_parse_color_match_hex(const wxString &value, wxColour &color_out);
+
+std::vector<int> normalize_color_match_weights(const std::vector<int> &weights, size_t count);
+std::vector<int> expand_color_match_recipe_weights(const MixedColorMatchRecipeResult &recipe, size_t num_physical);
+std::string      summarize_color_match_recipe(const MixedColorMatchRecipeResult &recipe);
+wxBitmap         make_color_match_swatch_bitmap(const wxColour &color, const wxSize &size);
+
+std::vector<MixedColorMatchRecipeResult> build_color_match_presets(
+    const std::vector<std::string> &physical_colors,
+    int                             min_component_percent = 0);
+
+double color_delta_e00(const wxColour &lhs, const wxColour &rhs);
+
+MixedColorMatchRecipeResult build_best_color_match_recipe(
+    const std::vector<std::string> &physical_colors,
+    const wxColour                 &target_color,
+    int                             min_component_percent = 0);
+
+// ---- display context helpers ----
+
+MixedFilamentDisplayContext build_mixed_filament_display_context(
+    const std::vector<std::string> &physical_colors);
+
+wxColour compute_color_match_recipe_display_color(
+    const MixedColorMatchRecipeResult  &recipe,
+    const MixedFilamentDisplayContext  &context);
+
+MixedColorMatchRecipeResult prompt_best_color_match_recipe(wxWindow *parent,
+                                                           const std::vector<std::string> &physical_colors,
+                                                           const wxColour &initial_color);
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedColorMatchPanel.cpp
+++ b/src/slic3r/GUI/MixedColorMatchPanel.cpp
@@ -1,0 +1,581 @@
+#include "MixedColorMatchPanel.hpp"
+#include "MixedColorMatchHelpers.hpp"
+#include "MixedFilamentColorMapPanel.hpp"
+#include "MixedGradientSelector.hpp"
+#include "GUI_App.hpp"
+#include "I18N.hpp"
+
+#include <wx/dcbuffer.h>
+#include <wx/bmpbuttn.h>
+#include <wx/sizer.h>
+#include <wx/statline.h>
+
+#include <thread>
+
+namespace Slic3r { namespace GUI {
+
+// ---------------------------------------------------------------------------
+// ColorMapPanel — thin wrapper around MixedFilamentColorMapPanel
+// ---------------------------------------------------------------------------
+
+class MixedColorMatchPanel::ColorMapPanel : public wxPanel
+{
+public:
+    ColorMapPanel(wxWindow *parent, const std::vector<wxColour> &palette, const wxSize &min_size)
+        : wxPanel(parent, wxID_ANY, wxDefaultPosition, min_size, wxBORDER_SIMPLE)
+    {
+        std::vector<unsigned int> ids;
+        ids.reserve(palette.size());
+        for (size_t i = 0; i < palette.size(); ++i)
+            ids.emplace_back(unsigned(i + 1));
+
+        std::vector<int> initial_weights(palette.size(), 0);
+        if (!initial_weights.empty()) initial_weights[0] = 100;
+        if (initial_weights.size() >= 2) { initial_weights[0] = 50; initial_weights[1] = 50; }
+
+        m_inner = create_color_map_panel(this, ids, palette, initial_weights, min_size);
+
+        auto *sizer = new wxBoxSizer(wxVERTICAL);
+        sizer->Add(m_inner, 1, wxEXPAND);
+        SetSizer(sizer);
+
+        m_inner->Bind(wxEVT_SLIDER, [this](wxCommandEvent &) {
+            wxCommandEvent evt(wxEVT_SLIDER, GetId());
+            evt.SetEventObject(this);
+            ProcessWindowEvent(evt);
+        });
+    }
+
+    wxColour selected_color() const { return m_inner->selected_color(); }
+
+    void set_normalized_weights(const std::vector<int> &weights, bool notify)
+    {
+        m_inner->set_normalized_weights(weights, notify);
+    }
+
+    void set_min_component_percent(int pct) { m_inner->set_min_component_percent(pct); }
+
+private:
+    MixedFilamentColorMapPanel *m_inner = nullptr;
+};
+
+// ---------------------------------------------------------------------------
+// StripedPreviewPanel — draws horizontal color stripes proportional to weights
+// ---------------------------------------------------------------------------
+
+class MixedColorMatchPanel::StripedPreviewPanel : public wxPanel
+{
+public:
+    StripedPreviewPanel(wxWindow *parent, const wxSize &size)
+        : wxPanel(parent, wxID_ANY, wxDefaultPosition, size, wxBORDER_SIMPLE)
+    {
+        SetBackgroundStyle(wxBG_STYLE_PAINT);
+        SetMinSize(size);
+        Bind(wxEVT_PAINT, &StripedPreviewPanel::on_paint, this);
+    }
+
+    void set_colors_and_weights(const std::vector<wxColour> &colors, const std::vector<int> &weights)
+    {
+        m_colors  = colors;
+        m_weights = weights;
+        Refresh();
+    }
+
+private:
+    void on_paint(wxPaintEvent &)
+    {
+        wxAutoBufferedPaintDC dc(this);
+        const wxSize sz = GetClientSize();
+        dc.SetBackground(wxBrush(GetBackgroundColour().IsOk() ? GetBackgroundColour() : wxColour(245, 245, 245)));
+        dc.Clear();
+
+        if (m_colors.empty() || m_weights.empty()) return;
+
+        int total = 0;
+        for (int w : m_weights) total += std::max(0, w);
+        if (total <= 0) return;
+
+        int y = 0;
+        for (size_t i = 0; i < m_colors.size() && i < m_weights.size(); ++i) {
+            const int w = std::max(0, m_weights[i]);
+            if (w <= 0) continue;
+            const int stripe_h = (i + 1 < m_colors.size())
+                ? int(std::lround(double(w) / double(total) * sz.GetHeight()))
+                : sz.GetHeight() - y;
+            dc.SetBrush(wxBrush(m_colors[i].IsOk() ? m_colors[i] : wxColour(200, 200, 200)));
+            dc.SetPen(*wxTRANSPARENT_PEN);
+            dc.DrawRectangle(0, y, sz.GetWidth(), stripe_h);
+            y += stripe_h;
+        }
+    }
+
+    std::vector<wxColour> m_colors;
+    std::vector<int>      m_weights;
+};
+
+// ---------------------------------------------------------------------------
+// MixedColorMatchPanel
+// ---------------------------------------------------------------------------
+
+MixedColorMatchPanel::MixedColorMatchPanel(wxWindow *parent,
+                                           const std::vector<std::string> &physical_colors,
+                                           const wxColour &initial_color)
+    : wxPanel(parent, wxID_ANY)
+    , m_physical_colors(physical_colors)
+{
+    m_recipe_timer.SetOwner(this);
+    m_loading_timer.SetOwner(this);
+    m_display_context = build_mixed_filament_display_context(m_physical_colors);
+
+    m_palette.reserve(m_physical_colors.size());
+    for (const std::string &hex : m_physical_colors)
+        m_palette.emplace_back(parse_mixed_color(hex));
+
+    const wxColour safe_initial = initial_color.IsOk() ? initial_color :
+        (m_palette.size() >= 2 ? blend_pair_filament_mixer(m_palette[0], m_palette[1], 0.5f) : wxColour("#26A69A"));
+
+    m_requested_target = safe_initial;
+    m_selected_target  = safe_initial;
+
+    const int M  = FromDIP(8);
+    const int M2 = FromDIP(4);
+
+    // -----------------------------------------------------------------------
+    // Root: vertical sizer — top half (left/right split) + bottom half
+    // -----------------------------------------------------------------------
+    auto *root = new wxBoxSizer(wxVERTICAL);
+
+    // -----------------------------------------------------------------------
+    // Top half: horizontal split
+    // -----------------------------------------------------------------------
+    auto *top_row = new wxBoxSizer(wxHORIZONTAL);
+
+    // ---- LEFT COLUMN -------------------------------------------------------
+    auto *left_col = new wxBoxSizer(wxVERTICAL);
+
+    // Legend row: colored dots + filament labels
+    auto *legend_row = new wxBoxSizer(wxHORIZONTAL);
+    legend_row->Add(new wxStaticText(this, wxID_ANY, _L("Legend:")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, M2);
+    for (size_t i = 0; i < m_palette.size(); ++i) {
+        auto *dot = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(12), FromDIP(12)), wxBORDER_SIMPLE);
+        dot->SetBackgroundColour(m_palette[i]);
+        legend_row->Add(dot, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, M2);
+        legend_row->Add(new wxStaticText(this, wxID_ANY,
+            wxString::Format(_L("F%zu"), i + 1)), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, M);
+    }
+    left_col->Add(legend_row, 0, wxEXPAND | wxBOTTOM, M2);
+
+    // Color map
+    m_color_map = new ColorMapPanel(this, m_palette, wxSize(FromDIP(260), FromDIP(200)));
+    left_col->Add(m_color_map, 1, wxEXPAND | wxBOTTOM, M);
+
+    // Range slider row
+    auto *range_row = new wxBoxSizer(wxHORIZONTAL);
+    range_row->Add(new wxStaticText(this, wxID_ANY, _L("Min ratio")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, M);
+    m_range_slider = new wxSlider(this, wxID_ANY, m_min_component_percent, 0, 50);
+    m_range_slider->SetToolTip(_L("Minimum percent for each participating color."));
+    range_row->Add(m_range_slider, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, M2);
+    m_range_value = new wxStaticText(this, wxID_ANY, wxEmptyString);
+    range_row->Add(m_range_value, 0, wxALIGN_CENTER_VERTICAL);
+    left_col->Add(range_row, 0, wxEXPAND | wxBOTTOM, M2);
+
+    // Target color row
+    auto *target_row = new wxBoxSizer(wxHORIZONTAL);
+    target_row->Add(new wxStaticText(this, wxID_ANY, _L("Target")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, M);
+    m_target_color_swatch = new wxPanel(this, wxID_ANY, wxDefaultPosition,
+                                        wxSize(FromDIP(56), FromDIP(18)), wxBORDER_SIMPLE);
+    target_row->Add(m_target_color_swatch, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, M2);
+    m_hex_input = new wxTextCtrl(this, wxID_ANY,
+        normalize_color_match_hex(safe_initial.GetAsString(wxC2S_HTML_SYNTAX)),
+        wxDefaultPosition, wxSize(FromDIP(80), -1), wxTE_PROCESS_ENTER);
+    m_hex_input->SetToolTip(_L("Enter a hex color like #00FF88."));
+    target_row->Add(m_hex_input, 0, wxALIGN_CENTER_VERTICAL);
+    left_col->Add(target_row, 0, wxEXPAND);
+
+    top_row->Add(left_col, 1, wxEXPAND | wxRIGHT, M * 2);
+
+    // ---- RIGHT COLUMN ------------------------------------------------------
+    auto *right_col = new wxBoxSizer(wxVERTICAL);
+
+    // Recipe formula label (e.g. "F1(40%)+F2(30%)+F3(30%)")
+    m_recipe_formula_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
+    right_col->Add(m_recipe_formula_label, 0, wxEXPAND | wxBOTTOM, M2);
+
+    // Large solid color swatch — "混色效果"
+    m_recipe_preview = new wxPanel(this, wxID_ANY, wxDefaultPosition,
+                                   wxSize(FromDIP(120), FromDIP(100)), wxBORDER_SIMPLE);
+    right_col->Add(m_recipe_preview, 0, wxEXPAND | wxBOTTOM, M2);
+    right_col->Add(new wxStaticText(this, wxID_ANY, _L("Blend result")), 0, wxALIGN_CENTER | wxBOTTOM, M);
+
+    // Striped preview — "混色预览"
+    m_striped_preview = new StripedPreviewPanel(this, wxSize(FromDIP(120), FromDIP(100)));
+    right_col->Add(m_striped_preview, 0, wxEXPAND | wxBOTTOM, M2);
+    right_col->Add(new wxStaticText(this, wxID_ANY, _L("Color preview")), 0, wxALIGN_CENTER);
+
+    top_row->Add(right_col, 0, wxEXPAND);
+
+    root->Add(top_row, 0, wxEXPAND | wxBOTTOM, M);
+
+    // -----------------------------------------------------------------------
+    // Bottom half (unchanged structure)
+    // -----------------------------------------------------------------------
+
+    // Summary grid (hidden selected_preview / selected_label kept for compat)
+    m_selected_preview = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(0, 0));
+    m_selected_preview->Hide();
+    m_selected_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
+    m_selected_label->Hide();
+    m_recipe_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
+    m_recipe_label->Hide();
+
+    m_delta_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
+    root->Add(m_delta_label, 0, wxEXPAND | wxBOTTOM, M2);
+
+    // Presets
+    m_presets_label = new wxStaticText(this, wxID_ANY, _L("Exact preset mixes"));
+    root->Add(m_presets_label, 0, wxBOTTOM, M2);
+    m_presets_host = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(-1, FromDIP(72)),
+                                          wxVSCROLL | wxBORDER_SIMPLE);
+    m_presets_host->SetScrollRate(FromDIP(6), FromDIP(6));
+    m_presets_sizer = new wxWrapSizer(wxHORIZONTAL, wxWRAPSIZER_DEFAULT_FLAGS);
+    m_presets_host->SetSizer(m_presets_sizer);
+    root->Add(m_presets_host, 0, wxEXPAND | wxBOTTOM, M);
+
+    m_error_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
+    m_error_label->SetForegroundColour(wxColour(196, 67, 63));
+    root->Add(m_error_label, 0, wxEXPAND | wxBOTTOM, M2);
+
+    // Loading indicator
+    auto *loading_row = new wxBoxSizer(wxHORIZONTAL);
+    m_loading_label = new wxStaticText(this, wxID_ANY, " ");
+    loading_row->Add(m_loading_label, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, M);
+    m_loading_gauge = new wxGauge(this, wxID_ANY, 100, wxDefaultPosition, wxSize(FromDIP(100), FromDIP(8)),
+                                  wxGA_HORIZONTAL | wxGA_SMOOTH);
+    m_loading_gauge->SetValue(0);
+    m_loading_gauge->Enable(false);
+    loading_row->Add(m_loading_gauge, 0, wxALIGN_CENTER_VERTICAL);
+    root->Add(loading_row, 0, wxEXPAND);
+
+    SetSizer(root);
+
+    if (m_color_map)
+        m_color_map->set_min_component_percent(m_min_component_percent);
+    update_range_label();
+    rebuild_presets_ui();
+    sync_inputs_to_requested();
+    update_panel_state();
+
+    // Bindings
+    if (m_color_map) {
+        m_color_map->Bind(wxEVT_SLIDER, [this](wxCommandEvent &) {
+            request_recipe_match(m_color_map->selected_color(), true, _L("Matching closest supported mix..."));
+        });
+    }
+    if (m_hex_input) {
+        m_hex_input->Bind(wxEVT_TEXT_ENTER, [this](wxCommandEvent &) { apply_hex_input(true); });
+        m_hex_input->Bind(wxEVT_KILL_FOCUS, [this](wxFocusEvent &evt) {
+            apply_hex_input(false);
+            evt.Skip();
+        });
+    }
+    if (m_range_slider) {
+        m_range_slider->Bind(wxEVT_SLIDER, [this](wxCommandEvent &) {
+            m_min_component_percent = m_range_slider ? std::clamp(m_range_slider->GetValue(), 0, 50) : m_min_component_percent;
+            update_range_label();
+            if (m_color_map)
+                m_color_map->set_min_component_percent(m_min_component_percent);
+            rebuild_presets_ui();
+            request_recipe_match(m_requested_target, true, _L("Matching closest supported mix..."));
+        });
+    }
+
+    Bind(wxEVT_TIMER, [this](wxTimerEvent &) { refresh_selected_recipe(); }, m_recipe_timer.GetId());
+    Bind(wxEVT_TIMER, [this](wxTimerEvent &) {
+        if (m_loading_gauge && m_recipe_loading)
+            m_loading_gauge->Pulse();
+    }, m_loading_timer.GetId());
+}
+
+MixedColorMatchPanel::~MixedColorMatchPanel()
+{
+    m_destroyed->store(true);
+    if (m_recipe_timer.IsRunning())
+        m_recipe_timer.Stop();
+    if (m_loading_timer.IsRunning())
+        m_loading_timer.Stop();
+}
+
+void MixedColorMatchPanel::begin_initial_recipe_load()
+{
+    request_recipe_match(m_requested_target, false, _L("Calculating closest supported mix..."));
+}
+
+void MixedColorMatchPanel::sync_recipe_preview(MixedColorMatchRecipeResult &recipe, const wxColour *requested)
+{
+    if (!recipe.valid)
+        return;
+    // Rebuild context each time so nozzle diameters and print settings stay current.
+    m_display_context = build_mixed_filament_display_context(m_physical_colors);
+    recipe.preview_color = compute_color_match_recipe_display_color(recipe, m_display_context);
+    if (requested && requested->IsOk())
+        recipe.delta_e = color_delta_e00(*requested, recipe.preview_color);
+}
+
+void MixedColorMatchPanel::update_range_label()
+{
+    if (m_range_value)
+        m_range_value->SetLabel(wxString::Format(_L("%d%%"), m_min_component_percent));
+}
+
+void MixedColorMatchPanel::rebuild_presets_ui()
+{
+    if (!m_presets_host || !m_presets_sizer || !m_presets_label)
+        return;
+
+    m_presets = build_color_match_presets(m_physical_colors, m_min_component_percent);
+    for (MixedColorMatchRecipeResult &preset : m_presets)
+        sync_recipe_preview(preset);
+
+    m_presets_host->Freeze();
+    while (m_presets_sizer->GetItemCount() > 0) {
+        wxSizerItem *item = m_presets_sizer->GetItem(size_t(0));
+        wxWindow *win = item ? item->GetWindow() : nullptr;
+        m_presets_sizer->Remove(0);
+        if (win) win->Destroy();
+    }
+
+    for (const MixedColorMatchRecipeResult &preset : m_presets) {
+        auto *btn = new wxBitmapButton(m_presets_host, wxID_ANY,
+                                       make_color_match_swatch_bitmap(preset.preview_color, wxSize(FromDIP(28), FromDIP(18))),
+                                       wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+        const wxString tip = from_u8(summarize_color_match_recipe(preset)) + "\n" +
+            normalize_color_match_hex(preset.preview_color.GetAsString(wxC2S_HTML_SYNTAX));
+        btn->SetToolTip(tip);
+        btn->Bind(wxEVT_BUTTON, [this, preset](wxCommandEvent &) { apply_preset(preset); });
+        m_presets_sizer->Add(btn, 0, wxALL, FromDIP(2));
+    }
+
+    m_presets_host->FitInside();
+    const bool show = !m_presets.empty();
+    m_presets_label->Show(show);
+    m_presets_host->Show(show);
+    m_presets_host->Thaw();
+}
+
+void MixedColorMatchPanel::set_recipe_loading(bool loading, const wxString &message)
+{
+    m_recipe_loading = loading;
+    if (!message.empty())
+        m_loading_message = message;
+
+    if (m_loading_label)
+        m_loading_label->SetLabel(loading ? m_loading_message : wxString(" "));
+    if (m_loading_gauge) {
+        if (loading) {
+            m_loading_gauge->Enable(true);
+            m_loading_gauge->Pulse();
+            if (!m_loading_timer.IsRunning())
+                m_loading_timer.Start(100);
+        } else {
+            if (m_loading_timer.IsRunning())
+                m_loading_timer.Stop();
+            m_loading_gauge->SetValue(0);
+            m_loading_gauge->Enable(false);
+        }
+    }
+}
+
+void MixedColorMatchPanel::sync_inputs_to_requested()
+{
+    m_syncing_inputs = true;
+    if (m_hex_input)
+        m_hex_input->ChangeValue(normalize_color_match_hex(m_requested_target.GetAsString(wxC2S_HTML_SYNTAX)));
+    m_syncing_inputs = false;
+}
+
+bool MixedColorMatchPanel::apply_requested_target(const wxColour &target)
+{
+    request_recipe_match(target, false, _L("Matching closest supported mix..."));
+    return true;
+}
+
+bool MixedColorMatchPanel::apply_hex_input(bool show_invalid_error)
+{
+    if (!m_hex_input || m_syncing_inputs)
+        return false;
+    wxColour parsed;
+    if (!try_parse_color_match_hex(m_hex_input->GetValue(), parsed)) {
+        if (show_invalid_error && m_error_label)
+            m_error_label->SetLabel(_L("Use a valid hex color like #00FF88."));
+        return false;
+    }
+    return apply_requested_target(parsed);
+}
+
+void MixedColorMatchPanel::request_recipe_match(const wxColour &target, bool debounce, const wxString &loading_message)
+{
+    m_requested_target = target;
+    m_selected_target  = target;
+    sync_inputs_to_requested();
+
+    ++m_recipe_request_token;
+    set_recipe_loading(true, loading_message);
+
+    if (m_recipe_timer.IsRunning())
+        m_recipe_timer.Stop();
+    m_recipe_refresh_pending = debounce;
+    update_panel_state();
+
+    if (debounce) {
+        m_recipe_timer.StartOnce(120);
+        return;
+    }
+    launch_recipe_match(m_recipe_request_token, target);
+}
+
+void MixedColorMatchPanel::refresh_selected_recipe()
+{
+    m_recipe_refresh_pending = false;
+    launch_recipe_match(m_recipe_request_token, m_requested_target);
+}
+
+void MixedColorMatchPanel::launch_recipe_match(size_t request_token, const wxColour &target)
+{
+    const std::vector<std::string> physical_colors = m_physical_colors;
+    const int min_pct = m_min_component_percent;
+    auto destroyed = m_destroyed;
+    std::thread([this, destroyed, physical_colors, target, request_token, min_pct]() {
+        MixedColorMatchRecipeResult recipe = build_best_color_match_recipe(physical_colors, target, min_pct);
+        wxGetApp().CallAfter([this, destroyed, target, recipe = std::move(recipe), request_token]() mutable {
+            if (destroyed->load()) return;
+            handle_recipe_result(request_token, target, std::move(recipe));
+        });
+    }).detach();
+}
+
+void MixedColorMatchPanel::handle_recipe_result(size_t request_token, const wxColour &requested,
+                                                 MixedColorMatchRecipeResult recipe)
+{
+    if (request_token != m_recipe_request_token)
+        return;
+
+    m_has_recipe_result = true;
+    m_selected_recipe   = std::move(recipe);
+    sync_recipe_preview(m_selected_recipe, &requested);
+    set_recipe_loading(false, wxEmptyString);
+
+    if (m_selected_recipe.valid) {
+        m_selected_target = m_selected_recipe.preview_color;
+        if (m_color_map)
+            m_color_map->set_normalized_weights(
+                expand_color_match_recipe_weights(m_selected_recipe, m_palette.size()), false);
+        sync_inputs_to_requested();
+    } else {
+        m_selected_target = requested;
+    }
+
+    update_panel_state();
+
+    wxCommandEvent evt(wxEVT_SLIDER, GetId());
+    evt.SetEventObject(this);
+    ProcessWindowEvent(evt);
+}
+
+void MixedColorMatchPanel::apply_preset(MixedColorMatchRecipeResult preset)
+{
+    preset.delta_e = 0.0;
+    sync_recipe_preview(preset);
+    ++m_recipe_request_token;
+    m_requested_target = preset.preview_color;
+    m_selected_target  = preset.preview_color;
+    m_selected_recipe  = std::move(preset);
+    m_has_recipe_result = true;
+    m_recipe_refresh_pending = false;
+    if (m_recipe_timer.IsRunning())
+        m_recipe_timer.Stop();
+    set_recipe_loading(false, wxEmptyString);
+    if (m_color_map)
+        m_color_map->set_normalized_weights(
+            expand_color_match_recipe_weights(m_selected_recipe, m_palette.size()), false);
+    sync_inputs_to_requested();
+    update_panel_state();
+
+    wxCommandEvent evt(wxEVT_SLIDER, GetId());
+    evt.SetEventObject(this);
+    ProcessWindowEvent(evt);
+}
+
+void MixedColorMatchPanel::update_panel_state()
+{
+    const wxColour fallback("#26A69A");
+
+    // Target color swatch
+    if (m_target_color_swatch) {
+        m_target_color_swatch->SetBackgroundColour(m_requested_target.IsOk() ? m_requested_target : fallback);
+        m_target_color_swatch->Refresh();
+    }
+
+    const bool valid = m_selected_recipe.valid;
+    const wxColour recipe_color = (valid && m_selected_recipe.preview_color.IsOk()) ?
+        m_selected_recipe.preview_color :
+        (m_requested_target.IsOk() ? m_requested_target : fallback);
+
+    // Solid blend result swatch
+    if (m_recipe_preview) {
+        m_recipe_preview->SetBackgroundColour(recipe_color);
+        m_recipe_preview->Refresh();
+    }
+
+    // Recipe formula label (top of right column)
+    if (m_recipe_formula_label) {
+        if (m_recipe_loading) {
+            m_recipe_formula_label->SetLabel(m_loading_message);
+        } else if (valid) {
+            m_recipe_formula_label->SetLabel(from_u8(summarize_color_match_recipe(m_selected_recipe)));
+        } else {
+            m_recipe_formula_label->SetLabel(wxEmptyString);
+        }
+    }
+
+    // Striped preview — show palette colors with their recipe weights
+    if (m_striped_preview) {
+        const std::vector<int> weights = valid
+            ? expand_color_match_recipe_weights(m_selected_recipe, m_palette.size())
+            : std::vector<int>(m_palette.size(), 0);
+        m_striped_preview->set_colors_and_weights(m_palette, weights);
+    }
+
+    // Delta label
+    if (m_delta_label) {
+        if (m_recipe_loading && m_requested_target.IsOk()) {
+            m_delta_label->SetLabel(wxString::Format(_L("Matching %s..."),
+                normalize_color_match_hex(m_requested_target.GetAsString(wxC2S_HTML_SYNTAX))));
+        } else if (valid && m_requested_target.IsOk()) {
+            m_delta_label->SetLabel(wxString::Format(_L("Requested %s, closest recipe delta: %.2f"),
+                normalize_color_match_hex(m_requested_target.GetAsString(wxC2S_HTML_SYNTAX)),
+                m_selected_recipe.delta_e));
+        } else {
+            m_delta_label->SetLabel(wxEmptyString);
+        }
+    }
+
+    // Error label
+    if (m_error_label) {
+        if (m_recipe_loading) {
+            m_error_label->SetLabel(wxEmptyString);
+        } else if (!valid && m_has_recipe_result) {
+            m_error_label->SetLabel(_L("Unable to create a color mix from the current physical filament colors within the selected range."));
+        } else if (m_hex_input && !m_syncing_inputs) {
+            wxColour parsed;
+            if (!try_parse_color_match_hex(m_hex_input->GetValue(), parsed))
+                m_error_label->SetLabel(_L("Use a valid hex color like #00FF88."));
+            else
+                m_error_label->SetLabel(wxEmptyString);
+        } else {
+            m_error_label->SetLabel(wxEmptyString);
+        }
+    }
+
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedColorMatchPanel.hpp
+++ b/src/slic3r/GUI/MixedColorMatchPanel.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "GUI_Utils.hpp"
+#include "Plater.hpp"
+
+#include <wx/wx.h>
+#include <wx/gauge.h>
+#include <wx/wrapsizer.h>
+#include <wx/scrolwin.h>
+
+#include <atomic>
+#include <memory>
+#include <vector>
+#include <string>
+
+namespace Slic3r { namespace GUI {
+
+// Embeddable panel that hosts the full color-match UI (color map, hex input,
+// range slider, preset swatches, recipe summary, loading indicator).
+// Fires wxEVT_SLIDER on its own ID whenever the selected recipe changes.
+class MixedColorMatchPanel : public wxPanel
+{
+public:
+    MixedColorMatchPanel(wxWindow                        *parent,
+                         const std::vector<std::string>  &physical_colors,
+                         const wxColour                  &initial_color);
+    ~MixedColorMatchPanel() override;
+
+    // Start the initial async recipe search (call after the panel is shown).
+    void begin_initial_recipe_load();
+
+    MixedColorMatchRecipeResult selected_recipe() const { return m_selected_recipe; }
+    bool                        has_valid_recipe()  const { return m_selected_recipe.valid && !m_recipe_loading; }
+
+private:
+    // ---- helpers ----
+    void sync_recipe_preview(MixedColorMatchRecipeResult &recipe, const wxColour *requested = nullptr);
+    void update_range_label();
+    void rebuild_presets_ui();
+    void set_recipe_loading(bool loading, const wxString &message);
+    void sync_inputs_to_requested();
+    bool apply_requested_target(const wxColour &target);
+    bool apply_hex_input(bool show_invalid_error);
+    void request_recipe_match(const wxColour &target, bool debounce, const wxString &loading_message);
+    void refresh_selected_recipe();
+    void launch_recipe_match(size_t request_token, const wxColour &target);
+    void handle_recipe_result(size_t request_token, const wxColour &requested, MixedColorMatchRecipeResult recipe);
+    void apply_preset(MixedColorMatchRecipeResult preset);
+    void update_panel_state();
+
+    // ---- forward-declared inner classes ----
+    class ColorMapPanel;
+    class StripedPreviewPanel;
+
+    // ---- data ----
+    std::vector<std::string>                 m_physical_colors;
+    MixedFilamentDisplayContext              m_display_context;
+    std::vector<wxColour>                    m_palette;
+    std::vector<MixedColorMatchRecipeResult> m_presets;
+
+    ColorMapPanel        *m_color_map            = nullptr;
+    wxTextCtrl           *m_hex_input            = nullptr;
+    wxSlider             *m_range_slider         = nullptr;
+    wxStaticText         *m_range_value          = nullptr;
+    // Target color row (left column, bottom)
+    wxPanel              *m_target_color_swatch  = nullptr;
+    wxStaticText         *m_target_color_label   = nullptr;
+    // Right column
+    wxStaticText         *m_recipe_formula_label = nullptr;
+    wxPanel              *m_recipe_preview       = nullptr;   // solid "混色效果" swatch
+    StripedPreviewPanel  *m_striped_preview      = nullptr;   // striped "混色预览"
+    // Presets
+    wxStaticText         *m_presets_label        = nullptr;
+    wxScrolledWindow     *m_presets_host         = nullptr;
+    wxWrapSizer          *m_presets_sizer        = nullptr;
+    // Loading
+    wxStaticText         *m_loading_label        = nullptr;
+    wxGauge              *m_loading_gauge        = nullptr;
+    // Summary (kept for update_panel_state compat)
+    wxPanel              *m_selected_preview     = nullptr;
+    wxStaticText         *m_selected_label       = nullptr;
+    wxStaticText         *m_recipe_label         = nullptr;
+    wxStaticText         *m_delta_label          = nullptr;
+    wxStaticText         *m_error_label          = nullptr;
+
+    wxColour                     m_requested_target { wxColour("#26A69A") };
+    wxColour                     m_selected_target  { wxColour("#26A69A") };
+    MixedColorMatchRecipeResult  m_selected_recipe;
+    wxTimer                      m_recipe_timer;
+    wxTimer                      m_loading_timer;
+    wxString                     m_loading_message;
+    size_t                       m_recipe_request_token  { 0 };
+    int                          m_min_component_percent { 15 };
+    bool                         m_has_recipe_result     { false };
+    bool                         m_recipe_loading        { false };
+    bool                         m_recipe_refresh_pending{ false };
+    bool                         m_syncing_inputs        { false };
+    // Shared with background threads so they can detect panel destruction safely.
+    std::shared_ptr<std::atomic<bool>> m_destroyed { std::make_shared<std::atomic<bool>>(false) };
+};
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedFilamentColorMapPanel.hpp
+++ b/src/slic3r/GUI/MixedFilamentColorMapPanel.hpp
@@ -1,0 +1,729 @@
+#pragma once
+
+#include "libslic3r/filament_mixer.h"
+
+#include <wx/panel.h>
+#include <wx/dcbuffer.h>
+
+#include <algorithm>
+#include <vector>
+
+namespace Slic3r { namespace GUI {
+inline wxColour blend_multi_filament_mixer(const std::vector<wxColour>& colors, const std::vector<double>& weights)
+{
+    if (colors.empty() || weights.empty())
+        return wxColour("#26A69A");
+
+    unsigned char out_r              = 0;
+    unsigned char out_g              = 0;
+    unsigned char out_b              = 0;
+    double        accumulated_weight = 0.0;
+    bool          has_color          = false;
+
+    for (size_t i = 0; i < colors.size() && i < weights.size(); ++i) {
+        const double weight = std::max(0.0, weights[i]);
+        if (weight <= 0.0)
+            continue;
+
+        const wxColour      safe = colors[i].IsOk() ? colors[i] : wxColour("#26A69A");
+        const unsigned char r    = static_cast<unsigned char>(safe.Red());
+        const unsigned char g    = static_cast<unsigned char>(safe.Green());
+        const unsigned char b    = static_cast<unsigned char>(safe.Blue());
+
+        if (!has_color) {
+            out_r              = r;
+            out_g              = g;
+            out_b              = b;
+            accumulated_weight = weight;
+            has_color          = true;
+            continue;
+        }
+
+        const double new_total = accumulated_weight + weight;
+        if (new_total <= 0.0)
+            continue;
+        const float t = float(weight / new_total);
+        ::Slic3r::filament_mixer_lerp(out_r, out_g, out_b, r, g, b, t, &out_r, &out_g, &out_b);
+        accumulated_weight = new_total;
+    }
+
+    if (!has_color)
+        return wxColour("#26A69A");
+
+    return wxColour(out_r, out_g, out_b);
+}
+
+class MixedFilamentColorMapPanel : public wxPanel
+{
+public:
+    MixedFilamentColorMapPanel(wxWindow*                        parent,
+                               const std::vector<unsigned int>& filament_ids,
+                               const std::vector<wxColour>&     palette,
+                               const std::vector<int>&          initial_weights,
+                               const wxSize&                    min_size)
+        : wxPanel(parent, wxID_ANY, wxDefaultPosition, min_size, wxBORDER_SIMPLE)
+    {
+        SetBackgroundStyle(wxBG_STYLE_PAINT);
+        SetMinSize(min_size);
+        m_render_timer.SetOwner(this);
+
+        m_colors.reserve(filament_ids.size());
+        for (const unsigned int filament_id : filament_ids) {
+            if (filament_id >= 1 && filament_id <= palette.size())
+                m_colors.emplace_back(palette[filament_id - 1]);
+            else
+                m_colors.emplace_back(wxColour("#26A69A"));
+        }
+        if (m_colors.empty())
+            m_colors.emplace_back(wxColour("#26A69A"));
+
+        set_normalized_weights(initial_weights, false);
+
+        Bind(wxEVT_PAINT, &MixedFilamentColorMapPanel::on_paint, this);
+        Bind(wxEVT_LEFT_DOWN, &MixedFilamentColorMapPanel::on_left_down, this);
+        Bind(wxEVT_LEFT_UP, &MixedFilamentColorMapPanel::on_left_up, this);
+        Bind(wxEVT_MOTION, &MixedFilamentColorMapPanel::on_mouse_move, this);
+        Bind(wxEVT_MOUSE_CAPTURE_LOST, &MixedFilamentColorMapPanel::on_capture_lost, this);
+        Bind(wxEVT_SIZE, &MixedFilamentColorMapPanel::on_size, this);
+        Bind(wxEVT_TIMER, &MixedFilamentColorMapPanel::on_render_timer, this, m_render_timer.GetId());
+    }
+
+    ~MixedFilamentColorMapPanel() override
+    {
+        if (HasCapture())
+            ReleaseMouse();
+        if (m_render_timer.IsRunning())
+            m_render_timer.Stop();
+    }
+
+    std::vector<int> normalized_weights() const { return m_weights; }
+
+    wxColour selected_color() const
+    {
+        std::vector<double> weights;
+        weights.reserve(m_weights.size());
+        for (const int weight : m_weights)
+            weights.emplace_back(double(std::max(0, weight)));
+        return blend_multi_filament_mixer(m_colors, weights);
+    }
+
+    void set_normalized_weights(const std::vector<int>& weights, bool notify)
+    {
+        m_weights = normalize_color_match_weights(weights, m_colors.size());
+        initialize_cursor_from_weights();
+        Refresh();
+        if (notify)
+            emit_changed();
+    }
+
+    void set_min_component_percent(int min_component_percent)
+    {
+        const int clamped = std::clamp(min_component_percent, 0, 50);
+        if (m_min_component_percent == clamped)
+            return;
+        m_min_component_percent = clamped;
+        invalidate_cached_bitmap();
+        Refresh();
+    }
+
+private:
+    enum class GeometryMode { Point, Line, Triangle, TriangleWithCenter, Radial };
+
+    struct AnchorPoint
+    {
+        double x{0.5};
+        double y{0.5};
+    };
+
+    struct Vec2
+    {
+        double x{0.0};
+        double y{0.0};
+    };
+
+    GeometryMode geometry_mode() const
+    {
+        if (m_colors.size() <= 1)
+            return GeometryMode::Point;
+        if (m_colors.size() == 2)
+            return GeometryMode::Line;
+        if (m_colors.size() == 3)
+            return GeometryMode::Triangle;
+        if (m_colors.size() == 4)
+            return GeometryMode::TriangleWithCenter;
+        return GeometryMode::Radial;
+    }
+
+    wxRect canvas_rect() const
+    {
+        const wxSize size = GetClientSize();
+        return wxRect(0, 0, std::max(1, size.GetWidth()), std::max(1, size.GetHeight()));
+    }
+
+    static Vec2 make_vec(double x, double y) { return Vec2{x, y}; }
+
+    static Vec2 add_vec(const Vec2& lhs, const Vec2& rhs) { return Vec2{lhs.x + rhs.x, lhs.y + rhs.y}; }
+
+    static Vec2 sub_vec(const Vec2& lhs, const Vec2& rhs) { return Vec2{lhs.x - rhs.x, lhs.y - rhs.y}; }
+
+    static Vec2 scale_vec(const Vec2& value, double factor) { return Vec2{value.x * factor, value.y * factor}; }
+
+    static double dot_vec(const Vec2& lhs, const Vec2& rhs) { return lhs.x * rhs.x + lhs.y * rhs.y; }
+
+    static double length_sq(const Vec2& value) { return dot_vec(value, value); }
+
+    static double dist_sq(const Vec2& lhs, const Vec2& rhs) { return length_sq(sub_vec(lhs, rhs)); }
+
+    std::array<Vec2, 3> simplex_vertices() const { return {make_vec(0.50, 0.05), make_vec(0.08, 0.94), make_vec(0.92, 0.94)}; }
+
+    Vec2 simplex_center() const
+    {
+        const auto vertices = simplex_vertices();
+        return make_vec((vertices[0].x + vertices[1].x + vertices[2].x) / 3.0, (vertices[0].y + vertices[1].y + vertices[2].y) / 3.0);
+    }
+
+    std::vector<AnchorPoint> radial_anchor_points() const
+    {
+        std::vector<AnchorPoint> anchors;
+        const size_t             count = m_colors.size();
+        anchors.reserve(count);
+        if (count == 0)
+            return anchors;
+        if (count == 1) {
+            anchors.emplace_back(AnchorPoint{0.5, 0.5});
+            return anchors;
+        }
+        if (count == 2) {
+            anchors.emplace_back(AnchorPoint{0.0, 0.5});
+            anchors.emplace_back(AnchorPoint{1.0, 0.5});
+            return anchors;
+        }
+        if (count == 3) {
+            anchors.emplace_back(AnchorPoint{0.0, 0.5});
+            anchors.emplace_back(AnchorPoint{1.0, 0.0});
+            anchors.emplace_back(AnchorPoint{1.0, 1.0});
+            return anchors;
+        }
+        if (count == 4) {
+            anchors.emplace_back(AnchorPoint{0.0, 0.0});
+            anchors.emplace_back(AnchorPoint{1.0, 0.0});
+            anchors.emplace_back(AnchorPoint{1.0, 1.0});
+            anchors.emplace_back(AnchorPoint{0.0, 1.0});
+            return anchors;
+        }
+
+        constexpr double k_pi     = 3.14159265358979323846;
+        const double     center_x = 0.5;
+        const double     center_y = 0.5;
+        const double     radius   = 0.45;
+        for (size_t idx = 0; idx < count; ++idx) {
+            const double angle = (2.0 * k_pi * double(idx)) / double(count);
+            anchors.emplace_back(AnchorPoint{center_x + radius * std::cos(angle), center_y + radius * std::sin(angle)});
+        }
+        return anchors;
+    }
+
+    std::vector<AnchorPoint> anchor_points() const
+    {
+        std::vector<AnchorPoint> anchors;
+        switch (geometry_mode()) {
+        case GeometryMode::Point: anchors.emplace_back(AnchorPoint{0.5, 0.5}); break;
+        case GeometryMode::Line:
+            anchors.emplace_back(AnchorPoint{0.06, 0.5});
+            anchors.emplace_back(AnchorPoint{0.94, 0.5});
+            break;
+        case GeometryMode::Triangle: {
+            const auto vertices = simplex_vertices();
+            for (const Vec2& vertex : vertices)
+                anchors.emplace_back(AnchorPoint{vertex.x, vertex.y});
+            break;
+        }
+        case GeometryMode::TriangleWithCenter: {
+            const auto vertices = simplex_vertices();
+            for (const Vec2& vertex : vertices)
+                anchors.emplace_back(AnchorPoint{vertex.x, vertex.y});
+            const Vec2 center = simplex_center();
+            anchors.emplace_back(AnchorPoint{center.x, center.y});
+            break;
+        }
+        case GeometryMode::Radial: anchors = radial_anchor_points(); break;
+        }
+        return anchors;
+    }
+
+    static std::array<double, 3> triangle_barycentric(const Vec2& point, const std::array<Vec2, 3>& triangle)
+    {
+        const Vec2&  a     = triangle[0];
+        const Vec2&  b     = triangle[1];
+        const Vec2&  c     = triangle[2];
+        const double denom = ((b.y - c.y) * (a.x - c.x) + (c.x - b.x) * (a.y - c.y));
+        if (std::abs(denom) <= 1e-9)
+            return {1.0, 0.0, 0.0};
+        const double w0 = ((b.y - c.y) * (point.x - c.x) + (c.x - b.x) * (point.y - c.y)) / denom;
+        const double w1 = ((c.y - a.y) * (point.x - c.x) + (a.x - c.x) * (point.y - c.y)) / denom;
+        const double w2 = 1.0 - w0 - w1;
+        return {w0, w1, w2};
+    }
+
+    static bool point_in_triangle(const Vec2& point, const std::array<Vec2, 3>& triangle)
+    {
+        const auto       barycentric = triangle_barycentric(point, triangle);
+        constexpr double eps         = 1e-6;
+        return barycentric[0] >= -eps && barycentric[1] >= -eps && barycentric[2] >= -eps;
+    }
+
+    static Vec2 closest_point_on_segment(const Vec2& point, const Vec2& start, const Vec2& end)
+    {
+        const Vec2   edge        = sub_vec(end, start);
+        const double edge_len_sq = length_sq(edge);
+        if (edge_len_sq <= 1e-9)
+            return start;
+        const double t = std::clamp(dot_vec(sub_vec(point, start), edge) / edge_len_sq, 0.0, 1.0);
+        return add_vec(start, scale_vec(edge, t));
+    }
+
+    static Vec2 closest_point_on_triangle(const Vec2& point, const std::array<Vec2, 3>& triangle)
+    {
+        if (point_in_triangle(point, triangle))
+            return point;
+
+        Vec2   best      = triangle[0];
+        double best_dist = std::numeric_limits<double>::max();
+        for (int edge_idx = 0; edge_idx < 3; ++edge_idx) {
+            const Vec2   candidate      = closest_point_on_segment(point, triangle[edge_idx], triangle[(edge_idx + 1) % 3]);
+            const double candidate_dist = dist_sq(point, candidate);
+            if (candidate_dist < best_dist) {
+                best_dist = candidate_dist;
+                best      = candidate;
+            }
+        }
+        return best;
+    }
+
+    Vec2 normalized_point_from_mouse(const wxMouseEvent& evt) const
+    {
+        const wxRect rect   = canvas_rect();
+        const int    width  = std::max(1, rect.GetWidth() - 1);
+        const int    height = std::max(1, rect.GetHeight() - 1);
+        return make_vec(std::clamp(double(evt.GetX() - rect.GetLeft()) / double(width), 0.0, 1.0),
+                        std::clamp(double(evt.GetY() - rect.GetTop()) / double(height), 0.0, 1.0));
+    }
+
+    Vec2 clamp_point_to_geometry(const Vec2& point) const
+    {
+        switch (geometry_mode()) {
+        case GeometryMode::Point: return make_vec(0.5, 0.5);
+        case GeometryMode::Line: return make_vec(std::clamp(point.x, 0.0, 1.0), 0.5);
+        case GeometryMode::Triangle:
+        case GeometryMode::TriangleWithCenter: return closest_point_on_triangle(point, simplex_vertices());
+        case GeometryMode::Radial: return make_vec(std::clamp(point.x, 0.0, 1.0), std::clamp(point.y, 0.0, 1.0));
+        }
+        return point;
+    }
+
+    std::vector<double> simplex_weights_from_pos(const Vec2& point) const
+    {
+        const auto triangle    = simplex_vertices();
+        const Vec2 clamped     = closest_point_on_triangle(point, triangle);
+        const auto barycentric = triangle_barycentric(clamped, triangle);
+
+        if (geometry_mode() == GeometryMode::Triangle)
+            return {std::max(0.0, barycentric[0]), std::max(0.0, barycentric[1]), std::max(0.0, barycentric[2])};
+
+        const double shared = std::max(0.0, std::min({barycentric[0], barycentric[1], barycentric[2]}));
+        return {std::max(0.0, barycentric[0] - shared), std::max(0.0, barycentric[1] - shared), std::max(0.0, barycentric[2] - shared),
+                std::max(0.0, shared * 3.0)};
+    }
+
+    Vec2 triangle_point_from_weights() const
+    {
+        const auto vertices = simplex_vertices();
+        double     total    = 0.0;
+        for (size_t idx = 0; idx < 3 && idx < m_weights.size(); ++idx)
+            total += std::max(0, m_weights[idx]);
+        if (total <= 0.0)
+            return simplex_center();
+
+        Vec2 out = make_vec(0.0, 0.0);
+        for (size_t idx = 0; idx < 3 && idx < m_weights.size(); ++idx) {
+            const double weight = double(std::max(0, m_weights[idx])) / total;
+            out                 = add_vec(out, scale_vec(vertices[idx], weight));
+        }
+        return out;
+    }
+
+    void initialize_cursor_from_grid_search()
+    {
+        double        best_x     = 0.5;
+        double        best_y     = 0.5;
+        double        best_error = std::numeric_limits<double>::max();
+        constexpr int grid       = 96;
+        for (int y_idx = 0; y_idx <= grid; ++y_idx) {
+            for (int x_idx = 0; x_idx <= grid; ++x_idx) {
+                const Vec2 point = clamp_point_to_geometry(make_vec(double(x_idx) / double(grid), double(y_idx) / double(grid)));
+                const std::vector<int> probe = normalized_weights_from_pos(point.x, point.y);
+                if (probe.size() != m_weights.size())
+                    continue;
+                double error = 0.0;
+                for (size_t idx = 0; idx < probe.size(); ++idx) {
+                    const double delta = double(probe[idx] - m_weights[idx]);
+                    error += delta * delta;
+                }
+                if (error < best_error) {
+                    best_error = error;
+                    best_x     = point.x;
+                    best_y     = point.y;
+                }
+            }
+        }
+        m_cursor_x = best_x;
+        m_cursor_y = best_y;
+        m_weights  = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
+    }
+
+    std::vector<double> raw_weights_from_pos(double normalized_x, double normalized_y) const
+    {
+        switch (geometry_mode()) {
+        case GeometryMode::Point: return {1.0};
+        case GeometryMode::Line: {
+            const double t = std::clamp(normalized_x, 0.0, 1.0);
+            return {1.0 - t, t};
+        }
+        case GeometryMode::Triangle:
+        case GeometryMode::TriangleWithCenter: return simplex_weights_from_pos(make_vec(normalized_x, normalized_y));
+        case GeometryMode::Radial: break;
+        }
+
+        const std::vector<AnchorPoint> anchors = radial_anchor_points();
+        std::vector<double>            out(anchors.size(), 0.0);
+        if (anchors.empty())
+            return out;
+
+        constexpr double eps       = 1e-8;
+        size_t           exact_idx = size_t(-1);
+        for (size_t idx = 0; idx < anchors.size(); ++idx) {
+            const double dx = normalized_x - anchors[idx].x;
+            const double dy = normalized_y - anchors[idx].y;
+            const double d2 = dx * dx + dy * dy;
+            if (d2 <= eps) {
+                exact_idx = idx;
+                break;
+            }
+            out[idx] = 1.0 / std::max(1e-6, d2);
+        }
+        if (exact_idx != size_t(-1)) {
+            std::fill(out.begin(), out.end(), 0.0);
+            out[exact_idx] = 1.0;
+            return out;
+        }
+
+        double sum = 0.0;
+        for (const double value : out)
+            sum += value;
+        if (sum <= 0.0) {
+            out.assign(out.size(), 0.0);
+            out[0] = 1.0;
+            return out;
+        }
+        for (double& value : out)
+            value /= sum;
+        return out;
+    }
+
+    std::vector<int> normalized_weights_from_pos(double normalized_x, double normalized_y) const
+    {
+        std::vector<int>          raw_weights;
+        const std::vector<double> raw = raw_weights_from_pos(normalized_x, normalized_y);
+        raw_weights.reserve(raw.size());
+        for (const double value : raw)
+            raw_weights.emplace_back(std::max(0, int(std::lround(value * 100.0))));
+        return normalize_color_match_weights(raw_weights, raw.size());
+    }
+
+    void initialize_cursor_from_weights()
+    {
+        if (m_weights.empty()) {
+            m_cursor_x = 0.5;
+            m_cursor_y = 0.5;
+            return;
+        }
+
+        switch (geometry_mode()) {
+        case GeometryMode::Point:
+            m_cursor_x = 0.5;
+            m_cursor_y = 0.5;
+            break;
+        case GeometryMode::Line: {
+            const int    total = std::accumulate(m_weights.begin(), m_weights.end(), 0);
+            const double t     = total > 0 && m_weights.size() >= 2 ? double(std::max(0, m_weights[1])) / double(total) : 0.5;
+            m_cursor_x         = std::clamp(t, 0.0, 1.0);
+            m_cursor_y         = 0.5;
+            m_weights          = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
+            break;
+        }
+        case GeometryMode::Triangle: {
+            const Vec2 point = triangle_point_from_weights();
+            m_cursor_x       = point.x;
+            m_cursor_y       = point.y;
+            m_weights        = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
+            break;
+        }
+        case GeometryMode::TriangleWithCenter:
+        case GeometryMode::Radial: initialize_cursor_from_grid_search(); break;
+        }
+    }
+
+    void emit_changed()
+    {
+        wxCommandEvent evt(wxEVT_SLIDER, GetId());
+        evt.SetEventObject(this);
+        ProcessWindowEvent(evt);
+    }
+
+    void update_from_mouse(const wxMouseEvent& evt, bool notify)
+    {
+        const Vec2 point = clamp_point_to_geometry(normalized_point_from_mouse(evt));
+        m_cursor_x       = point.x;
+        m_cursor_y       = point.y;
+        m_weights        = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
+        Refresh();
+        if (notify)
+            emit_changed();
+    }
+
+    wxColour canvas_background_color() const { return GetBackgroundColour().IsOk() ? GetBackgroundColour() : wxColour(245, 245, 245); }
+
+    bool cached_bitmap_matches(const wxSize& size, const wxColour& background) const
+    {
+        return m_cached_bitmap.IsOk() && m_cached_bitmap_size == size && m_cached_background == background;
+    }
+
+    void schedule_cached_bitmap_render()
+    {
+        if (!m_render_timer.IsRunning())
+            m_render_timer.StartOnce(80);
+    }
+
+    void invalidate_cached_bitmap()
+    {
+        m_cached_bitmap      = wxBitmap();
+        m_cached_bitmap_size = wxSize();
+        m_cached_background  = wxColour();
+    }
+
+    bool color_match_raw_weights_within_range(const std::vector<double> &weights, int min_component_percent)
+    {
+        if (min_component_percent <= 0)
+            return true;
+
+        const double min_allowed = double(std::clamp(min_component_percent, 0, 50));
+        int active_components = 0;
+        for (const double weight : weights) {
+            if (weight <= 1e-4)
+                continue;
+            ++active_components;
+            if (weight * 100.0 + 1e-6 < min_allowed)
+                return false;
+        }
+        return active_components >= 2;
+    }
+
+    void render_cached_bitmap(const wxSize& size, const wxColour& background)
+    {
+        const int width  = size.GetWidth();
+        const int height = size.GetHeight();
+        if (width <= 0 || height <= 0)
+            return;
+
+        wxImage        image(width, height);
+        unsigned char* data = image.GetData();
+        if (data != nullptr) {
+            for (int y = 0; y < height; ++y) {
+                const double normalized_y = (height > 1) ? double(y) / double(height - 1) : 0.5;
+                for (int x = 0; x < width; ++x) {
+                    const double normalized_x = (width > 1) ? double(x) / double(width - 1) : 0.5;
+                    const int    data_idx     = (y * width + x) * 3;
+                    bool         paint_pixel  = true;
+                    if (geometry_mode() == GeometryMode::Triangle || geometry_mode() == GeometryMode::TriangleWithCenter)
+                        paint_pixel = point_in_triangle(make_vec(normalized_x, normalized_y), simplex_vertices());
+
+                    const std::vector<double> raw_weights = raw_weights_from_pos(normalized_x, normalized_y);
+                    wxColour                  color       = paint_pixel ? blend_multi_filament_mixer(m_colors, raw_weights) : background;
+                    if (paint_pixel && m_min_component_percent > 0 &&
+                        !color_match_raw_weights_within_range(raw_weights, m_min_component_percent)) {
+                        const bool   stripe = (((x + y) / 8) % 2) == 0;
+                        const double factor = stripe ? 0.12 : 0.38;
+                        color = wxColour(static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Red()) * factor)), 0, 255)),
+                                         static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Green()) * factor)), 0, 255)),
+                                         static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Blue()) * factor)), 0, 255)));
+                    }
+                    data[data_idx + 0] = color.Red();
+                    data[data_idx + 1] = color.Green();
+                    data[data_idx + 2] = color.Blue();
+                }
+            }
+        }
+
+        m_cached_bitmap      = wxBitmap(image);
+        m_cached_bitmap_size = size;
+        m_cached_background  = background;
+    }
+
+    void draw_cached_bitmap(wxAutoBufferedPaintDC& dc, const wxRect& rect)
+    {
+        if (!m_cached_bitmap.IsOk())
+            return;
+
+        if (m_cached_bitmap_size == rect.GetSize()) {
+            dc.DrawBitmap(m_cached_bitmap, rect.GetLeft(), rect.GetTop(), false);
+            return;
+        }
+
+        wxMemoryDC memdc;
+        memdc.SelectObject(m_cached_bitmap);
+        dc.StretchBlit(rect.GetLeft(), rect.GetTop(), rect.GetWidth(), rect.GetHeight(), &memdc, 0, 0, m_cached_bitmap_size.GetWidth(),
+                       m_cached_bitmap_size.GetHeight());
+        memdc.SelectObject(wxNullBitmap);
+    }
+
+    void on_paint(wxPaintEvent&)
+    {
+        wxAutoBufferedPaintDC dc(this);
+        dc.SetBackground(wxBrush(GetBackgroundColour()));
+        dc.Clear();
+
+        const wxRect rect   = canvas_rect();
+        const int    width  = rect.GetWidth();
+        const int    height = rect.GetHeight();
+        if (width <= 0 || height <= 0)
+            return;
+
+        const wxColour background = canvas_background_color();
+        if (!cached_bitmap_matches(rect.GetSize(), background)) {
+            if (!m_cached_bitmap.IsOk())
+                render_cached_bitmap(rect.GetSize(), background);
+            else
+                schedule_cached_bitmap_render();
+        }
+
+        const bool is_triangle_mode = geometry_mode() == GeometryMode::Triangle ||
+                                      geometry_mode() == GeometryMode::TriangleWithCenter;
+
+        if (is_triangle_mode) {
+            const auto triangle = simplex_vertices();
+            wxPoint    points[3] = {
+                wxPoint(rect.GetLeft() + int(std::lround(triangle[0].x * double(std::max(1, width - 1)))),
+                        rect.GetTop()  + int(std::lround(triangle[0].y * double(std::max(1, height - 1))))),
+                wxPoint(rect.GetLeft() + int(std::lround(triangle[1].x * double(std::max(1, width - 1)))),
+                        rect.GetTop()  + int(std::lround(triangle[1].y * double(std::max(1, height - 1))))),
+                wxPoint(rect.GetLeft() + int(std::lround(triangle[2].x * double(std::max(1, width - 1)))),
+                        rect.GetTop()  + int(std::lround(triangle[2].y * double(std::max(1, height - 1)))))};
+
+            // Clip bitmap to triangle; dc.Clear() already filled outside with background.
+            dc.SetClippingRegion(wxRegion(3, points));
+            draw_cached_bitmap(dc, rect);
+            dc.DestroyClippingRegion();
+
+            // Triangle outline.
+            dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
+            dc.SetBrush(*wxTRANSPARENT_BRUSH);
+            dc.DrawPolygon(3, points);
+
+            if (geometry_mode() == GeometryMode::TriangleWithCenter) {
+                const Vec2    center = simplex_center();
+                const wxPoint center_pt(rect.GetLeft() + int(std::lround(center.x * double(std::max(1, width - 1)))),
+                                        rect.GetTop()  + int(std::lround(center.y * double(std::max(1, height - 1)))));
+                dc.SetPen(wxPen(wxColour(180, 180, 180), 1, wxPENSTYLE_DOT));
+                for (const wxPoint& vertex : points)
+                    dc.DrawLine(center_pt, vertex);
+            }
+        } else {
+            draw_cached_bitmap(dc, rect);
+            dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
+            dc.SetBrush(*wxTRANSPARENT_BRUSH);
+            dc.DrawRectangle(rect);
+        }
+
+        dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
+        dc.SetBrush(*wxTRANSPARENT_BRUSH);
+
+        const auto anchors = anchor_points();
+        for (size_t idx = 0; idx < anchors.size() && idx < m_colors.size(); ++idx) {
+            const int anchor_x = rect.GetLeft() + int(std::lround(anchors[idx].x * double(std::max(1, width - 1))));
+            const int anchor_y = rect.GetTop()  + int(std::lround(anchors[idx].y * double(std::max(1, height - 1))));
+            dc.SetPen(wxPen(wxColour(30, 30, 30), 1));
+            dc.SetBrush(wxBrush(m_colors[idx]));
+            dc.DrawCircle(wxPoint(anchor_x, anchor_y), FromDIP(4));
+        }
+
+        const int cursor_x = rect.GetLeft() + int(std::lround(m_cursor_x * double(std::max(1, width - 1))));
+        const int cursor_y = rect.GetTop()  + int(std::lround(m_cursor_y * double(std::max(1, height - 1))));
+        dc.SetPen(wxPen(wxColour(255, 255, 255), 3));
+        dc.SetBrush(*wxTRANSPARENT_BRUSH);
+        dc.DrawCircle(wxPoint(cursor_x, cursor_y), FromDIP(7));
+        dc.SetPen(wxPen(wxColour(30, 30, 30), 1));
+        dc.DrawCircle(wxPoint(cursor_x, cursor_y), FromDIP(7));
+    }
+
+    void on_left_down(wxMouseEvent& evt)
+    {
+        if (!HasCapture())
+            CaptureMouse();
+        m_dragging = true;
+        update_from_mouse(evt, true);
+    }
+
+    void on_left_up(wxMouseEvent& evt)
+    {
+        if (m_dragging)
+            update_from_mouse(evt, true);
+        m_dragging = false;
+        if (HasCapture())
+            ReleaseMouse();
+    }
+
+    void on_mouse_move(wxMouseEvent& evt)
+    {
+        if (m_dragging && evt.LeftIsDown())
+            update_from_mouse(evt, true);
+    }
+
+    void on_capture_lost(wxMouseCaptureLostEvent&) { m_dragging = false; }
+
+    void on_size(wxSizeEvent& evt)
+    {
+        if (m_cached_bitmap.IsOk())
+            schedule_cached_bitmap_render();
+        Refresh(false);
+        evt.Skip();
+    }
+
+    void on_render_timer(wxTimerEvent&)
+    {
+        const wxRect rect = canvas_rect();
+        render_cached_bitmap(rect.GetSize(), canvas_background_color());
+        Refresh(false);
+    }
+
+private:
+    std::vector<wxColour> m_colors;
+    std::vector<int>      m_weights;
+    wxBitmap              m_cached_bitmap;
+    wxSize                m_cached_bitmap_size;
+    wxColour              m_cached_background;
+    wxTimer               m_render_timer;
+    int                   m_min_component_percent{0};
+    double                m_cursor_x{0.5};
+    double                m_cursor_y{0.5};
+    bool                  m_dragging{false};
+};
+
+inline MixedFilamentColorMapPanel* create_color_map_panel(wxWindow*                        parent,
+                                                   const std::vector<unsigned int>& filament_ids,
+                                                   const std::vector<wxColour>&     palette,
+                                                   const std::vector<int>&          initial_weights,
+                                                   const wxSize&                    min_size)
+{
+    return new MixedFilamentColorMapPanel(parent, filament_ids, palette, initial_weights, min_size);
+}
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedGradientSelector.hpp
+++ b/src/slic3r/GUI/MixedGradientSelector.hpp
@@ -1,0 +1,244 @@
+#pragma once
+
+#include "GUI_App.hpp"
+#include "Widgets/Label.hpp"
+#include "I18N.hpp"
+#include "libslic3r/filament_mixer.h"
+
+#include <wx/panel.h>
+#include <wx/dcbuffer.h>
+
+#include <algorithm>
+#include <vector>
+
+namespace Slic3r { namespace GUI {
+
+inline wxColour blend_pair_filament_mixer(const wxColour &left, const wxColour &right, float t)
+{
+    const wxColour safe_left  = left.IsOk()  ? left  : wxColour("#26A69A");
+    const wxColour safe_right = right.IsOk() ? right : wxColour("#26A69A");
+
+    unsigned char out_r = static_cast<unsigned char>(safe_left.Red());
+    unsigned char out_g = static_cast<unsigned char>(safe_left.Green());
+    unsigned char out_b = static_cast<unsigned char>(safe_left.Blue());
+    ::Slic3r::filament_mixer_lerp(
+        static_cast<unsigned char>(safe_left.Red()),
+        static_cast<unsigned char>(safe_left.Green()),
+        static_cast<unsigned char>(safe_left.Blue()),
+        static_cast<unsigned char>(safe_right.Red()),
+        static_cast<unsigned char>(safe_right.Green()),
+        static_cast<unsigned char>(safe_right.Blue()),
+        std::clamp(t, 0.f, 1.f),
+        &out_r, &out_g, &out_b);
+    return wxColour(out_r, out_g, out_b);
+}
+
+class MixedGradientSelector : public wxPanel
+{
+public:
+    MixedGradientSelector(wxWindow *parent, const wxColour &left, const wxColour &right, int value_percent)
+        : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE)
+        , m_left(left)
+        , m_right(right)
+        , m_value(std::clamp(value_percent, 0, 100))
+    {
+        SetBackgroundStyle(wxBG_STYLE_PAINT);
+        SetMinSize(wxSize(FromDIP(96), FromDIP(24)));
+        Bind(wxEVT_PAINT,              &MixedGradientSelector::on_paint,        this);
+        Bind(wxEVT_LEFT_DOWN,          &MixedGradientSelector::on_left_down,    this);
+        Bind(wxEVT_LEFT_UP,            &MixedGradientSelector::on_left_up,      this);
+        Bind(wxEVT_MOTION,             &MixedGradientSelector::on_mouse_move,   this);
+        Bind(wxEVT_MOUSE_CAPTURE_LOST, &MixedGradientSelector::on_capture_lost, this);
+    }
+
+    ~MixedGradientSelector() override
+    {
+        if (HasCapture())
+            ReleaseMouse();
+    }
+
+    int  value()        const { return m_value; }
+    bool is_multi_mode() const { return m_multi_mode; }
+
+    void set_colors(const wxColour &left, const wxColour &right)
+    {
+        m_left  = left;
+        m_right = right;
+        m_multi_mode = false;
+        m_multi_colors.clear();
+        m_multi_weights.clear();
+        Refresh();
+    }
+
+    void set_multi_preview(const std::vector<wxColour> &corner_colors, const std::vector<int> &weights)
+    {
+        m_multi_mode    = corner_colors.size() >= 3;
+        m_multi_colors  = corner_colors;
+        m_multi_weights = weights;
+        Refresh();
+    }
+
+private:
+    wxRect gradient_rect() const
+    {
+        const int margin_x = FromDIP(2);
+        const int margin_y = FromDIP(1);
+        const wxSize sz = GetClientSize();
+        return wxRect(margin_x, margin_y,
+                      std::max(1, sz.GetWidth()  - margin_x * 2),
+                      std::max(1, sz.GetHeight() - margin_y * 2));
+    }
+
+    int value_from_x(int x) const
+    {
+        const wxRect rect = gradient_rect();
+        const int min_x   = rect.GetLeft();
+        const int max_x   = rect.GetLeft() + rect.GetWidth();
+        const int cx      = std::clamp(x, min_x, max_x);
+        return ((cx - min_x) * 100 + rect.GetWidth() / 2) / rect.GetWidth();
+    }
+
+    void update_from_x(int x, bool notify)
+    {
+        m_value = value_from_x(x);
+        Refresh();
+        if (notify) {
+            wxCommandEvent evt(wxEVT_SLIDER, GetId());
+            evt.SetInt(m_value);
+            evt.SetEventObject(this);
+            ProcessWindowEvent(evt);
+        }
+    }
+
+    void on_paint(wxPaintEvent &)
+    {
+        wxAutoBufferedPaintDC dc(this);
+        dc.SetBackground(wxBrush(GetBackgroundColour()));
+        dc.Clear();
+        const bool is_dark = wxGetApp().dark_mode();
+
+        const wxRect rect = gradient_rect();
+        if (m_multi_mode && m_multi_colors.size() >= 3) {
+            const wxPoint tl(rect.GetLeft(),  rect.GetTop());
+            const wxPoint tr(rect.GetRight(), rect.GetTop());
+            const wxPoint br(rect.GetRight(), rect.GetBottom());
+            const wxPoint bl(rect.GetLeft(),  rect.GetBottom());
+            const wxPoint cc(rect.GetLeft() + rect.GetWidth() / 2,
+                             rect.GetTop()  + rect.GetHeight() / 2);
+            auto draw_tri = [&dc](const wxColour &color,
+                                  const wxPoint &a, const wxPoint &b, const wxPoint &c) {
+                wxPoint pts[3] = {a, b, c};
+                dc.SetPen(*wxTRANSPARENT_PEN);
+                dc.SetBrush(wxBrush(color));
+                dc.DrawPolygon(3, pts);
+            };
+            if (m_multi_colors.size() >= 4) {
+                draw_tri(m_multi_colors[0], tl, tr, cc);
+                draw_tri(m_multi_colors[1], tr, br, cc);
+                draw_tri(m_multi_colors[2], br, bl, cc);
+                draw_tri(m_multi_colors[3], bl, tl, cc);
+            } else {
+                draw_tri(m_multi_colors[0], tl, bl, cc);
+                draw_tri(m_multi_colors[1], tl, tr, cc);
+                draw_tri(m_multi_colors[2], bl, br, cc);
+            }
+            if (m_multi_weights.size() == m_multi_colors.size()) {
+                dc.SetTextForeground(is_dark ? wxColour(236,236,236) : wxColour(20,20,20));
+                dc.SetFont(Label::Body_10);
+                const int pad = FromDIP(2);
+                if (m_multi_colors.size() >= 4) {
+                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[0]), rect.GetLeft()  + pad,          rect.GetTop()    + pad);
+                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[1]), rect.GetRight() - FromDIP(28),  rect.GetTop()    + pad);
+                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[2]), rect.GetRight() - FromDIP(28),  rect.GetBottom() - FromDIP(14));
+                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[3]), rect.GetLeft()  + pad,          rect.GetBottom() - FromDIP(14));
+                } else {
+                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[0]), rect.GetLeft()  + pad,         rect.GetTop() + rect.GetHeight()/2 - FromDIP(6));
+                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[1]), rect.GetRight() - FromDIP(28), rect.GetTop()    + pad);
+                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[2]), rect.GetRight() - FromDIP(28), rect.GetBottom() - FromDIP(14));
+                }
+            }
+        } else {
+            const int w = rect.GetWidth();
+            const int h = rect.GetHeight();
+            wxImage img(w, h);
+            unsigned char *data = img.GetData();
+            if (data != nullptr) {
+                for (int x = 0; x < w; ++x) {
+                    const float t   = (w > 1) ? float(x) / float(w - 1) : 0.5f;
+                    const wxColour col = blend_pair_filament_mixer(m_left, m_right, t);
+                    const unsigned char r = static_cast<unsigned char>(col.Red());
+                    const unsigned char g = static_cast<unsigned char>(col.Green());
+                    const unsigned char b = static_cast<unsigned char>(col.Blue());
+                    for (int y = 0; y < h; ++y) {
+                        const int idx = (y * w + x) * 3;
+                        data[idx + 0] = r;
+                        data[idx + 1] = g;
+                        data[idx + 2] = b;
+                    }
+                }
+                dc.DrawBitmap(wxBitmap(img), rect.GetLeft(), rect.GetTop(), false);
+            } else {
+                dc.GradientFillLinear(rect, m_left, m_right, wxEAST);
+            }
+        }
+
+        dc.SetPen(wxPen(is_dark ? wxColour(100,100,106) : wxColour(170,170,170), 1));
+        dc.SetBrush(*wxTRANSPARENT_BRUSH);
+        dc.DrawRectangle(rect);
+
+        if (m_multi_mode) {
+            dc.SetTextForeground(is_dark ? wxColour(236,236,236) : wxColour(30,30,30));
+            dc.SetFont(Label::Body_10);
+            const wxString hint = _L("Click to edit");
+            wxSize text_sz = dc.GetTextExtent(hint);
+            dc.DrawText(hint, rect.GetRight() - text_sz.GetWidth() - FromDIP(4), rect.GetTop() + FromDIP(2));
+            return;
+        }
+
+        int marker_x = rect.GetLeft() + (rect.GetWidth() * m_value + 50) / 100;
+        marker_x = std::clamp(marker_x, rect.GetLeft(), rect.GetRight());
+        dc.SetPen(wxPen(wxColour(255,255,255), 3));
+        dc.DrawLine(marker_x, rect.GetTop(), marker_x, rect.GetBottom());
+        dc.SetPen(wxPen(wxColour(33,33,33), 1));
+        dc.DrawLine(marker_x, rect.GetTop(), marker_x, rect.GetBottom());
+    }
+
+    void on_left_down(wxMouseEvent &evt)
+    {
+        if (m_multi_mode) return;
+        if (!HasCapture()) CaptureMouse();
+        m_dragging = true;
+        update_from_x(evt.GetX(), false);
+    }
+
+    void on_left_up(wxMouseEvent &evt)
+    {
+        if (m_multi_mode) {
+            wxCommandEvent click_evt(wxEVT_BUTTON, GetId());
+            click_evt.SetEventObject(this);
+            ProcessWindowEvent(click_evt);
+            return;
+        }
+        if (m_dragging) update_from_x(evt.GetX(), true);
+        m_dragging = false;
+        if (HasCapture()) ReleaseMouse();
+    }
+
+    void on_mouse_move(wxMouseEvent &evt)
+    {
+        if (m_dragging && evt.LeftIsDown())
+            update_from_x(evt.GetX(), false);
+    }
+
+    void on_capture_lost(wxMouseCaptureLostEvent &) { m_dragging = false; }
+
+    wxColour              m_left;
+    wxColour              m_right;
+    bool                  m_multi_mode    {false};
+    std::vector<wxColour> m_multi_colors;
+    std::vector<int>      m_multi_weights;
+    int                   m_value         {50};
+    bool                  m_dragging      {false};
+};
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1,4 +1,8 @@
 #include "Plater.hpp"
+#include "AddColorMixDialog.hpp"
+#include "MixedGradientSelector.hpp"
+#include "MixedColorMatchPanel.hpp"
+#include "MixedFilamentColorMapPanel.hpp"
 #include "libslic3r/Config.hpp"
 #include "libslic3r/MixedFilament.hpp"
 #include "libslic3r/filament_mixer.h"
@@ -227,31 +231,6 @@ wxDEFINE_EVENT(EVT_ADD_FILAMENT, SimpleEvent);
 wxDEFINE_EVENT(EVT_DEL_FILAMENT, SimpleEvent);
 wxDEFINE_EVENT(EVT_ADD_CUSTOM_FILAMENT, ColorEvent);
 
-struct MixedColorMatchRecipeResult
-{
-    bool        cancelled     = false;
-    bool        valid         = false;
-    unsigned int component_a  = 1;
-    unsigned int component_b  = 2;
-    int         mix_b_percent = 50;
-    std::string manual_pattern;
-    std::string gradient_component_ids;
-    std::string gradient_component_weights;
-    wxColour    preview_color = wxColour("#26A69A");
-    double      delta_e       = std::numeric_limits<double>::infinity();
-};
-
-MixedColorMatchRecipeResult prompt_best_color_match_recipe(wxWindow *parent,
-                                                           const std::vector<std::string> &physical_colors,
-                                                           const wxColour &initial_color);
-double color_delta_e00(const wxColour &lhs, const wxColour &rhs);
-
-namespace {
-
-MixedFilamentDisplayContext build_mixed_filament_display_context(const std::vector<std::string> &physical_colors);
-wxColour compute_color_match_recipe_display_color(const MixedColorMatchRecipeResult &recipe, const MixedFilamentDisplayContext &context);
-
-} // namespace
 
 #define PRINTER_THUMBNAIL_SIZE (wxSize(FromDIP(48), FromDIP(48)))
 #define PRINTER_THUMBNAIL_SIZE_SMALL (wxSize(FromDIP(32), FromDIP(32)))
@@ -704,6 +683,13 @@ struct Sidebar::priv
     std::vector<uint64_t>                m_mixed_filament_ui_order;
     bool                                 m_mixed_filament_drag_active = false;
     size_t                               m_mixed_filament_drag_source_mixed_id = size_t(-1);
+    // Color mix panel
+    StaticBox*      m_panel_color_mix_title   = nullptr;
+    wxPanel*        m_panel_color_mix_content = nullptr;
+    wxBoxSizer*     m_sizer_color_mix_content = nullptr;
+    ScalableButton* m_btn_add_color_mix       = nullptr;
+    ScalableButton* m_btn_del_color_mix       = nullptr;
+
     wxStaticLine* m_staticline2;
     wxPanel* m_panel_project_title;
     ScalableButton* m_filament_icon = nullptr;
@@ -1483,7 +1469,10 @@ Sidebar::Sidebar(Plater *parent)
     wxSizer *sizer_filaments2 = new wxBoxSizer(wxVERTICAL);
     sizer_filaments2->AddSpacer(FromDIP(16));
     sizer_filaments2->Add(p->sizer_filaments, 0, wxEXPAND, 0);
-    sizer_filaments2->AddSpacer(FromDIP(16));
+    sizer_filaments2->AddSpacer(FromDIP(8));
+    // --- Color Mix Panel (inside filament content, same level as filaments) ---
+    init_color_mix_panel(p->m_panel_filament_content, sizer_filaments2);
+    sizer_filaments2->AddSpacer(FromDIP(8));
     p->m_panel_filament_content->SetSizer(sizer_filaments2);
     p->m_panel_filament_content->Layout();
     scrolled_sizer->Add(p->m_panel_filament_content, 0, wxEXPAND, 0);
@@ -2412,76 +2401,12 @@ void Sidebar::on_filaments_change(size_t num_filaments)
     update_mixed_filament_panel();
 }
 
-namespace {
 wxColour parse_mixed_color(const std::string &value)
 {
     wxColour color(value);
     if (!color.IsOk())
         color = wxColour("#26A69A");
     return color;
-}
-
-wxColour blend_pair_filament_mixer(const wxColour &left, const wxColour &right, float t)
-{
-    const wxColour safe_left = left.IsOk() ? left : wxColour("#26A69A");
-    const wxColour safe_right = right.IsOk() ? right : wxColour("#26A69A");
-
-    unsigned char out_r = static_cast<unsigned char>(safe_left.Red());
-    unsigned char out_g = static_cast<unsigned char>(safe_left.Green());
-    unsigned char out_b = static_cast<unsigned char>(safe_left.Blue());
-    ::Slic3r::filament_mixer_lerp(static_cast<unsigned char>(safe_left.Red()),
-                                  static_cast<unsigned char>(safe_left.Green()),
-                                  static_cast<unsigned char>(safe_left.Blue()),
-                                  static_cast<unsigned char>(safe_right.Red()),
-                                  static_cast<unsigned char>(safe_right.Green()),
-                                  static_cast<unsigned char>(safe_right.Blue()),
-                                  std::clamp(t, 0.f, 1.f),
-                                  &out_r, &out_g, &out_b);
-    return wxColour(out_r, out_g, out_b);
-}
-
-wxColour blend_multi_filament_mixer(const std::vector<wxColour> &colors, const std::vector<double> &weights)
-{
-    if (colors.empty() || weights.empty())
-        return wxColour("#26A69A");
-
-    unsigned char out_r = 0;
-    unsigned char out_g = 0;
-    unsigned char out_b = 0;
-    double accumulated_weight = 0.0;
-    bool has_color = false;
-
-    for (size_t i = 0; i < colors.size() && i < weights.size(); ++i) {
-        const double weight = std::max(0.0, weights[i]);
-        if (weight <= 0.0)
-            continue;
-
-        const wxColour safe = colors[i].IsOk() ? colors[i] : wxColour("#26A69A");
-        const unsigned char r = static_cast<unsigned char>(safe.Red());
-        const unsigned char g = static_cast<unsigned char>(safe.Green());
-        const unsigned char b = static_cast<unsigned char>(safe.Blue());
-
-        if (!has_color) {
-            out_r = r;
-            out_g = g;
-            out_b = b;
-            accumulated_weight = weight;
-            has_color = true;
-            continue;
-        }
-
-        const double new_total = accumulated_weight + weight;
-        if (new_total <= 0.0)
-            continue;
-        const float t = float(weight / new_total);
-        ::Slic3r::filament_mixer_lerp(out_r, out_g, out_b, r, g, b, t, &out_r, &out_g, &out_b);
-        accumulated_weight = new_total;
-    }
-
-    if (!has_color)
-        return wxColour("#26A69A");
-
-    return wxColour(out_r, out_g, out_b);
 }
 
 wxString normalize_color_match_hex(const wxString &value)
@@ -2514,6 +2439,8 @@ bool try_parse_color_match_hex(const wxString &value, wxColour &color_out)
     color_out = parsed;
     return true;
 }
+
+namespace {
 
 std::vector<unsigned int> decode_color_match_gradient_ids(const std::string &value)
 {
@@ -2554,6 +2481,8 @@ std::vector<int> decode_color_match_gradient_weights(const std::string &value, s
         weights.clear();
     return weights;
 }
+
+} // namespace
 
 std::vector<int> normalize_color_match_weights(const std::vector<int> &weights, size_t count)
 {
@@ -2602,6 +2531,8 @@ std::vector<int> normalize_color_match_weights(const std::vector<int> &weights, 
 std::vector<unsigned int> build_color_match_sequence(const std::vector<unsigned int> &ids, const std::vector<int> &weights);
 wxColour blend_sequence_filament_mixer(const std::vector<wxColour> &palette, const std::vector<unsigned int> &sequence);
 
+namespace {
+
 bool color_match_weights_within_range(const std::vector<int> &weights, int min_component_percent)
 {
     if (min_component_percent <= 0)
@@ -2614,23 +2545,6 @@ bool color_match_weights_within_range(const std::vector<int> &weights, int min_c
             continue;
         ++active_components;
         if (weight < min_allowed)
-            return false;
-    }
-    return active_components >= 2;
-}
-
-bool color_match_raw_weights_within_range(const std::vector<double> &weights, int min_component_percent)
-{
-    if (min_component_percent <= 0)
-        return true;
-
-    const double min_allowed = double(std::clamp(min_component_percent, 0, 50));
-    int active_components = 0;
-    for (const double weight : weights) {
-        if (weight <= 1e-4)
-            continue;
-        ++active_components;
-        if (weight * 100.0 + 1e-6 < min_allowed)
             return false;
     }
     return active_components >= 2;
@@ -2723,6 +2637,10 @@ MixedColorMatchRecipeResult build_multi_color_match_candidate(const std::vector<
     return candidate;
 }
 
+} // namespace
+
+// Functions declared in MixedColorMatchHelpers.hpp — must be in Slic3r::GUI scope
+
 std::vector<int> expand_color_match_recipe_weights(const MixedColorMatchRecipeResult &recipe, size_t num_physical)
 {
     std::vector<int> weights(num_physical, 0);
@@ -2797,7 +2715,7 @@ wxBitmap make_color_match_swatch_bitmap(const wxColour &color, const wxSize &siz
 }
 
 std::vector<MixedColorMatchRecipeResult> build_color_match_presets(const std::vector<std::string> &physical_colors,
-                                                                   int                             min_component_percent = 0)
+                                                                   int                             min_component_percent)
 {
     std::vector<MixedColorMatchRecipeResult> presets;
     if (physical_colors.size() < 2)
@@ -2961,7 +2879,7 @@ wxColour blend_sequence_filament_mixer(const std::vector<wxColour> &palette, con
 
 MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std::string> &physical_colors,
                                                           const wxColour                 &target_color,
-                                                          int                             min_component_percent = 0)
+                                                          int                             min_component_percent)
 {
     MixedColorMatchRecipeResult best;
     if (!target_color.IsOk() || physical_colors.size() < 2)
@@ -3084,700 +3002,6 @@ MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std:
 
     return best;
 }
-class MixedFilamentColorMapPanel : public wxPanel
-{
-public:
-    MixedFilamentColorMapPanel(wxWindow                        *parent,
-                               const std::vector<unsigned int> &filament_ids,
-                               const std::vector<wxColour>     &palette,
-                               const std::vector<int>          &initial_weights,
-                               const wxSize                    &min_size)
-        : wxPanel(parent, wxID_ANY, wxDefaultPosition, min_size, wxBORDER_SIMPLE)
-    {
-        SetBackgroundStyle(wxBG_STYLE_PAINT);
-        SetMinSize(min_size);
-        m_render_timer.SetOwner(this);
-
-        m_colors.reserve(filament_ids.size());
-        for (const unsigned int filament_id : filament_ids) {
-            if (filament_id >= 1 && filament_id <= palette.size())
-                m_colors.emplace_back(palette[filament_id - 1]);
-            else
-                m_colors.emplace_back(wxColour("#26A69A"));
-        }
-        if (m_colors.empty())
-            m_colors.emplace_back(wxColour("#26A69A"));
-
-        set_normalized_weights(initial_weights, false);
-
-        Bind(wxEVT_PAINT, &MixedFilamentColorMapPanel::on_paint, this);
-        Bind(wxEVT_LEFT_DOWN, &MixedFilamentColorMapPanel::on_left_down, this);
-        Bind(wxEVT_LEFT_UP, &MixedFilamentColorMapPanel::on_left_up, this);
-        Bind(wxEVT_MOTION, &MixedFilamentColorMapPanel::on_mouse_move, this);
-        Bind(wxEVT_MOUSE_CAPTURE_LOST, &MixedFilamentColorMapPanel::on_capture_lost, this);
-        Bind(wxEVT_SIZE, &MixedFilamentColorMapPanel::on_size, this);
-        Bind(wxEVT_TIMER, &MixedFilamentColorMapPanel::on_render_timer, this, m_render_timer.GetId());
-    }
-
-    ~MixedFilamentColorMapPanel() override
-    {
-        if (HasCapture())
-            ReleaseMouse();
-        if (m_render_timer.IsRunning())
-            m_render_timer.Stop();
-    }
-
-    std::vector<int> normalized_weights() const
-    {
-        return m_weights;
-    }
-
-    wxColour selected_color() const
-    {
-        std::vector<double> weights;
-        weights.reserve(m_weights.size());
-        for (const int weight : m_weights)
-            weights.emplace_back(double(std::max(0, weight)));
-        return blend_multi_filament_mixer(m_colors, weights);
-    }
-
-    void set_normalized_weights(const std::vector<int> &weights, bool notify)
-    {
-        m_weights = normalize_color_match_weights(weights, m_colors.size());
-        initialize_cursor_from_weights();
-        Refresh();
-        if (notify)
-            emit_changed();
-    }
-
-    void set_min_component_percent(int min_component_percent)
-    {
-        const int clamped = std::clamp(min_component_percent, 0, 50);
-        if (m_min_component_percent == clamped)
-            return;
-        m_min_component_percent = clamped;
-        invalidate_cached_bitmap();
-        Refresh();
-    }
-
-private:
-    enum class GeometryMode {
-        Point,
-        Line,
-        Triangle,
-        TriangleWithCenter,
-        Radial
-    };
-
-    struct AnchorPoint {
-        double x { 0.5 };
-        double y { 0.5 };
-    };
-
-    struct Vec2 {
-        double x { 0.0 };
-        double y { 0.0 };
-    };
-
-    GeometryMode geometry_mode() const
-    {
-        if (m_colors.size() <= 1)
-            return GeometryMode::Point;
-        if (m_colors.size() == 2)
-            return GeometryMode::Line;
-        if (m_colors.size() == 3)
-            return GeometryMode::Triangle;
-        if (m_colors.size() == 4)
-            return GeometryMode::TriangleWithCenter;
-        return GeometryMode::Radial;
-    }
-
-    wxRect canvas_rect() const
-    {
-        const wxSize size = GetClientSize();
-        return wxRect(0, 0, std::max(1, size.GetWidth()), std::max(1, size.GetHeight()));
-    }
-
-    static Vec2 make_vec(double x, double y)
-    {
-        return Vec2 { x, y };
-    }
-
-    static Vec2 add_vec(const Vec2 &lhs, const Vec2 &rhs)
-    {
-        return Vec2 { lhs.x + rhs.x, lhs.y + rhs.y };
-    }
-
-    static Vec2 sub_vec(const Vec2 &lhs, const Vec2 &rhs)
-    {
-        return Vec2 { lhs.x - rhs.x, lhs.y - rhs.y };
-    }
-
-    static Vec2 scale_vec(const Vec2 &value, double factor)
-    {
-        return Vec2 { value.x * factor, value.y * factor };
-    }
-
-    static double dot_vec(const Vec2 &lhs, const Vec2 &rhs)
-    {
-        return lhs.x * rhs.x + lhs.y * rhs.y;
-    }
-
-    static double length_sq(const Vec2 &value)
-    {
-        return dot_vec(value, value);
-    }
-
-    static double dist_sq(const Vec2 &lhs, const Vec2 &rhs)
-    {
-        return length_sq(sub_vec(lhs, rhs));
-    }
-
-    std::array<Vec2, 3> simplex_vertices() const
-    {
-        return { make_vec(0.50, 0.05), make_vec(0.08, 0.94), make_vec(0.92, 0.94) };
-    }
-
-    Vec2 simplex_center() const
-    {
-        const auto vertices = simplex_vertices();
-        return make_vec((vertices[0].x + vertices[1].x + vertices[2].x) / 3.0,
-                        (vertices[0].y + vertices[1].y + vertices[2].y) / 3.0);
-    }
-
-    std::vector<AnchorPoint> radial_anchor_points() const
-    {
-        std::vector<AnchorPoint> anchors;
-        const size_t count = m_colors.size();
-        anchors.reserve(count);
-        if (count == 0)
-            return anchors;
-        if (count == 1) {
-            anchors.emplace_back(AnchorPoint { 0.5, 0.5 });
-            return anchors;
-        }
-        if (count == 2) {
-            anchors.emplace_back(AnchorPoint { 0.0, 0.5 });
-            anchors.emplace_back(AnchorPoint { 1.0, 0.5 });
-            return anchors;
-        }
-        if (count == 3) {
-            anchors.emplace_back(AnchorPoint { 0.0, 0.5 });
-            anchors.emplace_back(AnchorPoint { 1.0, 0.0 });
-            anchors.emplace_back(AnchorPoint { 1.0, 1.0 });
-            return anchors;
-        }
-        if (count == 4) {
-            anchors.emplace_back(AnchorPoint { 0.0, 0.0 });
-            anchors.emplace_back(AnchorPoint { 1.0, 0.0 });
-            anchors.emplace_back(AnchorPoint { 1.0, 1.0 });
-            anchors.emplace_back(AnchorPoint { 0.0, 1.0 });
-            return anchors;
-        }
-
-        constexpr double k_pi = 3.14159265358979323846;
-        const double center_x = 0.5;
-        const double center_y = 0.5;
-        const double radius = 0.45;
-        for (size_t idx = 0; idx < count; ++idx) {
-            const double angle = (2.0 * k_pi * double(idx)) / double(count);
-            anchors.emplace_back(AnchorPoint { center_x + radius * std::cos(angle), center_y + radius * std::sin(angle) });
-        }
-        return anchors;
-    }
-
-    std::vector<AnchorPoint> anchor_points() const
-    {
-        std::vector<AnchorPoint> anchors;
-        switch (geometry_mode()) {
-        case GeometryMode::Point:
-            anchors.emplace_back(AnchorPoint { 0.5, 0.5 });
-            break;
-        case GeometryMode::Line:
-            anchors.emplace_back(AnchorPoint { 0.06, 0.5 });
-            anchors.emplace_back(AnchorPoint { 0.94, 0.5 });
-            break;
-        case GeometryMode::Triangle: {
-            const auto vertices = simplex_vertices();
-            for (const Vec2 &vertex : vertices)
-                anchors.emplace_back(AnchorPoint { vertex.x, vertex.y });
-            break;
-        }
-        case GeometryMode::TriangleWithCenter: {
-            const auto vertices = simplex_vertices();
-            for (const Vec2 &vertex : vertices)
-                anchors.emplace_back(AnchorPoint { vertex.x, vertex.y });
-            const Vec2 center = simplex_center();
-            anchors.emplace_back(AnchorPoint { center.x, center.y });
-            break;
-        }
-        case GeometryMode::Radial:
-            anchors = radial_anchor_points();
-            break;
-        }
-        return anchors;
-    }
-
-    static std::array<double, 3> triangle_barycentric(const Vec2 &point, const std::array<Vec2, 3> &triangle)
-    {
-        const Vec2 &a = triangle[0];
-        const Vec2 &b = triangle[1];
-        const Vec2 &c = triangle[2];
-        const double denom = ((b.y - c.y) * (a.x - c.x) + (c.x - b.x) * (a.y - c.y));
-        if (std::abs(denom) <= 1e-9)
-            return { 1.0, 0.0, 0.0 };
-        const double w0 = ((b.y - c.y) * (point.x - c.x) + (c.x - b.x) * (point.y - c.y)) / denom;
-        const double w1 = ((c.y - a.y) * (point.x - c.x) + (a.x - c.x) * (point.y - c.y)) / denom;
-        const double w2 = 1.0 - w0 - w1;
-        return { w0, w1, w2 };
-    }
-
-    static bool point_in_triangle(const Vec2 &point, const std::array<Vec2, 3> &triangle)
-    {
-        const auto barycentric = triangle_barycentric(point, triangle);
-        constexpr double eps = 1e-6;
-        return barycentric[0] >= -eps && barycentric[1] >= -eps && barycentric[2] >= -eps;
-    }
-
-    static Vec2 closest_point_on_segment(const Vec2 &point, const Vec2 &start, const Vec2 &end)
-    {
-        const Vec2 edge = sub_vec(end, start);
-        const double edge_len_sq = length_sq(edge);
-        if (edge_len_sq <= 1e-9)
-            return start;
-        const double t = std::clamp(dot_vec(sub_vec(point, start), edge) / edge_len_sq, 0.0, 1.0);
-        return add_vec(start, scale_vec(edge, t));
-    }
-
-    static Vec2 closest_point_on_triangle(const Vec2 &point, const std::array<Vec2, 3> &triangle)
-    {
-        if (point_in_triangle(point, triangle))
-            return point;
-
-        Vec2 best = triangle[0];
-        double best_dist = std::numeric_limits<double>::max();
-        for (int edge_idx = 0; edge_idx < 3; ++edge_idx) {
-            const Vec2 candidate = closest_point_on_segment(point, triangle[edge_idx], triangle[(edge_idx + 1) % 3]);
-            const double candidate_dist = dist_sq(point, candidate);
-            if (candidate_dist < best_dist) {
-                best_dist = candidate_dist;
-                best = candidate;
-            }
-        }
-        return best;
-    }
-
-    Vec2 normalized_point_from_mouse(const wxMouseEvent &evt) const
-    {
-        const wxRect rect = canvas_rect();
-        const int width = std::max(1, rect.GetWidth() - 1);
-        const int height = std::max(1, rect.GetHeight() - 1);
-        return make_vec(
-            std::clamp(double(evt.GetX() - rect.GetLeft()) / double(width), 0.0, 1.0),
-            std::clamp(double(evt.GetY() - rect.GetTop()) / double(height), 0.0, 1.0));
-    }
-
-    Vec2 clamp_point_to_geometry(const Vec2 &point) const
-    {
-        switch (geometry_mode()) {
-        case GeometryMode::Point:
-            return make_vec(0.5, 0.5);
-        case GeometryMode::Line:
-            return make_vec(std::clamp(point.x, 0.0, 1.0), 0.5);
-        case GeometryMode::Triangle:
-        case GeometryMode::TriangleWithCenter:
-            return closest_point_on_triangle(point, simplex_vertices());
-        case GeometryMode::Radial:
-            return make_vec(std::clamp(point.x, 0.0, 1.0), std::clamp(point.y, 0.0, 1.0));
-        }
-        return point;
-    }
-
-    std::vector<double> simplex_weights_from_pos(const Vec2 &point) const
-    {
-        const auto triangle = simplex_vertices();
-        const Vec2 clamped = closest_point_on_triangle(point, triangle);
-        const auto barycentric = triangle_barycentric(clamped, triangle);
-
-        if (geometry_mode() == GeometryMode::Triangle)
-            return { std::max(0.0, barycentric[0]), std::max(0.0, barycentric[1]), std::max(0.0, barycentric[2]) };
-
-        const double shared = std::max(0.0, std::min({ barycentric[0], barycentric[1], barycentric[2] }));
-        return {
-            std::max(0.0, barycentric[0] - shared),
-            std::max(0.0, barycentric[1] - shared),
-            std::max(0.0, barycentric[2] - shared),
-            std::max(0.0, shared * 3.0)
-        };
-    }
-
-    Vec2 triangle_point_from_weights() const
-    {
-        const auto vertices = simplex_vertices();
-        double total = 0.0;
-        for (size_t idx = 0; idx < 3 && idx < m_weights.size(); ++idx)
-            total += std::max(0, m_weights[idx]);
-        if (total <= 0.0)
-            return simplex_center();
-
-        Vec2 out = make_vec(0.0, 0.0);
-        for (size_t idx = 0; idx < 3 && idx < m_weights.size(); ++idx) {
-            const double weight = double(std::max(0, m_weights[idx])) / total;
-            out = add_vec(out, scale_vec(vertices[idx], weight));
-        }
-        return out;
-    }
-
-    void initialize_cursor_from_grid_search()
-    {
-        double best_x = 0.5;
-        double best_y = 0.5;
-        double best_error = std::numeric_limits<double>::max();
-        constexpr int grid = 96;
-        for (int y_idx = 0; y_idx <= grid; ++y_idx) {
-            for (int x_idx = 0; x_idx <= grid; ++x_idx) {
-                const Vec2 point = clamp_point_to_geometry(make_vec(double(x_idx) / double(grid), double(y_idx) / double(grid)));
-                const std::vector<int> probe = normalized_weights_from_pos(point.x, point.y);
-                if (probe.size() != m_weights.size())
-                    continue;
-                double error = 0.0;
-                for (size_t idx = 0; idx < probe.size(); ++idx) {
-                    const double delta = double(probe[idx] - m_weights[idx]);
-                    error += delta * delta;
-                }
-                if (error < best_error) {
-                    best_error = error;
-                    best_x = point.x;
-                    best_y = point.y;
-                }
-            }
-        }
-        m_cursor_x = best_x;
-        m_cursor_y = best_y;
-        m_weights = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
-    }
-
-    std::vector<double> raw_weights_from_pos(double normalized_x, double normalized_y) const
-    {
-        switch (geometry_mode()) {
-        case GeometryMode::Point:
-            return { 1.0 };
-        case GeometryMode::Line: {
-            const double t = std::clamp(normalized_x, 0.0, 1.0);
-            return { 1.0 - t, t };
-        }
-        case GeometryMode::Triangle:
-        case GeometryMode::TriangleWithCenter:
-            return simplex_weights_from_pos(make_vec(normalized_x, normalized_y));
-        case GeometryMode::Radial:
-            break;
-        }
-
-        const std::vector<AnchorPoint> anchors = radial_anchor_points();
-        std::vector<double> out(anchors.size(), 0.0);
-        if (anchors.empty())
-            return out;
-
-        constexpr double eps = 1e-8;
-        size_t exact_idx = size_t(-1);
-        for (size_t idx = 0; idx < anchors.size(); ++idx) {
-            const double dx = normalized_x - anchors[idx].x;
-            const double dy = normalized_y - anchors[idx].y;
-            const double d2 = dx * dx + dy * dy;
-            if (d2 <= eps) {
-                exact_idx = idx;
-                break;
-            }
-            out[idx] = 1.0 / std::max(1e-6, d2);
-        }
-        if (exact_idx != size_t(-1)) {
-            std::fill(out.begin(), out.end(), 0.0);
-            out[exact_idx] = 1.0;
-            return out;
-        }
-
-        double sum = 0.0;
-        for (const double value : out)
-            sum += value;
-        if (sum <= 0.0) {
-            out.assign(out.size(), 0.0);
-            out[0] = 1.0;
-            return out;
-        }
-        for (double &value : out)
-            value /= sum;
-        return out;
-    }
-
-    std::vector<int> normalized_weights_from_pos(double normalized_x, double normalized_y) const
-    {
-        std::vector<int> raw_weights;
-        const std::vector<double> raw = raw_weights_from_pos(normalized_x, normalized_y);
-        raw_weights.reserve(raw.size());
-        for (const double value : raw)
-            raw_weights.emplace_back(std::max(0, int(std::lround(value * 100.0))));
-        return normalize_color_match_weights(raw_weights, raw.size());
-    }
-
-    void initialize_cursor_from_weights()
-    {
-        if (m_weights.empty()) {
-            m_cursor_x = 0.5;
-            m_cursor_y = 0.5;
-            return;
-        }
-
-        switch (geometry_mode()) {
-        case GeometryMode::Point:
-            m_cursor_x = 0.5;
-            m_cursor_y = 0.5;
-            break;
-        case GeometryMode::Line: {
-            const int total = std::accumulate(m_weights.begin(), m_weights.end(), 0);
-            const double t = total > 0 && m_weights.size() >= 2 ? double(std::max(0, m_weights[1])) / double(total) : 0.5;
-            m_cursor_x = std::clamp(t, 0.0, 1.0);
-            m_cursor_y = 0.5;
-            m_weights = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
-            break;
-        }
-        case GeometryMode::Triangle: {
-            const Vec2 point = triangle_point_from_weights();
-            m_cursor_x = point.x;
-            m_cursor_y = point.y;
-            m_weights = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
-            break;
-        }
-        case GeometryMode::TriangleWithCenter:
-        case GeometryMode::Radial:
-            initialize_cursor_from_grid_search();
-            break;
-        }
-    }
-
-    void emit_changed()
-    {
-        wxCommandEvent evt(wxEVT_SLIDER, GetId());
-        evt.SetEventObject(this);
-        ProcessWindowEvent(evt);
-    }
-
-    void update_from_mouse(const wxMouseEvent &evt, bool notify)
-    {
-        const Vec2 point = clamp_point_to_geometry(normalized_point_from_mouse(evt));
-        m_cursor_x = point.x;
-        m_cursor_y = point.y;
-        m_weights = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
-        Refresh();
-        if (notify)
-            emit_changed();
-    }
-
-    wxColour canvas_background_color() const
-    {
-        return GetBackgroundColour().IsOk() ? GetBackgroundColour() : wxColour(245, 245, 245);
-    }
-
-    bool cached_bitmap_matches(const wxSize &size, const wxColour &background) const
-    {
-        return m_cached_bitmap.IsOk() && m_cached_bitmap_size == size && m_cached_background == background;
-    }
-
-    void schedule_cached_bitmap_render()
-    {
-        if (!m_render_timer.IsRunning())
-            m_render_timer.StartOnce(80);
-    }
-
-    void invalidate_cached_bitmap()
-    {
-        m_cached_bitmap = wxBitmap();
-        m_cached_bitmap_size = wxSize();
-        m_cached_background = wxColour();
-    }
-
-    void render_cached_bitmap(const wxSize &size, const wxColour &background)
-    {
-        const int width = size.GetWidth();
-        const int height = size.GetHeight();
-        if (width <= 0 || height <= 0)
-            return;
-
-        wxImage image(width, height);
-        unsigned char *data = image.GetData();
-        if (data != nullptr) {
-            for (int y = 0; y < height; ++y) {
-                const double normalized_y = (height > 1) ? double(y) / double(height - 1) : 0.5;
-                for (int x = 0; x < width; ++x) {
-                    const double normalized_x = (width > 1) ? double(x) / double(width - 1) : 0.5;
-                    const int data_idx = (y * width + x) * 3;
-                    bool paint_pixel = true;
-                    if (geometry_mode() == GeometryMode::Triangle || geometry_mode() == GeometryMode::TriangleWithCenter)
-                        paint_pixel = point_in_triangle(make_vec(normalized_x, normalized_y), simplex_vertices());
-
-                    const std::vector<double> raw_weights = raw_weights_from_pos(normalized_x, normalized_y);
-                    wxColour color = paint_pixel ? blend_multi_filament_mixer(m_colors, raw_weights) : background;
-                    if (paint_pixel && m_min_component_percent > 0 &&
-                        !color_match_raw_weights_within_range(raw_weights, m_min_component_percent)) {
-                        const bool stripe = (((x + y) / 8) % 2) == 0;
-                        const double factor = stripe ? 0.12 : 0.38;
-                        color = wxColour(
-                            static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Red()) * factor)), 0, 255)),
-                            static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Green()) * factor)), 0, 255)),
-                            static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Blue()) * factor)), 0, 255)));
-                    }
-                    data[data_idx + 0] = color.Red();
-                    data[data_idx + 1] = color.Green();
-                    data[data_idx + 2] = color.Blue();
-                }
-            }
-        }
-
-        m_cached_bitmap = wxBitmap(image);
-        m_cached_bitmap_size = size;
-        m_cached_background = background;
-    }
-
-    void draw_cached_bitmap(wxAutoBufferedPaintDC &dc, const wxRect &rect)
-    {
-        if (!m_cached_bitmap.IsOk())
-            return;
-
-        if (m_cached_bitmap_size == rect.GetSize()) {
-            dc.DrawBitmap(m_cached_bitmap, rect.GetLeft(), rect.GetTop(), false);
-            return;
-        }
-
-        wxMemoryDC memdc;
-        memdc.SelectObject(m_cached_bitmap);
-        dc.StretchBlit(rect.GetLeft(), rect.GetTop(), rect.GetWidth(), rect.GetHeight(),
-                       &memdc, 0, 0, m_cached_bitmap_size.GetWidth(), m_cached_bitmap_size.GetHeight());
-        memdc.SelectObject(wxNullBitmap);
-    }
-
-    void on_paint(wxPaintEvent &)
-    {
-        wxAutoBufferedPaintDC dc(this);
-        dc.SetBackground(wxBrush(GetBackgroundColour()));
-        dc.Clear();
-
-        const wxRect rect = canvas_rect();
-        const int width = rect.GetWidth();
-        const int height = rect.GetHeight();
-        if (width <= 0 || height <= 0)
-            return;
-
-        const wxColour background = canvas_background_color();
-        if (!cached_bitmap_matches(rect.GetSize(), background)) {
-            if (!m_cached_bitmap.IsOk())
-                render_cached_bitmap(rect.GetSize(), background);
-            else
-                schedule_cached_bitmap_render();
-        }
-        draw_cached_bitmap(dc, rect);
-
-        if (geometry_mode() == GeometryMode::Triangle || geometry_mode() == GeometryMode::TriangleWithCenter) {
-            const auto triangle = simplex_vertices();
-            wxPoint points[3] = {
-                wxPoint(rect.GetLeft() + int(std::lround(triangle[0].x * double(std::max(1, width - 1)))),
-                        rect.GetTop()  + int(std::lround(triangle[0].y * double(std::max(1, height - 1))))),
-                wxPoint(rect.GetLeft() + int(std::lround(triangle[1].x * double(std::max(1, width - 1)))),
-                        rect.GetTop()  + int(std::lround(triangle[1].y * double(std::max(1, height - 1))))),
-                wxPoint(rect.GetLeft() + int(std::lround(triangle[2].x * double(std::max(1, width - 1)))),
-                        rect.GetTop()  + int(std::lround(triangle[2].y * double(std::max(1, height - 1)))))
-            };
-            dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
-            dc.SetBrush(*wxTRANSPARENT_BRUSH);
-            dc.DrawPolygon(3, points);
-            if (geometry_mode() == GeometryMode::TriangleWithCenter) {
-                const Vec2 center = simplex_center();
-                const wxPoint center_pt(rect.GetLeft() + int(std::lround(center.x * double(std::max(1, width - 1)))),
-                                        rect.GetTop()  + int(std::lround(center.y * double(std::max(1, height - 1)))));
-                dc.SetPen(wxPen(wxColour(180, 180, 180), 1, wxPENSTYLE_DOT));
-                for (const wxPoint &vertex : points)
-                    dc.DrawLine(center_pt, vertex);
-            }
-        } else {
-            dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
-            dc.SetBrush(*wxTRANSPARENT_BRUSH);
-            dc.DrawRectangle(rect);
-        }
-
-        dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-
-        const auto anchors = anchor_points();
-        for (size_t idx = 0; idx < anchors.size() && idx < m_colors.size(); ++idx) {
-            const int anchor_x = rect.GetLeft() + int(std::lround(anchors[idx].x * double(std::max(1, width - 1))));
-            const int anchor_y = rect.GetTop() + int(std::lround(anchors[idx].y * double(std::max(1, height - 1))));
-            dc.SetPen(wxPen(wxColour(30, 30, 30), 1));
-            dc.SetBrush(wxBrush(m_colors[idx]));
-            dc.DrawCircle(wxPoint(anchor_x, anchor_y), FromDIP(4));
-        }
-
-        const int cursor_x = rect.GetLeft() + int(std::lround(m_cursor_x * double(std::max(1, width - 1))));
-        const int cursor_y = rect.GetTop() + int(std::lround(m_cursor_y * double(std::max(1, height - 1))));
-        dc.SetPen(wxPen(wxColour(255, 255, 255), 3));
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.DrawCircle(wxPoint(cursor_x, cursor_y), FromDIP(7));
-        dc.SetPen(wxPen(wxColour(30, 30, 30), 1));
-        dc.DrawCircle(wxPoint(cursor_x, cursor_y), FromDIP(7));
-    }
-
-    void on_left_down(wxMouseEvent &evt)
-    {
-        if (!HasCapture())
-            CaptureMouse();
-        m_dragging = true;
-        update_from_mouse(evt, true);
-    }
-
-    void on_left_up(wxMouseEvent &evt)
-    {
-        if (m_dragging)
-            update_from_mouse(evt, true);
-        m_dragging = false;
-        if (HasCapture())
-            ReleaseMouse();
-    }
-
-    void on_mouse_move(wxMouseEvent &evt)
-    {
-        if (m_dragging && evt.LeftIsDown())
-            update_from_mouse(evt, true);
-    }
-
-    void on_capture_lost(wxMouseCaptureLostEvent &)
-    {
-        m_dragging = false;
-    }
-
-    void on_size(wxSizeEvent &evt)
-    {
-        if (m_cached_bitmap.IsOk())
-            schedule_cached_bitmap_render();
-        Refresh(false);
-        evt.Skip();
-    }
-
-    void on_render_timer(wxTimerEvent &)
-    {
-        const wxRect rect = canvas_rect();
-        render_cached_bitmap(rect.GetSize(), canvas_background_color());
-        Refresh(false);
-    }
-
-private:
-    std::vector<wxColour>     m_colors;
-    std::vector<int>          m_weights;
-    wxBitmap                  m_cached_bitmap;
-    wxSize                    m_cached_bitmap_size;
-    wxColour                  m_cached_background;
-    wxTimer                   m_render_timer;
-    int                       m_min_component_percent { 0 };
-    double                    m_cursor_x { 0.5 };
-    double                    m_cursor_y { 0.5 };
-    bool                      m_dragging { false };
-};
 
 class MixedFilamentColorMatchDialog : public DPIDialog
 {
@@ -4287,221 +3511,6 @@ private:
     bool                                    m_syncing_inputs { false };
 };
 
-class MixedGradientSelector : public wxPanel
-{
-public:
-    MixedGradientSelector(wxWindow *parent, const wxColour &left, const wxColour &right, int value_percent)
-        : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE)
-        , m_left(left)
-        , m_right(right)
-        , m_value(std::clamp(value_percent, 0, 100))
-    {
-        SetBackgroundStyle(wxBG_STYLE_PAINT);
-        SetMinSize(wxSize(FromDIP(96), FromDIP(12)));
-        Bind(wxEVT_PAINT, &MixedGradientSelector::on_paint, this);
-        Bind(wxEVT_LEFT_DOWN, &MixedGradientSelector::on_left_down, this);
-        Bind(wxEVT_LEFT_UP, &MixedGradientSelector::on_left_up, this);
-        Bind(wxEVT_MOTION, &MixedGradientSelector::on_mouse_move, this);
-        Bind(wxEVT_MOUSE_CAPTURE_LOST, &MixedGradientSelector::on_capture_lost, this);
-    }
-
-    ~MixedGradientSelector() override
-    {
-        if (HasCapture())
-            ReleaseMouse();
-    }
-
-    int value() const { return m_value; }
-    bool is_multi_mode() const { return m_multi_mode; }
-
-    void set_colors(const wxColour &left, const wxColour &right)
-    {
-        m_left = left;
-        m_right = right;
-        m_multi_mode = false;
-        m_multi_colors.clear();
-        m_multi_weights.clear();
-        Refresh();
-    }
-
-    void set_multi_preview(const std::vector<wxColour> &corner_colors, const std::vector<int> &weights)
-    {
-        m_multi_mode = corner_colors.size() >= 3;
-        m_multi_colors = corner_colors;
-        m_multi_weights = weights;
-        Refresh();
-    }
-
-private:
-    wxRect gradient_rect() const
-    {
-        const int margin_x = FromDIP(2);
-        const int margin_y = FromDIP(1);
-        const wxSize sz = GetClientSize();
-        return wxRect(margin_x, margin_y, std::max(1, sz.GetWidth() - margin_x * 2), std::max(1, sz.GetHeight() - margin_y * 2));
-    }
-
-    int value_from_x(int x) const
-    {
-        const wxRect rect = gradient_rect();
-        const int min_x = rect.GetLeft();
-        const int max_x = rect.GetLeft() + rect.GetWidth();
-        const int clamped_x = std::clamp(x, min_x, max_x);
-        return ((clamped_x - min_x) * 100 + rect.GetWidth() / 2) / rect.GetWidth();
-    }
-
-    void update_from_x(int x, bool notify)
-    {
-        const int new_value = value_from_x(x);
-        m_value = new_value;
-        Refresh();
-
-        if (notify) {
-            wxCommandEvent evt(wxEVT_SLIDER, GetId());
-            evt.SetInt(m_value);
-            evt.SetEventObject(this);
-            ProcessWindowEvent(evt);
-        }
-    }
-
-    void on_paint(wxPaintEvent &)
-    {
-        wxAutoBufferedPaintDC dc(this);
-        dc.SetBackground(wxBrush(GetBackgroundColour()));
-        dc.Clear();
-        const bool is_dark = wxGetApp().dark_mode();
-
-        const wxRect rect = gradient_rect();
-        if (m_multi_mode && m_multi_colors.size() >= 3) {
-            const wxPoint tl(rect.GetLeft(), rect.GetTop());
-            const wxPoint tr(rect.GetRight(), rect.GetTop());
-            const wxPoint br(rect.GetRight(), rect.GetBottom());
-            const wxPoint bl(rect.GetLeft(), rect.GetBottom());
-            const wxPoint cc(rect.GetLeft() + rect.GetWidth() / 2, rect.GetTop() + rect.GetHeight() / 2);
-            auto draw_tri = [&dc](const wxColour &color, const wxPoint &a, const wxPoint &b, const wxPoint &c) {
-                wxPoint pts[3] = { a, b, c };
-                dc.SetPen(*wxTRANSPARENT_PEN);
-                dc.SetBrush(wxBrush(color));
-                dc.DrawPolygon(3, pts);
-            };
-
-            if (m_multi_colors.size() >= 4) {
-                draw_tri(m_multi_colors[0], tl, tr, cc);
-                draw_tri(m_multi_colors[1], tr, br, cc);
-                draw_tri(m_multi_colors[2], br, bl, cc);
-                draw_tri(m_multi_colors[3], bl, tl, cc);
-            } else {
-                // 3-color layout: first color occupies one full side, two others on the opposite corners.
-                draw_tri(m_multi_colors[0], tl, bl, cc);
-                draw_tri(m_multi_colors[1], tl, tr, cc);
-                draw_tri(m_multi_colors[2], bl, br, cc);
-            }
-
-            if (m_multi_weights.size() == m_multi_colors.size()) {
-                dc.SetTextForeground(is_dark ? wxColour(236, 236, 236) : wxColour(20, 20, 20));
-                dc.SetFont(Label::Body_10);
-                const int pad = FromDIP(2);
-                if (m_multi_colors.size() >= 4) {
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[0]), rect.GetLeft() + pad, rect.GetTop() + pad);
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[1]), rect.GetRight() - FromDIP(28), rect.GetTop() + pad);
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[2]), rect.GetRight() - FromDIP(28), rect.GetBottom() - FromDIP(14));
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[3]), rect.GetLeft() + pad, rect.GetBottom() - FromDIP(14));
-                } else {
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[0]), rect.GetLeft() + pad, rect.GetTop() + rect.GetHeight() / 2 - FromDIP(6));
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[1]), rect.GetRight() - FromDIP(28), rect.GetTop() + pad);
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[2]), rect.GetRight() - FromDIP(28), rect.GetBottom() - FromDIP(14));
-                }
-            }
-        } else {
-            const int w = rect.GetWidth();
-            const int h = rect.GetHeight();
-            wxImage img(w, h);
-            unsigned char *data = img.GetData();
-            if (data != nullptr) {
-                for (int x = 0; x < w; ++x) {
-                    const float t = (w > 1) ? float(x) / float(w - 1) : 0.5f;
-                    const wxColour col = blend_pair_filament_mixer(m_left, m_right, t);
-                    const unsigned char r = static_cast<unsigned char>(col.Red());
-                    const unsigned char g = static_cast<unsigned char>(col.Green());
-                    const unsigned char b = static_cast<unsigned char>(col.Blue());
-                    for (int y = 0; y < h; ++y) {
-                        const int idx = (y * w + x) * 3;
-                        data[idx + 0] = r;
-                        data[idx + 1] = g;
-                        data[idx + 2] = b;
-                    }
-                }
-                dc.DrawBitmap(wxBitmap(img), rect.GetLeft(), rect.GetTop(), false);
-            } else {
-                dc.GradientFillLinear(rect, m_left, m_right, wxEAST);
-            }
-        }
-        dc.SetPen(wxPen(is_dark ? wxColour(100, 100, 106) : wxColour(170, 170, 170), 1));
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.DrawRectangle(rect);
-
-        if (m_multi_mode) {
-            dc.SetTextForeground(is_dark ? wxColour(236, 236, 236) : wxColour(30, 30, 30));
-            dc.SetFont(Label::Body_10);
-            const wxString hint = _L("Click to edit");
-            wxSize text_sz = dc.GetTextExtent(hint);
-            dc.DrawText(hint, rect.GetRight() - text_sz.GetWidth() - FromDIP(4), rect.GetTop() + FromDIP(2));
-            return;
-        }
-
-        int marker_x = rect.GetLeft() + (rect.GetWidth() * m_value + 50) / 100;
-        marker_x = std::clamp(marker_x, rect.GetLeft(), rect.GetRight());
-        dc.SetPen(wxPen(wxColour(255, 255, 255), 3));
-        dc.DrawLine(marker_x, rect.GetTop(), marker_x, rect.GetBottom());
-        dc.SetPen(wxPen(wxColour(33, 33, 33), 1));
-        dc.DrawLine(marker_x, rect.GetTop(), marker_x, rect.GetBottom());
-    }
-
-    void on_left_down(wxMouseEvent &evt)
-    {
-        if (m_multi_mode)
-            return;
-        if (!HasCapture())
-            CaptureMouse();
-        m_dragging = true;
-        update_from_x(evt.GetX(), false);
-    }
-
-    void on_left_up(wxMouseEvent &evt)
-    {
-        if (m_multi_mode) {
-            wxCommandEvent click_evt(wxEVT_BUTTON, GetId());
-            click_evt.SetEventObject(this);
-            ProcessWindowEvent(click_evt);
-            return;
-        }
-        if (m_dragging)
-            update_from_x(evt.GetX(), true);
-        m_dragging = false;
-        if (HasCapture())
-            ReleaseMouse();
-    }
-
-    void on_mouse_move(wxMouseEvent &evt)
-    {
-        if (m_dragging && evt.LeftIsDown())
-            update_from_x(evt.GetX(), false);
-    }
-
-    void on_capture_lost(wxMouseCaptureLostEvent &)
-    {
-        m_dragging = false;
-    }
-
-private:
-    wxColour m_left;
-    wxColour m_right;
-    bool     m_multi_mode { false };
-    std::vector<wxColour> m_multi_colors;
-    std::vector<int>      m_multi_weights;
-    int      m_value {50};
-    bool     m_dragging {false};
-};
 
 class MixedGradientWeightsDialog : public wxDialog
 {
@@ -6932,8 +5941,6 @@ static std::vector<size_t> build_mixed_filament_ui_indices(const std::vector<Mix
     return ordered_indices;
 }
 
-} // namespace
-
 MixedColorMatchRecipeResult prompt_best_color_match_recipe(wxWindow *parent,
                                                            const std::vector<std::string> &physical_colors,
                                                            const wxColour &initial_color)
@@ -6947,6 +5954,291 @@ MixedColorMatchRecipeResult prompt_best_color_match_recipe(wxWindow *parent,
     }
 
     return dlg.selected_recipe();
+}
+
+void Sidebar::init_color_mix_panel(wxWindow* parent, wxSizer* sizer)
+{
+    StateColor title_bg(std::pair<wxColour, int>(wxColour(0xF1F1F1), StateColor::Normal));
+
+    // Title bar — same parent as filament content
+    p->m_panel_color_mix_title = new StaticBox(parent, wxID_ANY, wxDefaultPosition,
+                                               wxDefaultSize, wxTAB_TRAVERSAL | wxBORDER_NONE);
+    p->m_panel_color_mix_title->SetBackgroundColor(title_bg);
+    p->m_panel_color_mix_title->SetBackgroundColor2(0xF1F1F1);
+
+    auto* icon = new ScalableButton(p->m_panel_color_mix_title, wxID_ANY, "filament");
+    auto* label = new Label(p->m_panel_color_mix_title, _L("Color Mix"), LB_PROPAGATE_MOUSE_EVENT);
+
+    p->m_btn_del_color_mix = new ScalableButton(p->m_panel_color_mix_title, wxID_ANY, "delete_filament");
+    p->m_btn_add_color_mix = new ScalableButton(p->m_panel_color_mix_title, wxID_ANY, "add_filament");
+
+    auto* h_title = new wxBoxSizer(wxHORIZONTAL);
+    h_title->Add(icon,  0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(8));
+    h_title->Add(label, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(4));
+    h_title->AddStretchSpacer();
+    h_title->Add(p->m_btn_del_color_mix, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+    h_title->Add(p->m_btn_add_color_mix, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+    p->m_panel_color_mix_title->SetSizer(h_title);
+    p->m_panel_color_mix_title->Layout();
+
+    // Content panel — same parent
+    p->m_panel_color_mix_content = new wxPanel(parent);
+    p->m_sizer_color_mix_content = new wxBoxSizer(wxVERTICAL);
+    p->m_panel_color_mix_content->SetSizer(p->m_sizer_color_mix_content);
+
+    sizer->Add(p->m_panel_color_mix_title,   0, wxEXPAND, 0);
+    sizer->Add(p->m_panel_color_mix_content, 0, wxEXPAND, 0);
+
+    // Add button: open dialog to create new mix
+    p->m_btn_add_color_mix->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+        auto* co = wxGetApp().preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour");
+        const std::vector<std::string> colors = co ? co->values : std::vector<std::string>{};
+        if (colors.size() < 2) return;
+
+        AddColorMixDialog dlg(wxGetApp().mainframe, colors);
+        if (dlg.ShowModal() != wxID_OK) return;
+
+        auto& mgr = wxGetApp().preset_bundle->mixed_filaments;
+        const MixedFilament& r = dlg.GetResult();
+        mgr.add_custom_filament(r.component_a, r.component_b, r.mix_b_percent, colors);
+        auto& mfs = mgr.mixed_filaments();
+        if (!mfs.empty()) {
+            mfs.back().distribution_mode       = r.distribution_mode;
+            mfs.back().manual_pattern          = r.manual_pattern;
+            mfs.back().gradient_component_ids      = r.gradient_component_ids;
+            mfs.back().gradient_component_weights  = r.gradient_component_weights;
+            mfs.back().ratio_a                     = r.ratio_a;
+            mfs.back().ratio_b                     = r.ratio_b;
+            mfs.back().custom                  = true;
+        }
+        if (auto* opt = wxGetApp().preset_bundle->project_config.option<ConfigOptionString>("mixed_filament_definitions"))
+            opt->value = mgr.serialize_custom_entries();
+        update_color_mix_panel();
+        m_scrolled_sizer->Layout();
+    });
+
+    // Delete button: remove last custom entry
+    p->m_btn_del_color_mix->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+        auto& mgr = wxGetApp().preset_bundle->mixed_filaments;
+        auto& mfs = mgr.mixed_filaments();
+        for (int i = static_cast<int>(mfs.size()) - 1; i >= 0; --i) {
+            if (mfs[i].custom && !mfs[i].deleted) {
+                mfs[i].deleted = true;
+                break;
+            }
+        }
+        if (auto* opt = wxGetApp().preset_bundle->project_config.option<ConfigOptionString>("mixed_filament_definitions"))
+            opt->value = mgr.serialize_custom_entries();
+        update_color_mix_panel();
+        m_scrolled_sizer->Layout();
+    });
+
+    // Initial visibility: hide if fewer than 2 physical filaments
+    update_color_mix_panel();
+}
+
+void Sidebar::update_color_mix_panel()
+{
+    if (!p->m_panel_color_mix_content) return;
+
+    auto* co = wxGetApp().preset_bundle
+                   ? wxGetApp().preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour")
+                   : nullptr;
+    const int n_physical = co ? static_cast<int>(co->values.size()) : 0;
+    const bool show = (n_physical >= 2);
+    p->m_panel_color_mix_title->Show(show);
+    p->m_panel_color_mix_content->Show(show);
+    if (!show) return;
+
+    wxWindowUpdateLocker no_updates(p->m_panel_color_mix_content);
+    p->m_sizer_color_mix_content->Clear(true);
+
+    auto* preset_bundle = wxGetApp().preset_bundle;
+    const size_t num_physical = p->combos_filament.size();
+
+    std::vector<std::string> physical_colors = co->values;
+    physical_colors.resize(num_physical, "#26A69A");
+
+    std::vector<double> nozzle_diameters(num_physical, 0.4);
+    if (const ConfigOptionFloats* opt = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionFloats>("nozzle_diameter")) {
+        const size_t opt_count = opt->values.size();
+        if (opt_count > 0)
+            for (size_t i = 0; i < num_physical; ++i)
+                nozzle_diameters[i] = std::max(0.05, opt->get_at(unsigned(std::min(i, opt_count - 1))));
+    }
+
+    float lower_bound = 0.04f, upper_bound = 0.16f;
+    if (preset_bundle->project_config.has("mixed_filament_height_lower_bound"))
+        lower_bound = std::max(0.01f, float(preset_bundle->project_config.opt_float("mixed_filament_height_lower_bound")));
+    if (preset_bundle->project_config.has("mixed_filament_height_upper_bound"))
+        upper_bound = std::max(lower_bound, float(preset_bundle->project_config.opt_float("mixed_filament_height_upper_bound")));
+
+    bool local_z_mode = false;
+    if (const ConfigOptionBool* opt = preset_bundle->project_config.option<ConfigOptionBool>("dithering_local_z_mode"))
+        local_z_mode = opt->value;
+
+    bool component_bias_enabled = false;
+    if (const ConfigOptionBool* opt = preset_bundle->project_config.option<ConfigOptionBool>("mixed_filament_component_bias_enabled"))
+        component_bias_enabled = opt->value;
+
+    const MixedFilamentPreviewSettings preview_settings {
+        0.2f, lower_bound, upper_bound, 0.f, 0.f, local_z_mode, false, 1
+    };
+    const MixedFilamentDisplayContext display_context {
+        num_physical, physical_colors, nozzle_diameters, preview_settings, component_bias_enabled
+    };
+    preset_bundle->mixed_filaments.set_display_context(display_context);
+
+    auto& mfs = preset_bundle->mixed_filaments.mixed_filaments();
+    bool any_visible = false;
+    for (const MixedFilament& mf : mfs)
+        if (!mf.deleted) { any_visible = true; break; }
+
+    if (!any_visible) {
+        auto* hint = new wxStaticText(p->m_panel_color_mix_content, wxID_ANY,
+                                      _L("No color mixes. Click + to add one."));
+        hint->SetForegroundColour(wxColour(120, 120, 120));
+        p->m_sizer_color_mix_content->Add(hint, 0, wxALL, FromDIP(8));
+        p->m_panel_color_mix_content->Layout();
+        return;
+    }
+
+    // 2-column grid matching the physical filament panel layout
+    auto* grid_sizer = new wxBoxSizer(wxHORIZONTAL);
+    auto* col0 = new wxBoxSizer(wxVERTICAL);
+    auto* col1 = new wxBoxSizer(wxVERTICAL);
+    grid_sizer->Add(col0, 1, wxEXPAND);
+    grid_sizer->Add(col1, 1, wxEXPAND);
+
+    int visible_idx = 0;
+    for (size_t i = 0; i < mfs.size(); ++i) {
+        MixedFilament& mf = mfs[i];
+        if (mf.deleted) continue;
+
+        const std::string synced_color = compute_mixed_filament_display_color(mf, display_context);
+        if (mf.display_color != synced_color)
+            mf.display_color = synced_color;
+
+        const int virtual_id = static_cast<int>(num_physical) + visible_idx + 1;
+        const wxColour badge_color = parse_mixed_color(mf.display_color);
+
+        // Badge button: colored background + virtual filament number
+        auto* badge = new wxButton(p->m_panel_color_mix_content, wxID_ANY,
+                                   wxString::Format("%d", virtual_id),
+                                   wxDefaultPosition,
+                                   wxSize(FromDIP(20), FromDIP(20)),
+                                   wxBU_EXACTFIT | wxBORDER_NONE);
+        badge->SetBackgroundColour(badge_color);
+        {
+            // Pick white or black text for contrast
+            const int luma = badge_color.Red() * 299 + badge_color.Green() * 587 + badge_color.Blue() * 114;
+            badge->SetForegroundColour(luma > 128000 ? *wxBLACK : *wxWHITE);
+        }
+
+        const std::string normalized_pattern_cm = MixedFilamentManager::normalize_manual_pattern(mf.manual_pattern);
+        wxString lbl;
+        if (!normalized_pattern_cm.empty())
+            lbl = _L("Pattern");
+        else if (mf.gradient_component_ids.size() >= 3) {
+            // parse weights
+            const size_t n = mf.gradient_component_ids.size();
+            std::vector<int> weights;
+            {
+                std::string token;
+                for (const char c : mf.gradient_component_weights) {
+                    if (c >= '0' && c <= '9') { token.push_back(c); continue; }
+                    if (!token.empty()) { weights.emplace_back(std::max(0, std::atoi(token.c_str()))); token.clear(); }
+                }
+                if (!token.empty()) weights.emplace_back(std::max(0, std::atoi(token.c_str())));
+                if (weights.size() != n) weights.assign(n, int(100 / n));
+            }
+            // normalize to 100
+            int sum = 0; for (int v : weights) sum += v;
+            if (sum <= 0) { weights.assign(n, 0); weights[0] = 100; sum = 100; }
+            for (size_t k = 0; k < n; ++k) {
+                const unsigned int fid = unsigned(mf.gradient_component_ids[k] - '0');
+                const int pct = int(std::round(100.0 * weights[k] / sum));
+                if (k > 0) lbl += "+";
+                lbl += wxString::Format("F%u %d%%", fid, pct);
+            }
+        }
+        else {
+            const int pct_b = std::clamp(mf.mix_b_percent, 0, 100);
+            const int pct_a = 100 - pct_b;
+            lbl = wxString::Format("F%u %d%%+F%u %d%%", mf.component_a, pct_a, mf.component_b, pct_b);
+            for (char c : mf.gradient_component_ids)
+                lbl += wxString::Format("+F%d", int(c - '0'));
+        }
+        auto* name_lbl = new wxStaticText(p->m_panel_color_mix_content, wxID_ANY, lbl);
+
+        auto* menu_btn = new ScalableButton(p->m_panel_color_mix_content, wxID_ANY, "menu_filament");
+        menu_btn->SetToolTip(_L("Options"));
+        menu_btn->Bind(wxEVT_BUTTON, [this, i, menu_btn](wxCommandEvent&) {
+            wxMenu menu;
+            const int edit_id = wxWindow::NewControlId();
+            const int del_id  = wxWindow::NewControlId();
+            menu.Append(edit_id, _L("Edit"));
+            menu.Bind(wxEVT_MENU, [this, i](wxCommandEvent&) {
+                auto* co = wxGetApp().preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour");
+                const std::vector<std::string> colors = co ? co->values : std::vector<std::string>{};
+                if (colors.size() < 2) return;
+                auto& mgr = wxGetApp().preset_bundle->mixed_filaments;
+                auto& mfs2 = mgr.mixed_filaments();
+                if (i >= mfs2.size()) return;
+                AddColorMixDialog dlg(wxGetApp().mainframe, colors, mfs2[i]);
+                if (dlg.ShowModal() != wxID_OK) return;
+                const MixedFilament& r = dlg.GetResult();
+                mfs2[i].component_a                = r.component_a;
+                mfs2[i].component_b                = r.component_b;
+                mfs2[i].mix_b_percent              = r.mix_b_percent;
+                mfs2[i].distribution_mode          = r.distribution_mode;
+                mfs2[i].manual_pattern             = r.manual_pattern;
+                mfs2[i].gradient_component_ids     = r.gradient_component_ids;
+                mfs2[i].gradient_component_weights = r.gradient_component_weights;
+                mfs2[i].ratio_a                    = r.ratio_a;
+                mfs2[i].ratio_b                    = r.ratio_b;
+                if (auto* opt = wxGetApp().preset_bundle->project_config.option<ConfigOptionString>("mixed_filament_definitions"))
+                    opt->value = mgr.serialize_custom_entries();
+                wxTheApp->CallAfter([this]() {
+                    update_color_mix_panel();
+                    m_scrolled_sizer->Layout();
+                });
+            }, edit_id);
+            menu.Append(del_id, _L("Delete"));
+            menu.Bind(wxEVT_MENU, [this, i](wxCommandEvent&) {
+                auto& mgr = wxGetApp().preset_bundle->mixed_filaments;
+                auto& mfs2 = mgr.mixed_filaments();
+                if (i < mfs2.size()) mfs2[i].deleted = true;
+                if (auto* opt = wxGetApp().preset_bundle->project_config.option<ConfigOptionString>("mixed_filament_definitions"))
+                    opt->value = mgr.serialize_custom_entries();
+                wxTheApp->CallAfter([this]() {
+                    update_color_mix_panel();
+                    m_scrolled_sizer->Layout();
+                });
+            }, del_id);
+            wxPoint pt{0, menu_btn->GetSize().GetHeight()};
+            pt = menu_btn->ClientToScreen(pt);
+            pt = wxGetApp().mainframe->ScreenToClient(pt);
+            wxGetApp().mainframe->PopupMenu(&menu, pt);
+        });
+
+        auto* cell = new wxBoxSizer(wxHORIZONTAL);
+        cell->AddSpacer(FromDIP(12));
+        cell->Add(badge,    0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(6));
+        cell->Add(name_lbl, 1, wxALIGN_CENTER_VERTICAL);
+        cell->Add(menu_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
+
+        (visible_idx % 2 == 0 ? col0 : col1)->Add(cell, 0, wxEXPAND | wxBOTTOM, FromDIP(4));
+
+        ++visible_idx;
+    }
+
+    // If odd count, pad right column so left column doesn't stretch
+    if (visible_idx % 2 == 1)
+        col1->AddStretchSpacer(1);
+
+    p->m_sizer_color_mix_content->Add(grid_sizer, 0, wxEXPAND | wxALL, FromDIP(8));
+    p->m_panel_color_mix_content->Layout();
 }
 
 void Sidebar::update_mixed_filament_panel(bool sync_manager)
@@ -8007,6 +7299,7 @@ void Sidebar::update_mixed_filament_panel(bool sync_manager)
     m_scrolled_sizer->Layout();
     Layout();
     refresh_model_canvas_colors();
+    update_color_mix_panel();
 }
 
 std::vector<unsigned int> Sidebar::get_ui_ordered_filament_ids() const

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -1,7 +1,9 @@
 #ifndef slic3r_Plater_hpp_
 #define slic3r_Plater_hpp_
 
+#include <limits>
 #include <memory>
+#include <string>
 #include <vector>
 #include <boost/filesystem/path.hpp>
 
@@ -10,6 +12,7 @@
 #include <wx/notebook.h>
 
 #include "Selection.hpp"
+#include "MixedColorMatchHelpers.hpp"
 
 #include "libslic3r/enum_bitmask.hpp"
 #include "libslic3r/Preset.hpp"
@@ -156,6 +159,8 @@ public:
     void edit_filament();
 
     void on_filaments_delete(size_t filament_id);
+    void init_color_mix_panel(wxWindow* parent, wxSizer* sizer);
+    void update_color_mix_panel();
     void update_mixed_filament_panel(bool sync_manager = true);
     std::vector<unsigned int> get_ui_ordered_filament_ids() const;
     // BBS
@@ -862,6 +867,7 @@ private:
 };
 
 std::vector<int> get_min_flush_volumes(const DynamicPrintConfig& full_config);
+
 } // namespace GUI
 } // namespace Slic3r
 


### PR DESCRIPTION
## Summary

Adds a full-featured "Add Color Mix" dialog for mixed-filament workflows.

### New files
- `AddColorMixDialog` — modal dialog with four modes: ratio blend,
  cycle pattern, color-match, and gradient. Includes a live preview
  strip and triangular 3-way weight picker.
- `MixedColorMatchPanel` — embeddable panel that runs an async recipe
  search to find the closest physical-filament mix for a target color,
  with a color-map, hex input, range slider, and preset swatches.
- `MixedGradientSelector` — interactive gradient bar widget for
  selecting gradient blend positions between two filaments.
- `MixedFilamentColorMapPanel` — panel that renders a2-D color map
  for multi-filament blending using weighted mixing.
- `MixedColorMatchHelpers` — shared pure helpers (color parsing,
  weight normalization, swatch bitmap generation) used by both
  `Plater.cpp` and `MixedColorMatchPanel`.

### Modified files
- `Plater.hpp` / `Plater.cpp` — expose `init_color_mix_panel` and
  `update_color_mix_panel`; refactor mixed-filament panel update path.
- `CMakeLists.txt` — register all new GUI source files.