### PR TITLE
fix(gui): split panel headers into .cpp and fix gradient mode bugs

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -314,10 +314,13 @@ set(SLIC3R_GUI_SOURCES
     GUI/AddColorMixDialog.cpp
     GUI/AddColorMixDialog.hpp
     GUI/MixedGradientSelector.hpp
+    GUI/MixedGradientSelector.cpp
     GUI/MixedColorMatchPanel.cpp
     GUI/MixedColorMatchPanel.hpp
     GUI/MixedColorMatchHelpers.hpp
+    GUI/MixedColorMatchHelpers.cpp
     GUI/MixedFilamentColorMapPanel.hpp
+    GUI/MixedFilamentColorMapPanel.cpp
     GUI/ObjColorDialog.cpp
     GUI/ObjColorDialog.hpp
     GUI/ObjectDataViewModel.cpp

--- a/src/slic3r/GUI/AddColorMixDialog.cpp
+++ b/src/slic3r/GUI/AddColorMixDialog.cpp
@@ -232,6 +232,7 @@ void AddColorMixDialog::build_ui()
     build_tri_picker();
     {
         m_tri_strip_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize);
+        m_tri_strip_panel->SetMinSize(wxSize(FromDIP(160), -1));
         m_tri_strip_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
         m_tri_strip_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
             wxAutoBufferedPaintDC dc(m_tri_strip_panel);
@@ -288,6 +289,10 @@ void AddColorMixDialog::build_ui()
         pattern_row->Add(m_pattern_ctrl, 1, wxALIGN_CENTER_VERTICAL);
         m_pattern_ctrl->Bind(wxEVT_TEXT, [this](wxCommandEvent&) {
             if (m_cycle_strip_panel) m_cycle_strip_panel->Refresh();
+            if (m_preview_panel) {
+                m_preview_panel->Refresh();
+                m_preview_panel->Update();
+            }
         });
         m_pattern_panel_sizer->Add(pattern_row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, M);
 
@@ -316,9 +321,6 @@ void AddColorMixDialog::build_ui()
         m_cycle_strip_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
             wxAutoBufferedPaintDC dc(m_cycle_strip_panel);
             draw_strip(dc, m_cycle_strip_panel);
-        });
-        m_pattern_ctrl->Bind(wxEVT_TEXT, [this](wxCommandEvent&) {
-            if (m_cycle_strip_panel) m_cycle_strip_panel->Refresh();
         });
         m_pattern_panel_sizer->Add(m_cycle_strip_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, M);
 
@@ -440,7 +442,10 @@ void AddColorMixDialog::rebuild_filament_rows()
     }
 
     int count = (int)sels.size();
-    count = std::max(2, std::min(count, max_filaments_for_mode(m_current_mode)));
+    if (m_current_mode == MODE_GRADIENT)
+        count = 2;
+    else
+        count = std::max(2, std::min(count, max_filaments_for_mode(m_current_mode)));
 
     for (int i = 0; i < count; ++i) {
         auto* row = new wxBoxSizer(wxHORIZONTAL);
@@ -517,7 +522,7 @@ void AddColorMixDialog::rebuild_filament_rows()
             row->Add(btn_up, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(4));
         }
 
-        if (i == count - 1) {
+        if (i == count - 1 && m_current_mode != MODE_GRADIENT) {
             auto* btn_rm = new wxButton(m_filament_rows_panel, wxID_ANY, "-",
                                         wxDefaultPosition, wxSize(FromDIP(24), FromDIP(24)));
             auto* btn_ad = new wxButton(m_filament_rows_panel, wxID_ANY, "+",
@@ -556,6 +561,12 @@ void AddColorMixDialog::rebuild_filament_rows()
 
     m_filament_rows_panel->Layout();
     update_ratio_or_tri_visibility();
+
+    if (m_swatch_grid_panel) {
+        m_swatch_grid_panel->DestroyChildren();
+        build_swatch_grid();
+    }
+
     update_preview();
 }
 
@@ -697,11 +708,12 @@ void AddColorMixDialog::update_ratio_or_tri_visibility()
     if (m_filament_rows_panel) m_filament_rows_panel->Show(!is_match_mode);
     if (m_preview_panel)       m_preview_panel->Show(!is_match_mode);
     if (m_preview_label)       m_preview_label->Show(!is_match_mode);
-    if (m_swatch_grid_panel)   m_swatch_grid_panel->Show(!is_match_mode);
-    if (m_recommended_label)   m_recommended_label->Show(!is_match_mode);
-    if (m_line_below_mid)      m_line_below_mid->Show(!is_match_mode);
-    if (m_line_above_swatch)   m_line_above_swatch->Show(!is_match_mode);
-    if (m_line_below_swatch)   m_line_below_swatch->Show(!is_match_mode);
+    bool show_swatches = !is_match_mode && !is_cycle_mode;
+    if (m_swatch_grid_panel)   m_swatch_grid_panel->Show(show_swatches);
+    if (m_recommended_label)   m_recommended_label->Show(show_swatches);
+    if (m_line_below_mid)      m_line_below_mid->Show(show_swatches);
+    if (m_line_above_swatch)   m_line_above_swatch->Show(show_swatches);
+    if (m_line_below_swatch)   m_line_below_swatch->Show(show_swatches);
 
     if (m_gradient_bar_sizer)  m_gradient_bar_sizer->ShowItems(show_slider && !is_match_mode);
     if (m_tri_picker_sizer)    m_tri_picker_sizer->ShowItems(show_tri && !is_match_mode);
@@ -746,6 +758,42 @@ std::string AddColorMixDialog::compute_preview_color()
         return std::max(0, std::min(raw, (int)m_filament_colours.size() - 1));
     };
 
+    // Cycle mode: blend by pattern frequency using the same logic as Plater.cpp
+    if (m_current_mode == MODE_CYCLE && m_pattern_ctrl) {
+        const std::string raw = into_u8(m_pattern_ctrl->GetValue());
+        const std::string normalized = MixedFilamentManager::normalize_manual_pattern(raw);
+        if (!normalized.empty()) {
+            // Get component_a and component_b (1-based extruder IDs)
+            const unsigned int component_a = (unsigned int)(std::max(0, m_filament_rows[0].combo->GetSelection()) + 1);
+            const unsigned int component_b = (unsigned int)(std::max(0, (m_filament_rows.size() > 1 ? m_filament_rows[1].combo->GetSelection() : 0)) + 1);
+            const size_t num_physical = m_filament_colours.size();
+
+            // Decode pattern tokens to extruder IDs (same as Plater.cpp)
+            std::vector<unsigned int> sequence;
+            for (char token : normalized) {
+                unsigned int extruder_id = 0;
+                if (token == '1')
+                    extruder_id = component_a;
+                else if (token == '2')
+                    extruder_id = component_b;
+                else if (token >= '3' && token <= '9')
+                    extruder_id = (unsigned int)(token - '0');
+                
+                if (extruder_id >= 1 && extruder_id <= num_physical)
+                    sequence.push_back(extruder_id);
+            }
+
+            if (!sequence.empty()) {
+                std::vector<wxColour> palette;
+                palette.reserve(m_filament_colours.size());
+                for (const auto& s : m_filament_colours)
+                    palette.push_back(parse_mixed_color(s));
+                wxColour result = blend_sequence_filament_mixer(palette, sequence);
+                return wxString::Format("#%02X%02X%02X", result.Red(), result.Green(), result.Blue()).ToStdString();
+            }
+        }
+    }
+
     if (n == 2) {
         int ia = safe_idx(m_filament_rows[0].combo->GetSelection());
         int ib = safe_idx(m_filament_rows[1].combo->GetSelection());
@@ -784,46 +832,115 @@ void AddColorMixDialog::draw_strip(wxDC& dc, wxPanel* panel)
         dc.SetBackground(*wxGREY_BRUSH); dc.Clear(); return;
     }
     int n = (int)m_filament_rows.size();
-    int seg = FromDIP(12), x = 0;
+    static constexpr int STRIP_SEGMENTS = 24;
+    bool vertical = (m_current_mode == MODE_RATIO && n == 3);
+    int total_px = vertical ? sz.y : sz.x;
 
     // In 2-color ratio mode, build a pattern reflecting the A:B ratio
     std::vector<int> pattern;
     if (m_current_mode == MODE_RATIO && n == 2 && m_gradient_selector) {
         int val = m_gradient_selector->value();
-        int steps_a = std::max(1, (100 - val) / 10);
-        int steps_b = std::max(1, val / 10);
-        for (int i = 0; i < steps_a; ++i) pattern.push_back(0);
-        for (int i = 0; i < steps_b; ++i) pattern.push_back(1);
+        const int pct_b = std::clamp(val, 0, 100);
+        const int pct_a = 100 - pct_b;
+        int ratio_a = 1, ratio_b = 0;
+        if (pct_b >= 100) {
+            ratio_a = 0; ratio_b = 1;
+        } else if (pct_b > 0) {
+            const bool b_major = pct_b >= pct_a;
+            const int major = b_major ? pct_b : pct_a;
+            const int minor = b_major ? pct_a : pct_b;
+            const int layers = std::max(1, (int)std::lround((double)major / (double)std::max(1, minor)));
+            ratio_a = b_major ? 1 : layers;
+            ratio_b = b_major ? layers : 1;
+            const int g = std::gcd(ratio_a, ratio_b);
+            if (g > 1) { ratio_a /= g; ratio_b /= g; }
+        }
+        const int cycle = std::max(1, ratio_a + ratio_b);
+        for (int pos = 0; pos < cycle; ++pos) {
+            const int b_before = (pos * ratio_b) / cycle;
+            const int b_after  = ((pos + 1) * ratio_b) / cycle;
+            pattern.push_back((b_after > b_before) ? 1 : 0);
+        }
     } else if (m_current_mode == MODE_RATIO && n == 3) {
-        int s0 = std::max(1, (int)(m_tri_wx * 10 + 0.5));
-        int s1 = std::max(1, (int)(m_tri_wy * 10 + 0.5));
-        int s2 = std::max(1, (int)(m_tri_wz * 10 + 0.5));
-        for (int i = 0; i < s0; ++i) pattern.push_back(0);
-        for (int i = 0; i < s1; ++i) pattern.push_back(1);
-        for (int i = 0; i < s2; ++i) pattern.push_back(2);
+        int w0 = std::max(1, (int)std::round(m_tri_wx * 100));
+        int w1 = std::max(1, (int)std::round(m_tri_wy * 100));
+        int w2 = std::max(1, 100 - w0 - w1);
+        int g = std::gcd(std::gcd(w0, w1), w2);
+        if (g > 1) { w0 /= g; w1 /= g; w2 /= g; }
+        const int counts[3] = {w0, w1, w2};
+        const int total = w0 + w1 + w2;
+        int emitted[3] = {0, 0, 0};
+        for (int pos = 0; pos < total; ++pos) {
+            int best = 0;
+            double best_score = -1e9;
+            for (int i = 0; i < 3; ++i) {
+                double score = double(pos + 1) * double(counts[i]) / double(total) - double(emitted[i]);
+                if (score > best_score) { best_score = score; best = i; }
+            }
+            ++emitted[best];
+            pattern.push_back(best);
+        }
     } else if (m_current_mode == MODE_CYCLE && m_pattern_ctrl) {
-        // Mirror physical_filament_from_pattern_step():
-        //   '1' → component_a (row 0), '2' → component_b (row 1),
-        //   '3'..'9' → direct physical filament ID (1-based, not a row index).
-        // Store as negative -(id) to distinguish direct IDs from row indices.
-        std::string raw = into_u8(m_pattern_ctrl->GetValue());
-        for (char c : raw) {
-            if (c == ',' ) continue;
-            if (c == '1' || c == 'A' || c == 'a') pattern.push_back(0);
-            else if (c == '2' || c == 'B' || c == 'b') pattern.push_back(1);
-            else if (c >= '3' && c <= '9') pattern.push_back(-(c - '0'));
+        // Decode pattern using the same logic as Plater.cpp:
+        //   '1' → component_a, '2' → component_b,
+        //   '3'-'9' → direct physical filament ID (1-based).
+        // Store as negative -(id) to distinguish direct IDs from component IDs.
+        const std::string raw = into_u8(m_pattern_ctrl->GetValue());
+        const std::string normalized = MixedFilamentManager::normalize_manual_pattern(raw);
+        const unsigned int component_a = (unsigned int)(std::max(0, m_filament_rows[0].combo->GetSelection()) + 1);
+        const unsigned int component_b = (unsigned int)(std::max(0, (m_filament_rows.size() > 1 ? m_filament_rows[1].combo->GetSelection() : 0)) + 1);
+        const size_t num_physical = m_filament_colours.size();
+        
+        for (char token : normalized) {
+            unsigned int extruder_id = 0;
+            if (token == '1')
+                extruder_id = component_a;
+            else if (token == '2')
+                extruder_id = component_b;
+            else if (token >= '3' && token <= '9')
+                extruder_id = (unsigned int)(token - '0');
+            
+            if (extruder_id >= 1 && extruder_id <= num_physical)
+                pattern.push_back(-(int)extruder_id);  // Store as negative to indicate direct extruder ID
         }
         if (pattern.empty())
             for (int i = 0; i < n; ++i) pattern.push_back(i);
+    } else if (m_current_mode == MODE_MATCH && m_match_panel) {
+        const MixedColorMatchRecipeResult recipe = m_match_panel->selected_recipe();
+        if (recipe.valid) {
+            std::vector<int> weights = expand_color_match_recipe_weights(recipe, m_filament_colours.size());
+            int g = 0;
+            for (int w : weights) g = std::gcd(g, w);
+            if (g > 1) for (int &w : weights) w /= g;
+            std::vector<int> ids, counts;
+            for (int i = 0; i < (int)weights.size(); ++i)
+                if (weights[i] > 0) { ids.push_back(i); counts.push_back(weights[i]); }
+            const int total = std::accumulate(counts.begin(), counts.end(), 0);
+            std::vector<int> emitted(counts.size(), 0);
+            for (int pos = 0; pos < total; ++pos) {
+                int best = 0; double best_score = -1e9;
+                for (int i = 0; i < (int)counts.size(); ++i) {
+                    double score = double(pos + 1) * double(counts[i]) / double(total) - double(emitted[i]);
+                    if (score > best_score) { best_score = score; best = i; }
+                }
+                ++emitted[best];
+                pattern.push_back(-(ids[best] + 1));  // negative = direct colour index
+            }
+        }
+        if (pattern.empty()) {
+            const int num_colours = (int)m_filament_colours.size();
+            for (int i = 0; i < num_colours; ++i) pattern.push_back(-(i + 1));
+        }
     } else {
         for (int i = 0; i < n; ++i) pattern.push_back(i);
     }
 
-    bool vertical = (m_current_mode == MODE_RATIO && n == 3);
-    int fi = 0, pos = 0;
-    int total = vertical ? sz.y : sz.x;
-    while (pos < total) {
-        int entry = pattern[fi % (int)pattern.size()];
+    if (pattern.empty())
+        return;
+
+    int seg = std::max(1, total_px / STRIP_SEGMENTS);
+    for (int s = 0; s < STRIP_SEGMENTS; ++s) {
+        int entry = pattern[s % (int)pattern.size()];
         int idx;
         if (entry < 0) {
             idx = std::max(0, std::min(-entry - 1, (int)m_filament_colours.size() - 1));
@@ -834,12 +951,17 @@ void AddColorMixDialog::draw_strip(wxDC& dc, wxPanel* panel)
         }
         dc.SetBrush(wxBrush(parse_mixed_color(m_filament_colours[idx])));
         dc.SetPen(*wxTRANSPARENT_PEN);
+        const int pos = s * seg;
+        const int len = (s == STRIP_SEGMENTS - 1) ? (total_px - pos) : seg;
         if (vertical)
-            dc.DrawRectangle(0, pos, sz.x, std::min(seg, sz.y - pos));
+            dc.DrawRectangle(0, pos, sz.x, len);
         else
-            dc.DrawRectangle(pos, 0, std::min(seg, sz.x - pos), sz.y);
-        pos += seg; ++fi;
+            dc.DrawRectangle(pos, 0, len, sz.y);
     }
+
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.SetPen(wxPen(wxColour(180, 180, 180), 1));
+    dc.DrawRectangle(0, 0, sz.x, sz.y);
 }
 
 void AddColorMixDialog::build_swatch_grid()
@@ -847,42 +969,148 @@ void AddColorMixDialog::build_swatch_grid()
     int n = (int)m_filament_colours.size();
     if (n < 2) return;
 
-    std::vector<std::pair<int,int>> pairs;
-    for (int i = 0; i < n; ++i)
-        for (int j = i + 1; j < n; ++j)
-            pairs.push_back(std::make_pair(i, j));
+    bool is_ratio_3 = (m_current_mode == MODE_RATIO) && ((int)m_filament_rows.size() == 3);
 
-    int cols = std::min((int)pairs.size(), 8);
-    if (cols == 0) return;
+    // Build candidates using the same preset logic as match mode.
+    // For ratio mode with 2 rows: pair candidates at 25/50/75.
+    // For ratio mode with 3 rows: pair + triple candidates.
+    // For other modes: pairs at 50 only.
+    struct Candidate {
+        wxColour color;
+        wxString tooltip;
+        // For pair: row indices and b_pct. For triple: row indices and weights.
+        int rows[3] = {0, 0, 0};
+        int n_rows   = 2;
+        int b_pct    = 50;       // used when n_rows == 2
+        double wx    = 1.0/3.0;  // used when n_rows == 3
+        double wy    = 1.0/3.0;
+        double wz    = 1.0/3.0;
+    };
+
+    std::vector<Candidate> candidates;
+
+    if (m_current_mode == MODE_RATIO) {
+        std::vector<wxColour> palette;
+        palette.reserve(n);
+        for (const auto& s : m_filament_colours)
+            palette.push_back(parse_mixed_color(s));
+
+        constexpr int pair_ratios[] = {25, 50, 75};
+
+        for (int i = 0; i < n; ++i) {
+            for (int j = i + 1; j < n; ++j) {
+                for (int b : pair_ratios) {
+                    auto recipe = build_pair_color_match_candidate(palette, i + 1, j + 1, b);
+                    if (!recipe.valid) continue;
+                    Candidate c;
+                    c.color   = recipe.preview_color;
+                    c.tooltip = wxString::Format("F%d(%d%%) + F%d(%d%%)", i+1, 100-b, j+1, b);
+                    c.rows[0] = i; c.rows[1] = j;
+                    c.n_rows  = 2;
+                    c.b_pct   = b;
+                    candidates.push_back(c);
+                }
+            }
+        }
+
+        if (is_ratio_3) {
+            // Helper: build a triple candidate and extract the reordered rows/weights
+            // from the recipe's gradient_component_ids (which reflect the internal sort).
+            auto make_triple_candidate = [&](int i, int j, int k,
+                                             const std::vector<int>& input_weights) -> Candidate {
+                std::vector<unsigned int> ids = {(unsigned)(i+1), (unsigned)(j+1), (unsigned)(k+1)};
+                auto recipe = build_multi_color_match_candidate(palette, ids, input_weights);
+                if (!recipe.valid) return {};
+
+                // Decode the reordered ids from the recipe.
+                auto ordered_ids = decode_color_match_gradient_ids(recipe.gradient_component_ids);
+                auto ordered_w   = normalize_color_match_weights(
+                    decode_color_match_gradient_weights(recipe.gradient_component_weights, ordered_ids.size()),
+                    ordered_ids.size());
+                if (ordered_ids.size() != 3 || ordered_w.size() != 3) return {};
+
+                Candidate c;
+                c.color  = recipe.preview_color;
+                c.n_rows = 3;
+                for (int r = 0; r < 3; ++r)
+                    c.rows[r] = (int)ordered_ids[r] - 1;  // filament id → 0-based index
+                c.wx = ordered_w[0] / 100.0;
+                c.wy = ordered_w[1] / 100.0;
+                c.wz = ordered_w[2] / 100.0;
+                c.tooltip = wxString::Format("F%d(%d%%)+F%d(%d%%)+F%d(%d%%)",
+                    ordered_ids[0], ordered_w[0],
+                    ordered_ids[1], ordered_w[1],
+                    ordered_ids[2], ordered_w[2]);
+                return c;
+            };
+
+            const std::vector<int> eq = normalize_color_match_weights({1, 1, 1}, 3);
+            for (int i = 0; i < n; ++i) {
+                for (int j = i + 1; j < n; ++j) {
+                    for (int k = j + 1; k < n; ++k) {
+                        auto c_eq = make_triple_candidate(i, j, k, eq);
+                        if (c_eq.n_rows == 3) candidates.push_back(c_eq);
+
+                        for (int dom = 0; dom < 3; ++dom) {
+                            std::vector<int> dw = {25, 25, 25};
+                            dw[dom] = 50;
+                            auto c_dom = make_triple_candidate(i, j, k, dw);
+                            if (c_dom.n_rows == 3) candidates.push_back(c_dom);
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        for (int i = 0; i < n; ++i) {
+            for (int j = i + 1; j < n; ++j) {
+                std::string blended = MixedFilamentManager::blend_color(
+                    m_filament_colours[i], m_filament_colours[j], 50, 50);
+                Candidate c;
+                c.color   = parse_mixed_color(blended);
+                c.tooltip = wxString::Format("F%d + F%d", i+1, j+1);
+                c.rows[0] = i; c.rows[1] = j;
+                c.n_rows  = 2;
+                c.b_pct   = 50;
+                candidates.push_back(c);
+            }
+        }
+    }
+
+    if (candidates.empty()) return;
+    int cols = std::min((int)candidates.size(), 8);
     auto* grid = new wxGridSizer(0, cols, FromDIP(4), FromDIP(4));
 
-    for (int pi = 0; pi < (int)pairs.size(); ++pi) {
-        int ia = pairs[pi].first;
-        int ib = pairs[pi].second;
-        std::string blended = MixedFilamentManager::blend_color(
-            m_filament_colours[ia], m_filament_colours[ib], 50, 50);
+    for (const auto& cand : candidates) {
         auto* btn = new wxBitmapButton(m_swatch_grid_panel, wxID_ANY,
-                                       make_color_bitmap(parse_mixed_color(blended), FromDIP(20)),
+                                       make_color_bitmap(cand.color, FromDIP(20)),
                                        wxDefaultPosition, wxSize(FromDIP(24), FromDIP(24)));
-        btn->SetToolTip(wxString::Format("F%d + F%d", ia + 1, ib + 1));
-        btn->Bind(wxEVT_BUTTON, [this, ia, ib](wxCommandEvent&) {
-            if (!m_filament_rows.empty()) {
-                m_filament_rows[0].combo->SetSelection(ia);
-                wxColour ca = parse_mixed_color(m_filament_colours[ia]);
-                m_filament_rows[0].swatch->Bind(wxEVT_PAINT, [sw0 = m_filament_rows[0].swatch, ca](wxPaintEvent&) {
-                    wxAutoBufferedPaintDC dc(sw0);
-                    dc.SetBackground(wxBrush(ca)); dc.Clear();
+        btn->SetToolTip(cand.tooltip);
+
+        btn->Bind(wxEVT_BUTTON, [this, cand](wxCommandEvent&) {
+            auto set_row = [this](int row, int idx) {
+                if (row >= (int)m_filament_rows.size()) return;
+                m_filament_rows[row].combo->SetSelection(idx);
+                wxColour c = parse_mixed_color(m_filament_colours[idx]);
+                m_filament_rows[row].swatch->Bind(wxEVT_PAINT, [sw = m_filament_rows[row].swatch, c](wxPaintEvent&) {
+                    wxAutoBufferedPaintDC dc(sw);
+                    dc.SetBackground(wxBrush(c)); dc.Clear();
                 });
-                m_filament_rows[0].swatch->Refresh();
-            }
-            if (m_filament_rows.size() > 1) {
-                m_filament_rows[1].combo->SetSelection(ib);
-                wxColour cb = parse_mixed_color(m_filament_colours[ib]);
-                m_filament_rows[1].swatch->Bind(wxEVT_PAINT, [sw1 = m_filament_rows[1].swatch, cb](wxPaintEvent&) {
-                    wxAutoBufferedPaintDC dc(sw1);
-                    dc.SetBackground(wxBrush(cb)); dc.Clear();
-                });
-                m_filament_rows[1].swatch->Refresh();
+                m_filament_rows[row].swatch->Refresh();
+            };
+
+            for (int r = 0; r < cand.n_rows; ++r)
+                set_row(r, cand.rows[r]);
+
+            if (cand.n_rows == 2 && m_current_mode == MODE_RATIO && m_gradient_selector) {
+                m_gradient_selector->set_value(cand.b_pct);
+                if (m_ratio_label_a) m_ratio_label_a->SetLabel(wxString::Format("%d%%", 100 - cand.b_pct));
+                if (m_ratio_label_b) m_ratio_label_b->SetLabel(wxString::Format("%d%%", cand.b_pct));
+                if (m_ratio_label_sizer) m_ratio_label_sizer->Layout();
+            } else if (cand.n_rows == 3) {
+                m_tri_wx = cand.wx;
+                m_tri_wy = cand.wy;
+                m_tri_wz = cand.wz;
             }
             update_preview();
         });
@@ -943,6 +1171,7 @@ void AddColorMixDialog::update_preview()
     if (m_strip_panel)      m_strip_panel->Refresh();
     if (m_tri_strip_panel)  m_tri_strip_panel->Refresh();
     if (m_tri_picker)       m_tri_picker->Refresh();
+    if (m_cycle_strip_panel) m_cycle_strip_panel->Refresh();
 }
 
 void AddColorMixDialog::collect_result()

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1,0 +1,657 @@
+#include "MixedColorMatchHelpers.hpp"
+#include "MixedGradientSelector.hpp"
+#include <unordered_set>
+#include <ColorSpaceConvert.hpp>
+#include "MixedFilamentColorMapPanel.hpp"
+
+namespace Slic3r { namespace GUI {
+wxColour parse_mixed_color(const std::string& value)
+{
+    wxColour color(value);
+    if (!color.IsOk())
+        color = wxColour("#26A69A");
+    return color;
+}
+
+wxString normalize_color_match_hex(const wxString& value)
+{
+    wxString normalized = value;
+    normalized.Trim(true);
+    normalized.Trim(false);
+    normalized.MakeUpper();
+    if (!normalized.empty() && normalized[0] != '#')
+        normalized.Prepend("#");
+    return normalized;
+}
+
+bool try_parse_color_match_hex(const wxString& value, wxColour& color_out)
+{
+    const wxString normalized = normalize_color_match_hex(value);
+    if (normalized.length() != 7)
+        return false;
+
+    for (size_t idx = 1; idx < normalized.length(); ++idx) {
+        const unsigned char ch = static_cast<unsigned char>(normalized[idx]);
+        if (!std::isxdigit(ch))
+            return false;
+    }
+
+    wxColour parsed(normalized);
+    if (!parsed.IsOk())
+        return false;
+
+    color_out = parsed;
+    return true;
+}
+
+std::vector<int> normalize_color_match_weights(const std::vector<int>& weights, size_t count)
+{
+    std::vector<int> out = weights;
+    if (out.size() != count)
+        out.assign(count, count > 0 ? int(100 / count) : 0);
+
+    int sum = 0;
+    for (int& value : out) {
+        value = std::max(0, value);
+        sum += value;
+    }
+    if (sum <= 0 && count > 0) {
+        out.assign(count, 0);
+        out[0] = 100;
+        return out;
+    }
+
+    std::vector<double> remainders(count, 0.0);
+    int                 assigned = 0;
+    for (size_t idx = 0; idx < count; ++idx) {
+        const double exact = 100.0 * double(out[idx]) / double(sum);
+        out[idx]           = int(std::floor(exact));
+        remainders[idx]    = exact - double(out[idx]);
+        assigned += out[idx];
+    }
+
+    int missing = std::max(0, 100 - assigned);
+    while (missing > 0) {
+        size_t best_idx       = 0;
+        double best_remainder = -1.0;
+        for (size_t idx = 0; idx < remainders.size(); ++idx) {
+            if (remainders[idx] > best_remainder) {
+                best_remainder = remainders[idx];
+                best_idx       = idx;
+            }
+        }
+        ++out[best_idx];
+        remainders[best_idx] = 0.0;
+        --missing;
+    }
+
+    return out;
+}
+
+std::vector<int> expand_color_match_recipe_weights(const MixedColorMatchRecipeResult& recipe, size_t num_physical)
+{
+    std::vector<int> weights(num_physical, 0);
+    if (!recipe.valid || num_physical == 0)
+        return weights;
+
+    if (!recipe.gradient_component_ids.empty()) {
+        const std::vector<unsigned int> ids = decode_color_match_gradient_ids(recipe.gradient_component_ids);
+        const std::vector<int>          raw_weights =
+            normalize_color_match_weights(decode_color_match_gradient_weights(recipe.gradient_component_weights, ids.size()), ids.size());
+        if (ids.size() != raw_weights.size())
+            return weights;
+        for (size_t idx = 0; idx < ids.size(); ++idx) {
+            if (ids[idx] >= 1 && ids[idx] <= num_physical)
+                weights[ids[idx] - 1] = raw_weights[idx];
+        }
+        return weights;
+    }
+
+    if (recipe.component_a >= 1 && recipe.component_a <= num_physical)
+        weights[recipe.component_a - 1] = std::max(0, 100 - std::clamp(recipe.mix_b_percent, 0, 100));
+    if (recipe.component_b >= 1 && recipe.component_b <= num_physical)
+        weights[recipe.component_b - 1] = std::max(0, std::clamp(recipe.mix_b_percent, 0, 100));
+    return weights;
+}
+
+std::string summarize_color_match_recipe(const MixedColorMatchRecipeResult& recipe)
+{
+    if (!recipe.valid)
+        return {};
+
+    std::vector<unsigned int> ids;
+    std::vector<int>          weights;
+    if (!recipe.gradient_component_ids.empty()) {
+        ids     = decode_color_match_gradient_ids(recipe.gradient_component_ids);
+        weights = normalize_color_match_weights(decode_color_match_gradient_weights(recipe.gradient_component_weights, ids.size()),
+                                                ids.size());
+    } else {
+        ids     = {recipe.component_a, recipe.component_b};
+        weights = {std::max(0, 100 - std::clamp(recipe.mix_b_percent, 0, 100)), std::max(0, std::clamp(recipe.mix_b_percent, 0, 100))};
+    }
+    if (ids.empty() || ids.size() != weights.size())
+        return {};
+
+    std::ostringstream out;
+    for (size_t idx = 0; idx < ids.size(); ++idx) {
+        if (idx > 0)
+            out << '/';
+        out << 'F' << ids[idx];
+    }
+    out << ' ';
+    for (size_t idx = 0; idx < weights.size(); ++idx) {
+        if (idx > 0)
+            out << '/';
+        out << weights[idx] << '%';
+    }
+    return out.str();
+}
+
+wxBitmap make_color_match_swatch_bitmap(const wxColour& color, const wxSize& size)
+{
+    wxBitmap   bmp(size.GetWidth(), size.GetHeight());
+    wxMemoryDC dc(bmp);
+    dc.SetBackground(wxBrush(wxColour(255, 255, 255)));
+    dc.Clear();
+    dc.SetPen(wxPen(wxColour(120, 120, 120), 1));
+    dc.SetBrush(wxBrush(color.IsOk() ? color : wxColour("#26A69A")));
+    dc.DrawRectangle(0, 0, size.GetWidth(), size.GetHeight());
+    dc.SelectObject(wxNullBitmap);
+    return bmp;
+}
+
+std::vector<MixedColorMatchRecipeResult> build_color_match_presets(const std::vector<std::string>& physical_colors,
+                                                                   int                             min_component_percent)
+{
+    std::vector<MixedColorMatchRecipeResult> presets;
+    if (physical_colors.size() < 2)
+        return presets;
+
+    std::vector<wxColour> palette;
+    palette.reserve(physical_colors.size());
+    for (const std::string& hex : physical_colors)
+        palette.emplace_back(parse_mixed_color(hex));
+
+    constexpr size_t                k_max_presets = 48;
+    std::unordered_set<std::string> seen_colors;
+    auto                            add_candidate = [&presets, &seen_colors](MixedColorMatchRecipeResult candidate) {
+        if (!candidate.valid)
+            return;
+        const std::string color_key = normalize_color_match_hex(candidate.preview_color.GetAsString(wxC2S_HTML_SYNTAX)).ToStdString();
+        if (color_key.empty() || !seen_colors.insert(color_key).second)
+            return;
+        presets.emplace_back(std::move(candidate));
+    };
+
+    constexpr int pair_ratios[] = {25, 50, 75};
+    for (size_t left_idx = 0; left_idx < palette.size() && presets.size() < k_max_presets; ++left_idx) {
+        for (size_t right_idx = left_idx + 1; right_idx < palette.size() && presets.size() < k_max_presets; ++right_idx) {
+            for (const int mix_b_percent : pair_ratios) {
+                add_candidate(build_pair_color_match_candidate(palette, unsigned(left_idx + 1), unsigned(right_idx + 1), mix_b_percent,
+                                                               min_component_percent));
+                if (presets.size() >= k_max_presets)
+                    break;
+            }
+        }
+    }
+
+    const size_t           triple_limit         = std::min<size_t>(palette.size(), 6);
+    const std::vector<int> equal_triple_weights = normalize_color_match_weights({1, 1, 1}, 3);
+    for (size_t first_idx = 0; first_idx + 2 < triple_limit && presets.size() < k_max_presets; ++first_idx) {
+        for (size_t second_idx = first_idx + 1; second_idx + 1 < triple_limit && presets.size() < k_max_presets; ++second_idx) {
+            for (size_t third_idx = second_idx + 1; third_idx < triple_limit && presets.size() < k_max_presets; ++third_idx) {
+                const std::vector<unsigned int> ids = {unsigned(first_idx + 1), unsigned(second_idx + 1), unsigned(third_idx + 1)};
+                add_candidate(build_multi_color_match_candidate(palette, ids, equal_triple_weights, min_component_percent));
+                for (size_t dominant_idx = 0; dominant_idx < ids.size() && presets.size() < k_max_presets; ++dominant_idx) {
+                    std::vector<int> dominant_weights(ids.size(), 25);
+                    dominant_weights[dominant_idx] = 50;
+                    add_candidate(build_multi_color_match_candidate(palette, ids, dominant_weights, min_component_percent));
+                }
+            }
+        }
+    }
+
+    const size_t quad_limit = std::min<size_t>(palette.size(), 5);
+    for (size_t first_idx = 0; first_idx + 3 < quad_limit && presets.size() < k_max_presets; ++first_idx) {
+        for (size_t second_idx = first_idx + 1; second_idx + 2 < quad_limit && presets.size() < k_max_presets; ++second_idx) {
+            for (size_t third_idx = second_idx + 1; third_idx + 1 < quad_limit && presets.size() < k_max_presets; ++third_idx) {
+                for (size_t fourth_idx = third_idx + 1; fourth_idx < quad_limit && presets.size() < k_max_presets; ++fourth_idx) {
+                    add_candidate(build_multi_color_match_candidate(palette,
+                                                                    {unsigned(first_idx + 1), unsigned(second_idx + 1),
+                                                                     unsigned(third_idx + 1), unsigned(fourth_idx + 1)},
+                                                                    {25, 25, 25, 25}, min_component_percent));
+                }
+            }
+        }
+    }
+
+    return presets;
+}
+
+double color_delta_e00(const wxColour& lhs, const wxColour& rhs)
+{
+    float lhs_l = 0.f, lhs_a = 0.f, lhs_b = 0.f;
+    float rhs_l = 0.f, rhs_a = 0.f, rhs_b = 0.f;
+    RGB2Lab(float(lhs.Red()), float(lhs.Green()), float(lhs.Blue()), &lhs_l, &lhs_a, &lhs_b);
+    RGB2Lab(float(rhs.Red()), float(rhs.Green()), float(rhs.Blue()), &rhs_l, &rhs_a, &rhs_b);
+    return double(DeltaE00(lhs_l, lhs_a, lhs_b, rhs_l, rhs_a, rhs_b));
+}
+
+MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std::string>& physical_colors,
+                                                          const wxColour&                 target_color,
+                                                          int                             min_component_percent)
+{
+    MixedColorMatchRecipeResult best;
+    if (!target_color.IsOk() || physical_colors.size() < 2)
+        return best;
+
+    std::vector<wxColour> palette;
+    palette.reserve(physical_colors.size());
+    for (const std::string& hex : physical_colors)
+        palette.emplace_back(parse_mixed_color(hex));
+
+    auto consider_candidate = [&best, &target_color](MixedColorMatchRecipeResult candidate) {
+        if (!candidate.valid)
+            return;
+        candidate.delta_e = color_delta_e00(target_color, candidate.preview_color);
+        if (!best.valid || candidate.delta_e + 1e-6 < best.delta_e)
+            best = std::move(candidate);
+    };
+
+    const int loop_min_weight      = std::max(1, std::clamp(min_component_percent, 0, 50));
+    const int loop_max_pair_weight = 100 - loop_min_weight;
+
+    for (size_t left_idx = 0; left_idx < palette.size(); ++left_idx) {
+        for (size_t right_idx = left_idx + 1; right_idx < palette.size(); ++right_idx) {
+            for (int mix_b_percent = loop_min_weight; mix_b_percent <= loop_max_pair_weight; ++mix_b_percent)
+                consider_candidate(build_pair_color_match_candidate(palette, unsigned(left_idx + 1), unsigned(right_idx + 1), mix_b_percent,
+                                                                    min_component_percent));
+        }
+    }
+
+    std::vector<std::pair<double, unsigned int>> ranked_ids;
+    ranked_ids.reserve(palette.size());
+    for (size_t idx = 0; idx < palette.size(); ++idx)
+        ranked_ids.emplace_back(color_delta_e00(target_color, palette[idx]), unsigned(idx + 1));
+    std::sort(ranked_ids.begin(), ranked_ids.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.first != rhs.first)
+            return lhs.first < rhs.first;
+        return lhs.second < rhs.second;
+    });
+
+    std::vector<unsigned int> candidate_pool;
+    candidate_pool.reserve(std::min<size_t>(palette.size(), 12));
+    auto push_unique_id = [&candidate_pool](unsigned int filament_id) {
+        if (filament_id == 0 || filament_id > 9)
+            return;
+        if (std::find(candidate_pool.begin(), candidate_pool.end(), filament_id) == candidate_pool.end())
+            candidate_pool.emplace_back(filament_id);
+    };
+
+    const size_t general_pool_limit = std::min<size_t>(ranked_ids.size(), 8);
+    for (size_t idx = 0; idx < general_pool_limit; ++idx)
+        push_unique_id(ranked_ids[idx].second);
+
+    size_t direct_token_count = 0;
+    for (const auto& [distance, filament_id] : ranked_ids) {
+        (void) distance;
+        if (filament_id < 3 || filament_id > 9)
+            continue;
+        push_unique_id(filament_id);
+        if (++direct_token_count >= 4)
+            break;
+    }
+
+    if (candidate_pool.size() < 3)
+        return best;
+
+    std::vector<unsigned int> triple_pool = candidate_pool;
+    std::sort(triple_pool.begin(), triple_pool.end());
+    for (size_t first_idx = 0; first_idx + 2 < triple_pool.size(); ++first_idx) {
+        for (size_t second_idx = first_idx + 1; second_idx + 1 < triple_pool.size(); ++second_idx) {
+            for (size_t third_idx = second_idx + 1; third_idx < triple_pool.size(); ++third_idx) {
+                const std::vector<unsigned int> ids = {triple_pool[first_idx], triple_pool[second_idx], triple_pool[third_idx]};
+                if (std::any_of(ids.begin(), ids.end(), [](unsigned int filament_id) { return filament_id == 0 || filament_id > 9; }))
+                    continue;
+
+                for (int weight_a = loop_min_weight; weight_a <= 100 - 2 * loop_min_weight; ++weight_a) {
+                    for (int weight_b = loop_min_weight; weight_a + weight_b <= 100 - loop_min_weight; ++weight_b) {
+                        const int weight_c = 100 - weight_a - weight_b;
+                        consider_candidate(
+                            build_multi_color_match_candidate(palette, ids, {weight_a, weight_b, weight_c}, min_component_percent));
+                    }
+                }
+            }
+        }
+    }
+
+    if (candidate_pool.size() < 4)
+        return best;
+
+    std::vector<unsigned int> quad_pool(candidate_pool.begin(), candidate_pool.begin() + std::min<size_t>(candidate_pool.size(), 6));
+    std::sort(quad_pool.begin(), quad_pool.end());
+    for (size_t first_idx = 0; first_idx + 3 < quad_pool.size(); ++first_idx) {
+        for (size_t second_idx = first_idx + 1; second_idx + 2 < quad_pool.size(); ++second_idx) {
+            for (size_t third_idx = second_idx + 1; third_idx + 1 < quad_pool.size(); ++third_idx) {
+                for (size_t fourth_idx = third_idx + 1; fourth_idx < quad_pool.size(); ++fourth_idx) {
+                    const std::vector<unsigned int> ids = {quad_pool[first_idx], quad_pool[second_idx], quad_pool[third_idx],
+                                                           quad_pool[fourth_idx]};
+
+                    for (int weight_a = loop_min_weight; weight_a <= 100 - 3 * loop_min_weight; ++weight_a) {
+                        for (int weight_b = loop_min_weight; weight_a + weight_b <= 100 - 2 * loop_min_weight; ++weight_b) {
+                            for (int weight_c = loop_min_weight; weight_a + weight_b + weight_c <= 100 - loop_min_weight; ++weight_c) {
+                                const int weight_d = 100 - weight_a - weight_b - weight_c;
+                                consider_candidate(build_multi_color_match_candidate(palette, ids, {weight_a, weight_b, weight_c, weight_d},
+                                                                                     min_component_percent));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return best;
+}
+
+MixedFilamentDisplayContext build_mixed_filament_display_context(const std::vector<std::string>& physical_colors)
+{
+    MixedFilamentDisplayContext context;
+    context.num_physical    = physical_colors.size();
+    context.physical_colors = physical_colors;
+    context.nozzle_diameters.assign(context.num_physical, 0.4);
+
+    auto* preset_bundle = wxGetApp().preset_bundle;
+    if (preset_bundle == nullptr)
+        return context;
+
+    DynamicPrintConfig* print_cfg = &preset_bundle->prints.get_edited_preset().config;
+    if (const ConfigOptionFloats* opt = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionFloats>("nozzle_diameter")) {
+        const size_t opt_count = opt->values.size();
+        if (opt_count > 0) {
+            for (size_t i = 0; i < context.num_physical; ++i)
+                context.nozzle_diameters[i] = std::max(0.05, opt->get_at(unsigned(std::min(i, opt_count - 1))));
+        }
+    }
+
+    auto get_mixed_bool = [preset_bundle, print_cfg](const std::string& key, bool fallback) {
+        if (const ConfigOptionBool* opt = preset_bundle->project_config.option<ConfigOptionBool>(key))
+            return opt->value;
+        if (const ConfigOptionInt* opt = preset_bundle->project_config.option<ConfigOptionInt>(key))
+            return opt->value != 0;
+        if (print_cfg != nullptr) {
+            if (const ConfigOptionBool* opt = print_cfg->option<ConfigOptionBool>(key))
+                return opt->value;
+            if (const ConfigOptionInt* opt = print_cfg->option<ConfigOptionInt>(key))
+                return opt->value != 0;
+        }
+        return fallback;
+    };
+    auto get_mixed_float = [preset_bundle, print_cfg](const std::string& key, float fallback) {
+        if (preset_bundle->project_config.has(key))
+            return float(preset_bundle->project_config.opt_float(key));
+        if (print_cfg != nullptr && print_cfg->has(key))
+            return float(print_cfg->opt_float(key));
+        return fallback;
+    };
+
+    context.preview_settings.mixed_lower_bound    = std::max(0.01, double(get_mixed_float("mixed_filament_height_lower_bound", 0.04f)));
+    context.preview_settings.mixed_upper_bound    = std::max(context.preview_settings.mixed_lower_bound,
+                                                             double(get_mixed_float("mixed_filament_height_upper_bound", 0.16f)));
+    context.preview_settings.preferred_a_height   = std::max(0.0, double(get_mixed_float("mixed_color_layer_height_a", 0.f)));
+    context.preview_settings.preferred_b_height   = std::max(0.0, double(get_mixed_float("mixed_color_layer_height_b", 0.f)));
+    context.preview_settings.nominal_layer_height = 0.2;
+    if (print_cfg != nullptr && print_cfg->has("layer_height"))
+        context.preview_settings.nominal_layer_height = std::max(0.01, print_cfg->opt_float("layer_height"));
+    if (print_cfg != nullptr && print_cfg->has("wall_loops"))
+        context.preview_settings.wall_loops = std::max<size_t>(1, size_t(std::max(1, print_cfg->opt_int("wall_loops"))));
+    context.preview_settings.local_z_mode              = get_mixed_bool("dithering_local_z_mode", false);
+    context.preview_settings.local_z_direct_multicolor = get_mixed_bool("dithering_local_z_direct_multicolor", false) &&
+                                                         context.preview_settings.preferred_a_height <= EPSILON &&
+                                                         context.preview_settings.preferred_b_height <= EPSILON;
+    context.component_bias_enabled = get_mixed_bool("mixed_filament_component_bias_enabled", false);
+
+    return context;
+}
+
+wxColour compute_color_match_recipe_display_color(const MixedColorMatchRecipeResult& recipe, const MixedFilamentDisplayContext& context)
+{
+    if (!recipe.valid)
+        return recipe.preview_color.IsOk() ? recipe.preview_color : wxColour("#26A69A");
+
+    MixedFilament entry;
+    entry.component_a                = recipe.component_a;
+    entry.component_b                = recipe.component_b;
+    entry.mix_b_percent              = recipe.mix_b_percent;
+    entry.manual_pattern             = recipe.manual_pattern;
+    entry.gradient_component_ids     = recipe.gradient_component_ids;
+    entry.gradient_component_weights = recipe.gradient_component_weights;
+    entry.distribution_mode          = recipe.gradient_component_ids.empty() ? int(MixedFilament::Simple) : int(MixedFilament::LayerCycle);
+
+    return parse_mixed_color(compute_mixed_filament_display_color(entry, context));
+}
+
+std::vector<unsigned int> decode_color_match_gradient_ids(const std::string& value)
+{
+    std::vector<unsigned int> ids;
+    bool                      seen[10] = {false};
+    for (const char ch : value) {
+        if (ch < '1' || ch > '9')
+            continue;
+        const unsigned int id = unsigned(ch - '0');
+        if (seen[id])
+            continue;
+        seen[id] = true;
+        ids.emplace_back(id);
+    }
+    return ids;
+}
+
+std::vector<int> decode_color_match_gradient_weights(const std::string& value, size_t expected_components)
+{
+    std::vector<int> weights;
+    if (value.empty() || expected_components == 0)
+        return weights;
+
+    std::string token;
+    for (const char ch : value) {
+        if (ch >= '0' && ch <= '9') {
+            token.push_back(ch);
+            continue;
+        }
+        if (!token.empty()) {
+            weights.emplace_back(std::max(0, std::atoi(token.c_str())));
+            token.clear();
+        }
+    }
+    if (!token.empty())
+        weights.emplace_back(std::max(0, std::atoi(token.c_str())));
+    if (weights.size() != expected_components)
+        weights.clear();
+    return weights;
+}
+
+MixedColorMatchRecipeResult build_pair_color_match_candidate(
+    const std::vector<wxColour>& palette, unsigned int component_a, unsigned int component_b, int mix_b_percent, int min_component_percent)
+{
+    MixedColorMatchRecipeResult candidate;
+    if (component_a == 0 || component_b == 0 || component_a == component_b)
+        return candidate;
+    if (component_a > palette.size() || component_b > palette.size())
+        return candidate;
+    if (!color_match_weights_within_range({100 - std::clamp(mix_b_percent, 0, 100), std::clamp(mix_b_percent, 0, 100)},
+                                          min_component_percent))
+        return candidate;
+
+    candidate.valid         = true;
+    candidate.component_a   = component_a;
+    candidate.component_b   = component_b;
+    candidate.mix_b_percent = std::clamp(mix_b_percent, 0, 100);
+    candidate.preview_color = blend_pair_filament_mixer(palette[component_a - 1], palette[component_b - 1],
+                                                        float(candidate.mix_b_percent) / 100.f);
+    return candidate;
+}
+
+MixedColorMatchRecipeResult build_multi_color_match_candidate(const std::vector<wxColour>&     palette,
+                                                              const std::vector<unsigned int>& ids,
+                                                              const std::vector<int>&          weights,
+                                                              int                              min_component_percent)
+{
+    MixedColorMatchRecipeResult candidate;
+    if (ids.size() < 3 || ids.size() != weights.size())
+        return candidate;
+    if (!color_match_weights_within_range(weights, min_component_percent))
+        return candidate;
+
+    std::vector<std::pair<int, unsigned int>> weighted_ids;
+    weighted_ids.reserve(ids.size());
+    for (size_t idx = 0; idx < ids.size(); ++idx) {
+        if (ids[idx] == 0 || ids[idx] > palette.size() || ids[idx] > 9)
+            return candidate;
+        if (weights[idx] <= 0)
+            continue;
+        weighted_ids.emplace_back(weights[idx], ids[idx]);
+    }
+    if (weighted_ids.size() < 3)
+        return candidate;
+
+    std::sort(weighted_ids.begin(), weighted_ids.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.first != rhs.first)
+            return lhs.first > rhs.first;
+        return lhs.second < rhs.second;
+    });
+
+    std::vector<unsigned int> ordered_ids;
+    std::vector<int>          ordered_weights;
+    ordered_ids.reserve(weighted_ids.size());
+    ordered_weights.reserve(weighted_ids.size());
+    for (const auto& [weight, filament_id] : weighted_ids) {
+        ordered_ids.emplace_back(filament_id);
+        ordered_weights.emplace_back(weight);
+    }
+
+    const std::vector<unsigned int> sequence = build_color_match_sequence(ordered_ids, ordered_weights);
+    if (sequence.empty())
+        return candidate;
+
+    candidate.valid             = true;
+    candidate.component_a       = ordered_ids[0];
+    candidate.component_b       = ordered_ids[1];
+    const int pair_weight_total = ordered_weights[0] + ordered_weights[1];
+    candidate.mix_b_percent     = pair_weight_total > 0 ?
+                                      std::clamp(int(std::lround(100.0 * double(ordered_weights[1]) / double(pair_weight_total))), 0, 100) :
+                                      50;
+    for (const unsigned int filament_id : ordered_ids)
+        candidate.gradient_component_ids.push_back(char('0' + filament_id));
+    {
+        std::ostringstream weights_ss;
+        for (size_t weight_idx = 0; weight_idx < ordered_weights.size(); ++weight_idx) {
+            if (weight_idx > 0)
+                weights_ss << '/';
+            weights_ss << ordered_weights[weight_idx];
+        }
+        candidate.gradient_component_weights = weights_ss.str();
+    }
+    candidate.preview_color = blend_sequence_filament_mixer(palette, sequence);
+    return candidate;
+}
+
+bool color_match_weights_within_range(const std::vector<int>& weights, int min_component_percent)
+{
+    if (min_component_percent <= 0)
+        return true;
+
+    const int min_allowed       = std::clamp(min_component_percent, 0, 50);
+    int       active_components = 0;
+    for (const int weight : weights) {
+        if (weight <= 0)
+            continue;
+        ++active_components;
+        if (weight < min_allowed)
+            return false;
+    }
+    return active_components >= 2;
+}
+
+std::vector<unsigned int> build_color_match_sequence(const std::vector<unsigned int>& ids, const std::vector<int>& weights)
+{
+    if (ids.empty() || ids.size() != weights.size())
+        return {};
+
+    constexpr int k_max_cycle = 48;
+
+    std::vector<unsigned int> filtered_ids;
+    std::vector<int>          counts;
+    filtered_ids.reserve(ids.size());
+    counts.reserve(weights.size());
+    for (size_t idx = 0; idx < ids.size(); ++idx) {
+        const int weight = std::max(0, weights[idx]);
+        if (weight <= 0)
+            continue;
+        filtered_ids.emplace_back(ids[idx]);
+        counts.emplace_back(std::max(1, int(std::round((double(weight) / 100.0) * k_max_cycle))));
+    }
+
+    if (filtered_ids.empty())
+        return {};
+
+    int cycle = std::accumulate(counts.begin(), counts.end(), 0);
+    while (cycle > k_max_cycle) {
+        auto it = std::max_element(counts.begin(), counts.end());
+        if (it == counts.end() || *it <= 1)
+            break;
+        --(*it);
+        --cycle;
+    }
+
+    if (cycle <= 0)
+        return {};
+
+    std::vector<unsigned int> sequence;
+    sequence.reserve(size_t(cycle));
+    std::vector<int> emitted(counts.size(), 0);
+    for (int pos = 0; pos < cycle; ++pos) {
+        size_t best_idx   = 0;
+        double best_score = -1e9;
+        for (size_t idx = 0; idx < counts.size(); ++idx) {
+            const double target = double((pos + 1) * counts[idx]) / double(std::max(1, cycle));
+            const double score  = target - double(emitted[idx]);
+            if (score > best_score) {
+                best_score = score;
+                best_idx   = idx;
+            }
+        }
+        ++emitted[best_idx];
+        sequence.emplace_back(filtered_ids[best_idx]);
+    }
+
+    return sequence;
+}
+
+wxColour blend_sequence_filament_mixer(const std::vector<wxColour>& palette, const std::vector<unsigned int>& sequence)
+{
+    if (palette.empty() || sequence.empty())
+        return wxColour("#26A69A");
+
+    std::vector<int> counts(palette.size() + 1, 0);
+    for (const unsigned int filament_id : sequence) {
+        if (filament_id == 0 || filament_id > palette.size())
+            continue;
+        ++counts[filament_id];
+    }
+
+    std::vector<wxColour> colors;
+    std::vector<double>   weights;
+    colors.reserve(palette.size());
+    weights.reserve(palette.size());
+    for (size_t filament_id = 1; filament_id <= palette.size(); ++filament_id) {
+        if (counts[filament_id] <= 0)
+            continue;
+        colors.emplace_back(palette[filament_id - 1]);
+        weights.emplace_back(double(counts[filament_id]));
+    }
+
+    return blend_multi_filament_mixer(colors, weights);
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedColorMatchHelpers.hpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.hpp
@@ -59,8 +59,19 @@ wxColour compute_color_match_recipe_display_color(
     const MixedColorMatchRecipeResult  &recipe,
     const MixedFilamentDisplayContext  &context);
 
-MixedColorMatchRecipeResult prompt_best_color_match_recipe(wxWindow *parent,
-                                                           const std::vector<std::string> &physical_colors,
-                                                           const wxColour &initial_color);
+std::vector<unsigned int> decode_color_match_gradient_ids(const std::string& value);
+std::vector<int>          decode_color_match_gradient_weights(const std::string& value, size_t expected_components);
+MixedColorMatchRecipeResult build_pair_color_match_candidate(const std::vector<wxColour>& palette,
+                                                             unsigned int                 component_a,
+                                                             unsigned int                 component_b,
+                                                             int                          mix_b_percent,
+                                                             int                          min_component_percent = 0);
+MixedColorMatchRecipeResult build_multi_color_match_candidate(const std::vector<wxColour>&     palette,
+                                                              const std::vector<unsigned int>& ids,
+                                                              const std::vector<int>&          weights,
+                                                              int                              min_component_percent = 0);
+bool color_match_weights_within_range(const std::vector<int>& weights, int min_component_percent);
+std::vector<unsigned int>   build_color_match_sequence(const std::vector<unsigned int>& ids, const std::vector<int>& weights);
+wxColour                    blend_sequence_filament_mixer(const std::vector<wxColour>& palette, const std::vector<unsigned int>& sequence);
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedColorMatchPanel.cpp
+++ b/src/slic3r/GUI/MixedColorMatchPanel.cpp
@@ -82,6 +82,8 @@ public:
     }
 
 private:
+    static constexpr int SEGMENTS = 24;
+
     void on_paint(wxPaintEvent &)
     {
         wxAutoBufferedPaintDC dc(this);
@@ -91,21 +93,37 @@ private:
 
         if (m_colors.empty() || m_weights.empty()) return;
 
+        // Build a Bresenham-scheduled sequence of colour indices, same as draw_strip.
+        std::vector<int> ids, counts;
         int total = 0;
         for (int w : m_weights) total += std::max(0, w);
         if (total <= 0) return;
+        for (size_t i = 0; i < m_weights.size(); ++i)
+            if (m_weights[i] > 0) { ids.push_back((int)i); counts.push_back(m_weights[i]); }
 
-        int y = 0;
-        for (size_t i = 0; i < m_colors.size() && i < m_weights.size(); ++i) {
-            const int w = std::max(0, m_weights[i]);
-            if (w <= 0) continue;
-            const int stripe_h = (i + 1 < m_colors.size())
-                ? int(std::lround(double(w) / double(total) * sz.GetHeight()))
-                : sz.GetHeight() - y;
-            dc.SetBrush(wxBrush(m_colors[i].IsOk() ? m_colors[i] : wxColour(200, 200, 200)));
+        std::vector<int> pattern;
+        pattern.reserve(SEGMENTS);
+        std::vector<int> emitted(counts.size(), 0);
+        for (int pos = 0; pos < SEGMENTS; ++pos) {
+            int best = 0; double best_score = -1e9;
+            for (int i = 0; i < (int)counts.size(); ++i) {
+                double score = double(pos + 1) * double(counts[i]) / double(total) - double(emitted[i]);
+                if (score > best_score) { best_score = score; best = i; }
+            }
+            ++emitted[best];
+            pattern.push_back(ids[best]);
+        }
+
+        const int seg = std::max(1, sz.GetHeight() / SEGMENTS);
+        for (int s = 0; s < SEGMENTS; ++s) {
+            const int idx = pattern[s];
+            const wxColour &c = (idx >= 0 && idx < (int)m_colors.size() && m_colors[idx].IsOk())
+                ? m_colors[idx] : wxColour(200, 200, 200);
+            dc.SetBrush(wxBrush(c));
             dc.SetPen(*wxTRANSPARENT_PEN);
-            dc.DrawRectangle(0, y, sz.GetWidth(), stripe_h);
-            y += stripe_h;
+            const int y   = s * seg;
+            const int len = (s == SEGMENTS - 1) ? (sz.GetHeight() - y) : seg;
+            dc.DrawRectangle(0, y, sz.GetWidth(), len);
         }
     }
 

--- a/src/slic3r/GUI/MixedColorMatchPanel.hpp
+++ b/src/slic3r/GUI/MixedColorMatchPanel.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "GUI_Utils.hpp"
-#include "Plater.hpp"
 
 #include <wx/wx.h>
 #include <wx/gauge.h>
@@ -12,6 +11,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include "MixedColorMatchHelpers.hpp"
 
 namespace Slic3r { namespace GUI {
 

--- a/src/slic3r/GUI/MixedFilamentColorMapPanel.cpp
+++ b/src/slic3r/GUI/MixedFilamentColorMapPanel.cpp
@@ -1,0 +1,672 @@
+#include "MixedFilamentColorMapPanel.hpp"
+
+#include <numeric>
+#include "MixedColorMatchHelpers.hpp"
+
+namespace Slic3r { namespace GUI {
+
+wxColour blend_multi_filament_mixer(const std::vector<wxColour>& colors, const std::vector<double>& weights)
+{
+    if (colors.empty() || weights.empty())
+        return wxColour("#26A69A");
+
+    unsigned char out_r              = 0;
+    unsigned char out_g              = 0;
+    unsigned char out_b              = 0;
+    double        accumulated_weight = 0.0;
+    bool          has_color          = false;
+
+    for (size_t i = 0; i < colors.size() && i < weights.size(); ++i) {
+        const double weight = std::max(0.0, weights[i]);
+        if (weight <= 0.0)
+            continue;
+
+        const wxColour      safe = colors[i].IsOk() ? colors[i] : wxColour("#26A69A");
+        const unsigned char r    = static_cast<unsigned char>(safe.Red());
+        const unsigned char g    = static_cast<unsigned char>(safe.Green());
+        const unsigned char b    = static_cast<unsigned char>(safe.Blue());
+
+        if (!has_color) {
+            out_r              = r;
+            out_g              = g;
+            out_b              = b;
+            accumulated_weight = weight;
+            has_color          = true;
+            continue;
+        }
+
+        const double new_total = accumulated_weight + weight;
+        if (new_total <= 0.0)
+            continue;
+        const float t = float(weight / new_total);
+        ::Slic3r::filament_mixer_lerp(out_r, out_g, out_b, r, g, b, t, &out_r, &out_g, &out_b);
+        accumulated_weight = new_total;
+    }
+
+    if (!has_color)
+        return wxColour("#26A69A");
+
+    return wxColour(out_r, out_g, out_b);
+}
+
+// --- MixedFilamentColorMapPanel ---
+
+MixedFilamentColorMapPanel::MixedFilamentColorMapPanel(wxWindow*                        parent,
+                                                       const std::vector<unsigned int>& filament_ids,
+                                                       const std::vector<wxColour>&     palette,
+                                                       const std::vector<int>&          initial_weights,
+                                                       const wxSize&                    min_size)
+    : wxPanel(parent, wxID_ANY, wxDefaultPosition, min_size, wxBORDER_SIMPLE)
+{
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
+    SetMinSize(min_size);
+    m_render_timer.SetOwner(this);
+
+    m_colors.reserve(filament_ids.size());
+    for (const unsigned int filament_id : filament_ids) {
+        if (filament_id >= 1 && filament_id <= palette.size())
+            m_colors.emplace_back(palette[filament_id - 1]);
+        else
+            m_colors.emplace_back(wxColour("#26A69A"));
+    }
+    if (m_colors.empty())
+        m_colors.emplace_back(wxColour("#26A69A"));
+
+    set_normalized_weights(initial_weights, false);
+
+    Bind(wxEVT_PAINT, &MixedFilamentColorMapPanel::on_paint, this);
+    Bind(wxEVT_LEFT_DOWN, &MixedFilamentColorMapPanel::on_left_down, this);
+    Bind(wxEVT_LEFT_UP, &MixedFilamentColorMapPanel::on_left_up, this);
+    Bind(wxEVT_MOTION, &MixedFilamentColorMapPanel::on_mouse_move, this);
+    Bind(wxEVT_MOUSE_CAPTURE_LOST, &MixedFilamentColorMapPanel::on_capture_lost, this);
+    Bind(wxEVT_SIZE, &MixedFilamentColorMapPanel::on_size, this);
+    Bind(wxEVT_TIMER, &MixedFilamentColorMapPanel::on_render_timer, this, m_render_timer.GetId());
+}
+
+MixedFilamentColorMapPanel::~MixedFilamentColorMapPanel()
+{
+    if (HasCapture())
+        ReleaseMouse();
+    if (m_render_timer.IsRunning())
+        m_render_timer.Stop();
+}
+
+wxColour MixedFilamentColorMapPanel::selected_color() const
+{
+    std::vector<double> weights;
+    weights.reserve(m_weights.size());
+    for (const int weight : m_weights)
+        weights.emplace_back(double(std::max(0, weight)));
+    return blend_multi_filament_mixer(m_colors, weights);
+}
+
+void MixedFilamentColorMapPanel::set_normalized_weights(const std::vector<int>& weights, bool notify)
+{
+    m_weights = normalize_color_match_weights(weights, m_colors.size());
+    initialize_cursor_from_weights();
+    Refresh();
+    if (notify)
+        emit_changed();
+}
+
+void MixedFilamentColorMapPanel::set_min_component_percent(int min_component_percent)
+{
+    const int clamped = std::clamp(min_component_percent, 0, 50);
+    if (m_min_component_percent == clamped)
+        return;
+    m_min_component_percent = clamped;
+    invalidate_cached_bitmap();
+    Refresh();
+}
+
+MixedFilamentColorMapPanel::GeometryMode MixedFilamentColorMapPanel::geometry_mode() const
+{
+    if (m_colors.size() <= 1)
+        return GeometryMode::Point;
+    if (m_colors.size() == 2)
+        return GeometryMode::Line;
+    if (m_colors.size() == 3)
+        return GeometryMode::Triangle;
+    if (m_colors.size() == 4)
+        return GeometryMode::TriangleWithCenter;
+    return GeometryMode::Radial;
+}
+
+wxRect MixedFilamentColorMapPanel::canvas_rect() const
+{
+    const wxSize size = GetClientSize();
+    return wxRect(0, 0, std::max(1, size.GetWidth()), std::max(1, size.GetHeight()));
+}
+
+std::array<MixedFilamentColorMapPanel::Vec2, 3> MixedFilamentColorMapPanel::simplex_vertices() const
+{
+    return {make_vec(0.50, 0.05), make_vec(0.08, 0.94), make_vec(0.92, 0.94)};
+}
+
+MixedFilamentColorMapPanel::Vec2 MixedFilamentColorMapPanel::simplex_center() const
+{
+    const auto vertices = simplex_vertices();
+    return make_vec((vertices[0].x + vertices[1].x + vertices[2].x) / 3.0,
+                    (vertices[0].y + vertices[1].y + vertices[2].y) / 3.0);
+}
+
+std::vector<MixedFilamentColorMapPanel::AnchorPoint> MixedFilamentColorMapPanel::radial_anchor_points() const
+{
+    std::vector<AnchorPoint> anchors;
+    const size_t             count = m_colors.size();
+    anchors.reserve(count);
+    if (count == 0)
+        return anchors;
+    if (count == 1) {
+        anchors.emplace_back(AnchorPoint{0.5, 0.5});
+        return anchors;
+    }
+    if (count == 2) {
+        anchors.emplace_back(AnchorPoint{0.0, 0.5});
+        anchors.emplace_back(AnchorPoint{1.0, 0.5});
+        return anchors;
+    }
+    if (count == 3) {
+        anchors.emplace_back(AnchorPoint{0.0, 0.5});
+        anchors.emplace_back(AnchorPoint{1.0, 0.0});
+        anchors.emplace_back(AnchorPoint{1.0, 1.0});
+        return anchors;
+    }
+    if (count == 4) {
+        anchors.emplace_back(AnchorPoint{0.0, 0.0});
+        anchors.emplace_back(AnchorPoint{1.0, 0.0});
+        anchors.emplace_back(AnchorPoint{1.0, 1.0});
+        anchors.emplace_back(AnchorPoint{0.0, 1.0});
+        return anchors;
+    }
+
+    constexpr double k_pi     = 3.14159265358979323846;
+    const double     center_x = 0.5;
+    const double     center_y = 0.5;
+    const double     radius   = 0.45;
+    for (size_t idx = 0; idx < count; ++idx) {
+        const double angle = (2.0 * k_pi * double(idx)) / double(count);
+        anchors.emplace_back(AnchorPoint{center_x + radius * std::cos(angle), center_y + radius * std::sin(angle)});
+    }
+    return anchors;
+}
+
+std::vector<MixedFilamentColorMapPanel::AnchorPoint> MixedFilamentColorMapPanel::anchor_points() const
+{
+    std::vector<AnchorPoint> anchors;
+    switch (geometry_mode()) {
+    case GeometryMode::Point: anchors.emplace_back(AnchorPoint{0.5, 0.5}); break;
+    case GeometryMode::Line:
+        anchors.emplace_back(AnchorPoint{0.06, 0.5});
+        anchors.emplace_back(AnchorPoint{0.94, 0.5});
+        break;
+    case GeometryMode::Triangle: {
+        const auto vertices = simplex_vertices();
+        for (const Vec2& vertex : vertices)
+            anchors.emplace_back(AnchorPoint{vertex.x, vertex.y});
+        break;
+    }
+    case GeometryMode::TriangleWithCenter: {
+        const auto vertices = simplex_vertices();
+        for (const Vec2& vertex : vertices)
+            anchors.emplace_back(AnchorPoint{vertex.x, vertex.y});
+        const Vec2 center = simplex_center();
+        anchors.emplace_back(AnchorPoint{center.x, center.y});
+        break;
+    }
+    case GeometryMode::Radial: anchors = radial_anchor_points(); break;
+    }
+    return anchors;
+}
+
+std::array<double, 3> MixedFilamentColorMapPanel::triangle_barycentric(const Vec2& point, const std::array<Vec2, 3>& triangle)
+{
+    const Vec2&  a     = triangle[0];
+    const Vec2&  b     = triangle[1];
+    const Vec2&  c     = triangle[2];
+    const double denom = ((b.y - c.y) * (a.x - c.x) + (c.x - b.x) * (a.y - c.y));
+    if (std::abs(denom) <= 1e-9)
+        return {1.0, 0.0, 0.0};
+    const double w0 = ((b.y - c.y) * (point.x - c.x) + (c.x - b.x) * (point.y - c.y)) / denom;
+    const double w1 = ((c.y - a.y) * (point.x - c.x) + (a.x - c.x) * (point.y - c.y)) / denom;
+    const double w2 = 1.0 - w0 - w1;
+    return {w0, w1, w2};
+}
+
+bool MixedFilamentColorMapPanel::point_in_triangle(const Vec2& point, const std::array<Vec2, 3>& triangle)
+{
+    const auto       barycentric = triangle_barycentric(point, triangle);
+    constexpr double eps         = 1e-6;
+    return barycentric[0] >= -eps && barycentric[1] >= -eps && barycentric[2] >= -eps;
+}
+
+MixedFilamentColorMapPanel::Vec2 MixedFilamentColorMapPanel::closest_point_on_segment(const Vec2& point, const Vec2& start, const Vec2& end)
+{
+    const Vec2   edge        = sub_vec(end, start);
+    const double edge_len_sq = length_sq(edge);
+    if (edge_len_sq <= 1e-9)
+        return start;
+    const double t = std::clamp(dot_vec(sub_vec(point, start), edge) / edge_len_sq, 0.0, 1.0);
+    return add_vec(start, scale_vec(edge, t));
+}
+
+MixedFilamentColorMapPanel::Vec2 MixedFilamentColorMapPanel::closest_point_on_triangle(const Vec2& point, const std::array<Vec2, 3>& triangle)
+{
+    if (point_in_triangle(point, triangle))
+        return point;
+
+    Vec2   best      = triangle[0];
+    double best_dist = std::numeric_limits<double>::max();
+    for (int edge_idx = 0; edge_idx < 3; ++edge_idx) {
+        const Vec2   candidate      = closest_point_on_segment(point, triangle[edge_idx], triangle[(edge_idx + 1) % 3]);
+        const double candidate_dist = dist_sq(point, candidate);
+        if (candidate_dist < best_dist) {
+            best_dist = candidate_dist;
+            best      = candidate;
+        }
+    }
+    return best;
+}
+
+MixedFilamentColorMapPanel::Vec2 MixedFilamentColorMapPanel::normalized_point_from_mouse(const wxMouseEvent& evt) const
+{
+    const wxRect rect   = canvas_rect();
+    const int    width  = std::max(1, rect.GetWidth() - 1);
+    const int    height = std::max(1, rect.GetHeight() - 1);
+    return make_vec(std::clamp(double(evt.GetX() - rect.GetLeft()) / double(width), 0.0, 1.0),
+                    std::clamp(double(evt.GetY() - rect.GetTop()) / double(height), 0.0, 1.0));
+}
+
+MixedFilamentColorMapPanel::Vec2 MixedFilamentColorMapPanel::clamp_point_to_geometry(const Vec2& point) const
+{
+    switch (geometry_mode()) {
+    case GeometryMode::Point: return make_vec(0.5, 0.5);
+    case GeometryMode::Line: return make_vec(std::clamp(point.x, 0.0, 1.0), 0.5);
+    case GeometryMode::Triangle:
+    case GeometryMode::TriangleWithCenter: return closest_point_on_triangle(point, simplex_vertices());
+    case GeometryMode::Radial: return make_vec(std::clamp(point.x, 0.0, 1.0), std::clamp(point.y, 0.0, 1.0));
+    }
+    return point;
+}
+
+std::vector<double> MixedFilamentColorMapPanel::simplex_weights_from_pos(const Vec2& point) const
+{
+    const auto triangle    = simplex_vertices();
+    const Vec2 clamped     = closest_point_on_triangle(point, triangle);
+    const auto barycentric = triangle_barycentric(clamped, triangle);
+
+    if (geometry_mode() == GeometryMode::Triangle)
+        return {std::max(0.0, barycentric[0]), std::max(0.0, barycentric[1]), std::max(0.0, barycentric[2])};
+
+    const double shared = std::max(0.0, std::min({barycentric[0], barycentric[1], barycentric[2]}));
+    return {std::max(0.0, barycentric[0] - shared), std::max(0.0, barycentric[1] - shared),
+            std::max(0.0, barycentric[2] - shared), std::max(0.0, shared * 3.0)};
+}
+
+MixedFilamentColorMapPanel::Vec2 MixedFilamentColorMapPanel::triangle_point_from_weights() const
+{
+    const auto vertices = simplex_vertices();
+    double     total    = 0.0;
+    for (size_t idx = 0; idx < 3 && idx < m_weights.size(); ++idx)
+        total += std::max(0, m_weights[idx]);
+    if (total <= 0.0)
+        return simplex_center();
+
+    Vec2 out = make_vec(0.0, 0.0);
+    for (size_t idx = 0; idx < 3 && idx < m_weights.size(); ++idx) {
+        const double weight = double(std::max(0, m_weights[idx])) / total;
+        out                 = add_vec(out, scale_vec(vertices[idx], weight));
+    }
+    return out;
+}
+
+void MixedFilamentColorMapPanel::initialize_cursor_from_grid_search()
+{
+    double        best_x     = 0.5;
+    double        best_y     = 0.5;
+    double        best_error = std::numeric_limits<double>::max();
+    constexpr int grid       = 96;
+    for (int y_idx = 0; y_idx <= grid; ++y_idx) {
+        for (int x_idx = 0; x_idx <= grid; ++x_idx) {
+            const Vec2             point = clamp_point_to_geometry(make_vec(double(x_idx) / double(grid), double(y_idx) / double(grid)));
+            const std::vector<int> probe = normalized_weights_from_pos(point.x, point.y);
+            if (probe.size() != m_weights.size())
+                continue;
+            double error = 0.0;
+            for (size_t idx = 0; idx < probe.size(); ++idx) {
+                const double delta = double(probe[idx] - m_weights[idx]);
+                error += delta * delta;
+            }
+            if (error < best_error) {
+                best_error = error;
+                best_x     = point.x;
+                best_y     = point.y;
+            }
+        }
+    }
+    m_cursor_x = best_x;
+    m_cursor_y = best_y;
+    m_weights  = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
+}
+
+std::vector<double> MixedFilamentColorMapPanel::raw_weights_from_pos(double normalized_x, double normalized_y) const
+{
+    switch (geometry_mode()) {
+    case GeometryMode::Point: return {1.0};
+    case GeometryMode::Line: {
+        const double t = std::clamp(normalized_x, 0.0, 1.0);
+        return {1.0 - t, t};
+    }
+    case GeometryMode::Triangle:
+    case GeometryMode::TriangleWithCenter: return simplex_weights_from_pos(make_vec(normalized_x, normalized_y));
+    case GeometryMode::Radial: break;
+    }
+
+    const std::vector<AnchorPoint> anchors = radial_anchor_points();
+    std::vector<double>            out(anchors.size(), 0.0);
+    if (anchors.empty())
+        return out;
+
+    constexpr double eps       = 1e-8;
+    size_t           exact_idx = size_t(-1);
+    for (size_t idx = 0; idx < anchors.size(); ++idx) {
+        const double dx = normalized_x - anchors[idx].x;
+        const double dy = normalized_y - anchors[idx].y;
+        const double d2 = dx * dx + dy * dy;
+        if (d2 <= eps) {
+            exact_idx = idx;
+            break;
+        }
+        out[idx] = 1.0 / std::max(1e-6, d2);
+    }
+    if (exact_idx != size_t(-1)) {
+        std::fill(out.begin(), out.end(), 0.0);
+        out[exact_idx] = 1.0;
+        return out;
+    }
+
+    double sum = 0.0;
+    for (const double value : out)
+        sum += value;
+    if (sum <= 0.0) {
+        out.assign(out.size(), 0.0);
+        out[0] = 1.0;
+        return out;
+    }
+    for (double& value : out)
+        value /= sum;
+    return out;
+}
+
+std::vector<int> MixedFilamentColorMapPanel::normalized_weights_from_pos(double normalized_x, double normalized_y) const
+{
+    std::vector<int>          raw_weights;
+    const std::vector<double> raw = raw_weights_from_pos(normalized_x, normalized_y);
+    raw_weights.reserve(raw.size());
+    for (const double value : raw)
+        raw_weights.emplace_back(std::max(0, int(std::lround(value * 100.0))));
+    return normalize_color_match_weights(raw_weights, raw.size());
+}
+
+void MixedFilamentColorMapPanel::initialize_cursor_from_weights()
+{
+    if (m_weights.empty()) {
+        m_cursor_x = 0.5;
+        m_cursor_y = 0.5;
+        return;
+    }
+
+    switch (geometry_mode()) {
+    case GeometryMode::Point:
+        m_cursor_x = 0.5;
+        m_cursor_y = 0.5;
+        break;
+    case GeometryMode::Line: {
+        const int    total = std::accumulate(m_weights.begin(), m_weights.end(), 0);
+        const double t     = total > 0 && m_weights.size() >= 2 ? double(std::max(0, m_weights[1])) / double(total) : 0.5;
+        m_cursor_x         = std::clamp(t, 0.0, 1.0);
+        m_cursor_y         = 0.5;
+        m_weights          = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
+        break;
+    }
+    case GeometryMode::Triangle: {
+        const Vec2 point = triangle_point_from_weights();
+        m_cursor_x       = point.x;
+        m_cursor_y       = point.y;
+        m_weights        = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
+        break;
+    }
+    case GeometryMode::TriangleWithCenter:
+    case GeometryMode::Radial: initialize_cursor_from_grid_search(); break;
+    }
+}
+
+void MixedFilamentColorMapPanel::emit_changed()
+{
+    wxCommandEvent evt(wxEVT_SLIDER, GetId());
+    evt.SetEventObject(this);
+    ProcessWindowEvent(evt);
+}
+
+void MixedFilamentColorMapPanel::update_from_mouse(const wxMouseEvent& evt, bool notify)
+{
+    const Vec2 point = clamp_point_to_geometry(normalized_point_from_mouse(evt));
+    m_cursor_x       = point.x;
+    m_cursor_y       = point.y;
+    m_weights        = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
+    Refresh();
+    if (notify)
+        emit_changed();
+}
+
+bool MixedFilamentColorMapPanel::cached_bitmap_matches(const wxSize& size, const wxColour& background) const
+{
+    return m_cached_bitmap.IsOk() && m_cached_bitmap_size == size && m_cached_background == background;
+}
+
+void MixedFilamentColorMapPanel::schedule_cached_bitmap_render()
+{
+    if (!m_render_timer.IsRunning())
+        m_render_timer.StartOnce(80);
+}
+
+void MixedFilamentColorMapPanel::invalidate_cached_bitmap()
+{
+    m_cached_bitmap      = wxBitmap();
+    m_cached_bitmap_size = wxSize();
+    m_cached_background  = wxColour();
+}
+
+bool MixedFilamentColorMapPanel::color_match_raw_weights_within_range(const std::vector<double>& weights, int min_component_percent)
+{
+    if (min_component_percent <= 0)
+        return true;
+
+    const double min_allowed     = double(std::clamp(min_component_percent, 0, 50));
+    int          active_components = 0;
+    for (const double weight : weights) {
+        if (weight <= 1e-4)
+            continue;
+        ++active_components;
+        if (weight * 100.0 + 1e-6 < min_allowed)
+            return false;
+    }
+    return active_components >= 2;
+}
+
+void MixedFilamentColorMapPanel::render_cached_bitmap(const wxSize& size, const wxColour& background)
+{
+    const int width  = size.GetWidth();
+    const int height = size.GetHeight();
+    if (width <= 0 || height <= 0)
+        return;
+
+    wxImage        image(width, height);
+    unsigned char* data = image.GetData();
+    if (data != nullptr) {
+        for (int y = 0; y < height; ++y) {
+            const double normalized_y = (height > 1) ? double(y) / double(height - 1) : 0.5;
+            for (int x = 0; x < width; ++x) {
+                const double normalized_x = (width > 1) ? double(x) / double(width - 1) : 0.5;
+                const int    data_idx     = (y * width + x) * 3;
+                bool         paint_pixel  = true;
+                if (geometry_mode() == GeometryMode::Triangle || geometry_mode() == GeometryMode::TriangleWithCenter)
+                    paint_pixel = point_in_triangle(make_vec(normalized_x, normalized_y), simplex_vertices());
+
+                const std::vector<double> raw_weights = raw_weights_from_pos(normalized_x, normalized_y);
+                wxColour                  color       = paint_pixel ? blend_multi_filament_mixer(m_colors, raw_weights) : background;
+                if (paint_pixel && m_min_component_percent > 0 &&
+                    !color_match_raw_weights_within_range(raw_weights, m_min_component_percent)) {
+                    const bool   stripe = (((x + y) / 8) % 2) == 0;
+                    const double factor = stripe ? 0.12 : 0.38;
+                    color = wxColour(static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Red()) * factor)), 0, 255)),
+                                     static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Green()) * factor)), 0, 255)),
+                                     static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Blue()) * factor)), 0, 255)));
+                }
+                data[data_idx + 0] = color.Red();
+                data[data_idx + 1] = color.Green();
+                data[data_idx + 2] = color.Blue();
+            }
+        }
+    }
+
+    m_cached_bitmap      = wxBitmap(image);
+    m_cached_bitmap_size = size;
+    m_cached_background  = background;
+}
+
+void MixedFilamentColorMapPanel::draw_cached_bitmap(wxAutoBufferedPaintDC& dc, const wxRect& rect)
+{
+    if (!m_cached_bitmap.IsOk())
+        return;
+
+    if (m_cached_bitmap_size == rect.GetSize()) {
+        dc.DrawBitmap(m_cached_bitmap, rect.GetLeft(), rect.GetTop(), false);
+        return;
+    }
+
+    wxMemoryDC memdc;
+    memdc.SelectObject(m_cached_bitmap);
+    dc.StretchBlit(rect.GetLeft(), rect.GetTop(), rect.GetWidth(), rect.GetHeight(), &memdc, 0, 0,
+                   m_cached_bitmap_size.GetWidth(), m_cached_bitmap_size.GetHeight());
+    memdc.SelectObject(wxNullBitmap);
+}
+
+void MixedFilamentColorMapPanel::on_paint(wxPaintEvent&)
+{
+    wxAutoBufferedPaintDC dc(this);
+    dc.SetBackground(wxBrush(GetBackgroundColour()));
+    dc.Clear();
+
+    const wxRect rect   = canvas_rect();
+    const int    width  = rect.GetWidth();
+    const int    height = rect.GetHeight();
+    if (width <= 0 || height <= 0)
+        return;
+
+    const wxColour background = canvas_background_color();
+    if (!cached_bitmap_matches(rect.GetSize(), background)) {
+        if (!m_cached_bitmap.IsOk())
+            render_cached_bitmap(rect.GetSize(), background);
+        else
+            schedule_cached_bitmap_render();
+    }
+
+    const bool is_triangle_mode = geometry_mode() == GeometryMode::Triangle ||
+                                  geometry_mode() == GeometryMode::TriangleWithCenter;
+
+    if (is_triangle_mode) {
+        const auto triangle  = simplex_vertices();
+        wxPoint    points[3] = {
+            wxPoint(rect.GetLeft() + int(std::lround(triangle[0].x * double(std::max(1, width - 1)))),
+                    rect.GetTop()  + int(std::lround(triangle[0].y * double(std::max(1, height - 1))))),
+            wxPoint(rect.GetLeft() + int(std::lround(triangle[1].x * double(std::max(1, width - 1)))),
+                    rect.GetTop()  + int(std::lround(triangle[1].y * double(std::max(1, height - 1))))),
+            wxPoint(rect.GetLeft() + int(std::lround(triangle[2].x * double(std::max(1, width - 1)))),
+                    rect.GetTop()  + int(std::lround(triangle[2].y * double(std::max(1, height - 1)))))};
+
+        dc.SetClippingRegion(wxRegion(3, points));
+        draw_cached_bitmap(dc, rect);
+        dc.DestroyClippingRegion();
+
+        dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
+        dc.SetBrush(*wxTRANSPARENT_BRUSH);
+        dc.DrawPolygon(3, points);
+
+        if (geometry_mode() == GeometryMode::TriangleWithCenter) {
+            const Vec2    center = simplex_center();
+            const wxPoint center_pt(rect.GetLeft() + int(std::lround(center.x * double(std::max(1, width - 1)))),
+                                    rect.GetTop()  + int(std::lround(center.y * double(std::max(1, height - 1)))));
+            dc.SetPen(wxPen(wxColour(180, 180, 180), 1, wxPENSTYLE_DOT));
+            for (const wxPoint& vertex : points)
+                dc.DrawLine(center_pt, vertex);
+        }
+    } else {
+        draw_cached_bitmap(dc, rect);
+        dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
+        dc.SetBrush(*wxTRANSPARENT_BRUSH);
+        dc.DrawRectangle(rect);
+    }
+
+    dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+
+    const auto anchors = anchor_points();
+    for (size_t idx = 0; idx < anchors.size() && idx < m_colors.size(); ++idx) {
+        const int anchor_x = rect.GetLeft() + int(std::lround(anchors[idx].x * double(std::max(1, width - 1))));
+        const int anchor_y = rect.GetTop()  + int(std::lround(anchors[idx].y * double(std::max(1, height - 1))));
+        dc.SetPen(wxPen(wxColour(30, 30, 30), 1));
+        dc.SetBrush(wxBrush(m_colors[idx]));
+        dc.DrawCircle(wxPoint(anchor_x, anchor_y), FromDIP(4));
+    }
+
+    const int cursor_x = rect.GetLeft() + int(std::lround(m_cursor_x * double(std::max(1, width - 1))));
+    const int cursor_y = rect.GetTop()  + int(std::lround(m_cursor_y * double(std::max(1, height - 1))));
+    dc.SetPen(wxPen(wxColour(255, 255, 255), 3));
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.DrawCircle(wxPoint(cursor_x, cursor_y), FromDIP(7));
+    dc.SetPen(wxPen(wxColour(30, 30, 30), 1));
+    dc.DrawCircle(wxPoint(cursor_x, cursor_y), FromDIP(7));
+}
+
+void MixedFilamentColorMapPanel::on_left_down(wxMouseEvent& evt)
+{
+    if (!HasCapture())
+        CaptureMouse();
+    m_dragging = true;
+    update_from_mouse(evt, true);
+}
+
+void MixedFilamentColorMapPanel::on_left_up(wxMouseEvent& evt)
+{
+    if (m_dragging)
+        update_from_mouse(evt, true);
+    m_dragging = false;
+    if (HasCapture())
+        ReleaseMouse();
+}
+
+void MixedFilamentColorMapPanel::on_mouse_move(wxMouseEvent& evt)
+{
+    if (m_dragging && evt.LeftIsDown())
+        update_from_mouse(evt, true);
+}
+
+void MixedFilamentColorMapPanel::on_capture_lost(wxMouseCaptureLostEvent&) { m_dragging = false; }
+
+void MixedFilamentColorMapPanel::on_size(wxSizeEvent& evt)
+{
+    if (m_cached_bitmap.IsOk())
+        schedule_cached_bitmap_render();
+    Refresh(false);
+    evt.Skip();
+}
+
+void MixedFilamentColorMapPanel::on_render_timer(wxTimerEvent&)
+{
+    const wxRect rect = canvas_rect();
+    render_cached_bitmap(rect.GetSize(), canvas_background_color());
+    Refresh(false);
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedFilamentColorMapPanel.hpp
+++ b/src/slic3r/GUI/MixedFilamentColorMapPanel.hpp
@@ -9,49 +9,7 @@
 #include <vector>
 
 namespace Slic3r { namespace GUI {
-inline wxColour blend_multi_filament_mixer(const std::vector<wxColour>& colors, const std::vector<double>& weights)
-{
-    if (colors.empty() || weights.empty())
-        return wxColour("#26A69A");
-
-    unsigned char out_r              = 0;
-    unsigned char out_g              = 0;
-    unsigned char out_b              = 0;
-    double        accumulated_weight = 0.0;
-    bool          has_color          = false;
-
-    for (size_t i = 0; i < colors.size() && i < weights.size(); ++i) {
-        const double weight = std::max(0.0, weights[i]);
-        if (weight <= 0.0)
-            continue;
-
-        const wxColour      safe = colors[i].IsOk() ? colors[i] : wxColour("#26A69A");
-        const unsigned char r    = static_cast<unsigned char>(safe.Red());
-        const unsigned char g    = static_cast<unsigned char>(safe.Green());
-        const unsigned char b    = static_cast<unsigned char>(safe.Blue());
-
-        if (!has_color) {
-            out_r              = r;
-            out_g              = g;
-            out_b              = b;
-            accumulated_weight = weight;
-            has_color          = true;
-            continue;
-        }
-
-        const double new_total = accumulated_weight + weight;
-        if (new_total <= 0.0)
-            continue;
-        const float t = float(weight / new_total);
-        ::Slic3r::filament_mixer_lerp(out_r, out_g, out_b, r, g, b, t, &out_r, &out_g, &out_b);
-        accumulated_weight = new_total;
-    }
-
-    if (!has_color)
-        return wxColour("#26A69A");
-
-    return wxColour(out_r, out_g, out_b);
-}
+wxColour blend_multi_filament_mixer(const std::vector<wxColour>& colors, const std::vector<double>& weights);
 
 class MixedFilamentColorMapPanel : public wxPanel
 {
@@ -60,71 +18,17 @@ public:
                                const std::vector<unsigned int>& filament_ids,
                                const std::vector<wxColour>&     palette,
                                const std::vector<int>&          initial_weights,
-                               const wxSize&                    min_size)
-        : wxPanel(parent, wxID_ANY, wxDefaultPosition, min_size, wxBORDER_SIMPLE)
-    {
-        SetBackgroundStyle(wxBG_STYLE_PAINT);
-        SetMinSize(min_size);
-        m_render_timer.SetOwner(this);
+                               const wxSize&                    min_size);
 
-        m_colors.reserve(filament_ids.size());
-        for (const unsigned int filament_id : filament_ids) {
-            if (filament_id >= 1 && filament_id <= palette.size())
-                m_colors.emplace_back(palette[filament_id - 1]);
-            else
-                m_colors.emplace_back(wxColour("#26A69A"));
-        }
-        if (m_colors.empty())
-            m_colors.emplace_back(wxColour("#26A69A"));
-
-        set_normalized_weights(initial_weights, false);
-
-        Bind(wxEVT_PAINT, &MixedFilamentColorMapPanel::on_paint, this);
-        Bind(wxEVT_LEFT_DOWN, &MixedFilamentColorMapPanel::on_left_down, this);
-        Bind(wxEVT_LEFT_UP, &MixedFilamentColorMapPanel::on_left_up, this);
-        Bind(wxEVT_MOTION, &MixedFilamentColorMapPanel::on_mouse_move, this);
-        Bind(wxEVT_MOUSE_CAPTURE_LOST, &MixedFilamentColorMapPanel::on_capture_lost, this);
-        Bind(wxEVT_SIZE, &MixedFilamentColorMapPanel::on_size, this);
-        Bind(wxEVT_TIMER, &MixedFilamentColorMapPanel::on_render_timer, this, m_render_timer.GetId());
-    }
-
-    ~MixedFilamentColorMapPanel() override
-    {
-        if (HasCapture())
-            ReleaseMouse();
-        if (m_render_timer.IsRunning())
-            m_render_timer.Stop();
-    }
+    ~MixedFilamentColorMapPanel() override;
 
     std::vector<int> normalized_weights() const { return m_weights; }
 
-    wxColour selected_color() const
-    {
-        std::vector<double> weights;
-        weights.reserve(m_weights.size());
-        for (const int weight : m_weights)
-            weights.emplace_back(double(std::max(0, weight)));
-        return blend_multi_filament_mixer(m_colors, weights);
-    }
+    wxColour selected_color() const;
 
-    void set_normalized_weights(const std::vector<int>& weights, bool notify)
-    {
-        m_weights = normalize_color_match_weights(weights, m_colors.size());
-        initialize_cursor_from_weights();
-        Refresh();
-        if (notify)
-            emit_changed();
-    }
+    void set_normalized_weights(const std::vector<int>& weights, bool notify);
 
-    void set_min_component_percent(int min_component_percent)
-    {
-        const int clamped = std::clamp(min_component_percent, 0, 50);
-        if (m_min_component_percent == clamped)
-            return;
-        m_min_component_percent = clamped;
-        invalidate_cached_bitmap();
-        Refresh();
-    }
+    void set_min_component_percent(int min_component_percent);
 
 private:
     enum class GeometryMode { Point, Line, Triangle, TriangleWithCenter, Radial };
@@ -141,571 +45,57 @@ private:
         double y{0.0};
     };
 
-    GeometryMode geometry_mode() const
-    {
-        if (m_colors.size() <= 1)
-            return GeometryMode::Point;
-        if (m_colors.size() == 2)
-            return GeometryMode::Line;
-        if (m_colors.size() == 3)
-            return GeometryMode::Triangle;
-        if (m_colors.size() == 4)
-            return GeometryMode::TriangleWithCenter;
-        return GeometryMode::Radial;
-    }
+    GeometryMode geometry_mode() const;
 
-    wxRect canvas_rect() const
-    {
-        const wxSize size = GetClientSize();
-        return wxRect(0, 0, std::max(1, size.GetWidth()), std::max(1, size.GetHeight()));
-    }
+    wxRect canvas_rect() const;
 
     static Vec2 make_vec(double x, double y) { return Vec2{x, y}; }
-
     static Vec2 add_vec(const Vec2& lhs, const Vec2& rhs) { return Vec2{lhs.x + rhs.x, lhs.y + rhs.y}; }
-
     static Vec2 sub_vec(const Vec2& lhs, const Vec2& rhs) { return Vec2{lhs.x - rhs.x, lhs.y - rhs.y}; }
-
     static Vec2 scale_vec(const Vec2& value, double factor) { return Vec2{value.x * factor, value.y * factor}; }
-
     static double dot_vec(const Vec2& lhs, const Vec2& rhs) { return lhs.x * rhs.x + lhs.y * rhs.y; }
-
     static double length_sq(const Vec2& value) { return dot_vec(value, value); }
-
     static double dist_sq(const Vec2& lhs, const Vec2& rhs) { return length_sq(sub_vec(lhs, rhs)); }
 
-    std::array<Vec2, 3> simplex_vertices() const { return {make_vec(0.50, 0.05), make_vec(0.08, 0.94), make_vec(0.92, 0.94)}; }
+    std::array<Vec2, 3> simplex_vertices() const;
+    Vec2 simplex_center() const;
+    std::vector<AnchorPoint> radial_anchor_points() const;
+    std::vector<AnchorPoint> anchor_points() const;
 
-    Vec2 simplex_center() const
-    {
-        const auto vertices = simplex_vertices();
-        return make_vec((vertices[0].x + vertices[1].x + vertices[2].x) / 3.0, (vertices[0].y + vertices[1].y + vertices[2].y) / 3.0);
-    }
+    static std::array<double, 3> triangle_barycentric(const Vec2& point, const std::array<Vec2, 3>& triangle);
+    static bool point_in_triangle(const Vec2& point, const std::array<Vec2, 3>& triangle);
+    static Vec2 closest_point_on_segment(const Vec2& point, const Vec2& start, const Vec2& end);
+    static Vec2 closest_point_on_triangle(const Vec2& point, const std::array<Vec2, 3>& triangle);
 
-    std::vector<AnchorPoint> radial_anchor_points() const
-    {
-        std::vector<AnchorPoint> anchors;
-        const size_t             count = m_colors.size();
-        anchors.reserve(count);
-        if (count == 0)
-            return anchors;
-        if (count == 1) {
-            anchors.emplace_back(AnchorPoint{0.5, 0.5});
-            return anchors;
-        }
-        if (count == 2) {
-            anchors.emplace_back(AnchorPoint{0.0, 0.5});
-            anchors.emplace_back(AnchorPoint{1.0, 0.5});
-            return anchors;
-        }
-        if (count == 3) {
-            anchors.emplace_back(AnchorPoint{0.0, 0.5});
-            anchors.emplace_back(AnchorPoint{1.0, 0.0});
-            anchors.emplace_back(AnchorPoint{1.0, 1.0});
-            return anchors;
-        }
-        if (count == 4) {
-            anchors.emplace_back(AnchorPoint{0.0, 0.0});
-            anchors.emplace_back(AnchorPoint{1.0, 0.0});
-            anchors.emplace_back(AnchorPoint{1.0, 1.0});
-            anchors.emplace_back(AnchorPoint{0.0, 1.0});
-            return anchors;
-        }
+    Vec2 normalized_point_from_mouse(const wxMouseEvent& evt) const;
+    Vec2 clamp_point_to_geometry(const Vec2& point) const;
+    std::vector<double> simplex_weights_from_pos(const Vec2& point) const;
+    Vec2 triangle_point_from_weights() const;
+    void initialize_cursor_from_grid_search();
+    std::vector<double> raw_weights_from_pos(double normalized_x, double normalized_y) const;
+    std::vector<int> normalized_weights_from_pos(double normalized_x, double normalized_y) const;
+    void initialize_cursor_from_weights();
 
-        constexpr double k_pi     = 3.14159265358979323846;
-        const double     center_x = 0.5;
-        const double     center_y = 0.5;
-        const double     radius   = 0.45;
-        for (size_t idx = 0; idx < count; ++idx) {
-            const double angle = (2.0 * k_pi * double(idx)) / double(count);
-            anchors.emplace_back(AnchorPoint{center_x + radius * std::cos(angle), center_y + radius * std::sin(angle)});
-        }
-        return anchors;
-    }
-
-    std::vector<AnchorPoint> anchor_points() const
-    {
-        std::vector<AnchorPoint> anchors;
-        switch (geometry_mode()) {
-        case GeometryMode::Point: anchors.emplace_back(AnchorPoint{0.5, 0.5}); break;
-        case GeometryMode::Line:
-            anchors.emplace_back(AnchorPoint{0.06, 0.5});
-            anchors.emplace_back(AnchorPoint{0.94, 0.5});
-            break;
-        case GeometryMode::Triangle: {
-            const auto vertices = simplex_vertices();
-            for (const Vec2& vertex : vertices)
-                anchors.emplace_back(AnchorPoint{vertex.x, vertex.y});
-            break;
-        }
-        case GeometryMode::TriangleWithCenter: {
-            const auto vertices = simplex_vertices();
-            for (const Vec2& vertex : vertices)
-                anchors.emplace_back(AnchorPoint{vertex.x, vertex.y});
-            const Vec2 center = simplex_center();
-            anchors.emplace_back(AnchorPoint{center.x, center.y});
-            break;
-        }
-        case GeometryMode::Radial: anchors = radial_anchor_points(); break;
-        }
-        return anchors;
-    }
-
-    static std::array<double, 3> triangle_barycentric(const Vec2& point, const std::array<Vec2, 3>& triangle)
-    {
-        const Vec2&  a     = triangle[0];
-        const Vec2&  b     = triangle[1];
-        const Vec2&  c     = triangle[2];
-        const double denom = ((b.y - c.y) * (a.x - c.x) + (c.x - b.x) * (a.y - c.y));
-        if (std::abs(denom) <= 1e-9)
-            return {1.0, 0.0, 0.0};
-        const double w0 = ((b.y - c.y) * (point.x - c.x) + (c.x - b.x) * (point.y - c.y)) / denom;
-        const double w1 = ((c.y - a.y) * (point.x - c.x) + (a.x - c.x) * (point.y - c.y)) / denom;
-        const double w2 = 1.0 - w0 - w1;
-        return {w0, w1, w2};
-    }
-
-    static bool point_in_triangle(const Vec2& point, const std::array<Vec2, 3>& triangle)
-    {
-        const auto       barycentric = triangle_barycentric(point, triangle);
-        constexpr double eps         = 1e-6;
-        return barycentric[0] >= -eps && barycentric[1] >= -eps && barycentric[2] >= -eps;
-    }
-
-    static Vec2 closest_point_on_segment(const Vec2& point, const Vec2& start, const Vec2& end)
-    {
-        const Vec2   edge        = sub_vec(end, start);
-        const double edge_len_sq = length_sq(edge);
-        if (edge_len_sq <= 1e-9)
-            return start;
-        const double t = std::clamp(dot_vec(sub_vec(point, start), edge) / edge_len_sq, 0.0, 1.0);
-        return add_vec(start, scale_vec(edge, t));
-    }
-
-    static Vec2 closest_point_on_triangle(const Vec2& point, const std::array<Vec2, 3>& triangle)
-    {
-        if (point_in_triangle(point, triangle))
-            return point;
-
-        Vec2   best      = triangle[0];
-        double best_dist = std::numeric_limits<double>::max();
-        for (int edge_idx = 0; edge_idx < 3; ++edge_idx) {
-            const Vec2   candidate      = closest_point_on_segment(point, triangle[edge_idx], triangle[(edge_idx + 1) % 3]);
-            const double candidate_dist = dist_sq(point, candidate);
-            if (candidate_dist < best_dist) {
-                best_dist = candidate_dist;
-                best      = candidate;
-            }
-        }
-        return best;
-    }
-
-    Vec2 normalized_point_from_mouse(const wxMouseEvent& evt) const
-    {
-        const wxRect rect   = canvas_rect();
-        const int    width  = std::max(1, rect.GetWidth() - 1);
-        const int    height = std::max(1, rect.GetHeight() - 1);
-        return make_vec(std::clamp(double(evt.GetX() - rect.GetLeft()) / double(width), 0.0, 1.0),
-                        std::clamp(double(evt.GetY() - rect.GetTop()) / double(height), 0.0, 1.0));
-    }
-
-    Vec2 clamp_point_to_geometry(const Vec2& point) const
-    {
-        switch (geometry_mode()) {
-        case GeometryMode::Point: return make_vec(0.5, 0.5);
-        case GeometryMode::Line: return make_vec(std::clamp(point.x, 0.0, 1.0), 0.5);
-        case GeometryMode::Triangle:
-        case GeometryMode::TriangleWithCenter: return closest_point_on_triangle(point, simplex_vertices());
-        case GeometryMode::Radial: return make_vec(std::clamp(point.x, 0.0, 1.0), std::clamp(point.y, 0.0, 1.0));
-        }
-        return point;
-    }
-
-    std::vector<double> simplex_weights_from_pos(const Vec2& point) const
-    {
-        const auto triangle    = simplex_vertices();
-        const Vec2 clamped     = closest_point_on_triangle(point, triangle);
-        const auto barycentric = triangle_barycentric(clamped, triangle);
-
-        if (geometry_mode() == GeometryMode::Triangle)
-            return {std::max(0.0, barycentric[0]), std::max(0.0, barycentric[1]), std::max(0.0, barycentric[2])};
-
-        const double shared = std::max(0.0, std::min({barycentric[0], barycentric[1], barycentric[2]}));
-        return {std::max(0.0, barycentric[0] - shared), std::max(0.0, barycentric[1] - shared), std::max(0.0, barycentric[2] - shared),
-                std::max(0.0, shared * 3.0)};
-    }
-
-    Vec2 triangle_point_from_weights() const
-    {
-        const auto vertices = simplex_vertices();
-        double     total    = 0.0;
-        for (size_t idx = 0; idx < 3 && idx < m_weights.size(); ++idx)
-            total += std::max(0, m_weights[idx]);
-        if (total <= 0.0)
-            return simplex_center();
-
-        Vec2 out = make_vec(0.0, 0.0);
-        for (size_t idx = 0; idx < 3 && idx < m_weights.size(); ++idx) {
-            const double weight = double(std::max(0, m_weights[idx])) / total;
-            out                 = add_vec(out, scale_vec(vertices[idx], weight));
-        }
-        return out;
-    }
-
-    void initialize_cursor_from_grid_search()
-    {
-        double        best_x     = 0.5;
-        double        best_y     = 0.5;
-        double        best_error = std::numeric_limits<double>::max();
-        constexpr int grid       = 96;
-        for (int y_idx = 0; y_idx <= grid; ++y_idx) {
-            for (int x_idx = 0; x_idx <= grid; ++x_idx) {
-                const Vec2 point = clamp_point_to_geometry(make_vec(double(x_idx) / double(grid), double(y_idx) / double(grid)));
-                const std::vector<int> probe = normalized_weights_from_pos(point.x, point.y);
-                if (probe.size() != m_weights.size())
-                    continue;
-                double error = 0.0;
-                for (size_t idx = 0; idx < probe.size(); ++idx) {
-                    const double delta = double(probe[idx] - m_weights[idx]);
-                    error += delta * delta;
-                }
-                if (error < best_error) {
-                    best_error = error;
-                    best_x     = point.x;
-                    best_y     = point.y;
-                }
-            }
-        }
-        m_cursor_x = best_x;
-        m_cursor_y = best_y;
-        m_weights  = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
-    }
-
-    std::vector<double> raw_weights_from_pos(double normalized_x, double normalized_y) const
-    {
-        switch (geometry_mode()) {
-        case GeometryMode::Point: return {1.0};
-        case GeometryMode::Line: {
-            const double t = std::clamp(normalized_x, 0.0, 1.0);
-            return {1.0 - t, t};
-        }
-        case GeometryMode::Triangle:
-        case GeometryMode::TriangleWithCenter: return simplex_weights_from_pos(make_vec(normalized_x, normalized_y));
-        case GeometryMode::Radial: break;
-        }
-
-        const std::vector<AnchorPoint> anchors = radial_anchor_points();
-        std::vector<double>            out(anchors.size(), 0.0);
-        if (anchors.empty())
-            return out;
-
-        constexpr double eps       = 1e-8;
-        size_t           exact_idx = size_t(-1);
-        for (size_t idx = 0; idx < anchors.size(); ++idx) {
-            const double dx = normalized_x - anchors[idx].x;
-            const double dy = normalized_y - anchors[idx].y;
-            const double d2 = dx * dx + dy * dy;
-            if (d2 <= eps) {
-                exact_idx = idx;
-                break;
-            }
-            out[idx] = 1.0 / std::max(1e-6, d2);
-        }
-        if (exact_idx != size_t(-1)) {
-            std::fill(out.begin(), out.end(), 0.0);
-            out[exact_idx] = 1.0;
-            return out;
-        }
-
-        double sum = 0.0;
-        for (const double value : out)
-            sum += value;
-        if (sum <= 0.0) {
-            out.assign(out.size(), 0.0);
-            out[0] = 1.0;
-            return out;
-        }
-        for (double& value : out)
-            value /= sum;
-        return out;
-    }
-
-    std::vector<int> normalized_weights_from_pos(double normalized_x, double normalized_y) const
-    {
-        std::vector<int>          raw_weights;
-        const std::vector<double> raw = raw_weights_from_pos(normalized_x, normalized_y);
-        raw_weights.reserve(raw.size());
-        for (const double value : raw)
-            raw_weights.emplace_back(std::max(0, int(std::lround(value * 100.0))));
-        return normalize_color_match_weights(raw_weights, raw.size());
-    }
-
-    void initialize_cursor_from_weights()
-    {
-        if (m_weights.empty()) {
-            m_cursor_x = 0.5;
-            m_cursor_y = 0.5;
-            return;
-        }
-
-        switch (geometry_mode()) {
-        case GeometryMode::Point:
-            m_cursor_x = 0.5;
-            m_cursor_y = 0.5;
-            break;
-        case GeometryMode::Line: {
-            const int    total = std::accumulate(m_weights.begin(), m_weights.end(), 0);
-            const double t     = total > 0 && m_weights.size() >= 2 ? double(std::max(0, m_weights[1])) / double(total) : 0.5;
-            m_cursor_x         = std::clamp(t, 0.0, 1.0);
-            m_cursor_y         = 0.5;
-            m_weights          = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
-            break;
-        }
-        case GeometryMode::Triangle: {
-            const Vec2 point = triangle_point_from_weights();
-            m_cursor_x       = point.x;
-            m_cursor_y       = point.y;
-            m_weights        = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
-            break;
-        }
-        case GeometryMode::TriangleWithCenter:
-        case GeometryMode::Radial: initialize_cursor_from_grid_search(); break;
-        }
-    }
-
-    void emit_changed()
-    {
-        wxCommandEvent evt(wxEVT_SLIDER, GetId());
-        evt.SetEventObject(this);
-        ProcessWindowEvent(evt);
-    }
-
-    void update_from_mouse(const wxMouseEvent& evt, bool notify)
-    {
-        const Vec2 point = clamp_point_to_geometry(normalized_point_from_mouse(evt));
-        m_cursor_x       = point.x;
-        m_cursor_y       = point.y;
-        m_weights        = normalized_weights_from_pos(m_cursor_x, m_cursor_y);
-        Refresh();
-        if (notify)
-            emit_changed();
-    }
+    void emit_changed();
+    void update_from_mouse(const wxMouseEvent& evt, bool notify);
 
     wxColour canvas_background_color() const { return GetBackgroundColour().IsOk() ? GetBackgroundColour() : wxColour(245, 245, 245); }
 
-    bool cached_bitmap_matches(const wxSize& size, const wxColour& background) const
-    {
-        return m_cached_bitmap.IsOk() && m_cached_bitmap_size == size && m_cached_background == background;
-    }
+    bool cached_bitmap_matches(const wxSize& size, const wxColour& background) const;
+    void schedule_cached_bitmap_render();
+    void invalidate_cached_bitmap();
+    bool color_match_raw_weights_within_range(const std::vector<double>& weights, int min_component_percent);
+    void render_cached_bitmap(const wxSize& size, const wxColour& background);
+    void draw_cached_bitmap(wxAutoBufferedPaintDC& dc, const wxRect& rect);
 
-    void schedule_cached_bitmap_render()
-    {
-        if (!m_render_timer.IsRunning())
-            m_render_timer.StartOnce(80);
-    }
+    void on_paint(wxPaintEvent&);
+    void on_left_down(wxMouseEvent& evt);
+    void on_left_up(wxMouseEvent& evt);
+    void on_mouse_move(wxMouseEvent& evt);
+    void on_capture_lost(wxMouseCaptureLostEvent&);
+    void on_size(wxSizeEvent& evt);
+    void on_render_timer(wxTimerEvent&);
 
-    void invalidate_cached_bitmap()
-    {
-        m_cached_bitmap      = wxBitmap();
-        m_cached_bitmap_size = wxSize();
-        m_cached_background  = wxColour();
-    }
-
-    bool color_match_raw_weights_within_range(const std::vector<double> &weights, int min_component_percent)
-    {
-        if (min_component_percent <= 0)
-            return true;
-
-        const double min_allowed = double(std::clamp(min_component_percent, 0, 50));
-        int active_components = 0;
-        for (const double weight : weights) {
-            if (weight <= 1e-4)
-                continue;
-            ++active_components;
-            if (weight * 100.0 + 1e-6 < min_allowed)
-                return false;
-        }
-        return active_components >= 2;
-    }
-
-    void render_cached_bitmap(const wxSize& size, const wxColour& background)
-    {
-        const int width  = size.GetWidth();
-        const int height = size.GetHeight();
-        if (width <= 0 || height <= 0)
-            return;
-
-        wxImage        image(width, height);
-        unsigned char* data = image.GetData();
-        if (data != nullptr) {
-            for (int y = 0; y < height; ++y) {
-                const double normalized_y = (height > 1) ? double(y) / double(height - 1) : 0.5;
-                for (int x = 0; x < width; ++x) {
-                    const double normalized_x = (width > 1) ? double(x) / double(width - 1) : 0.5;
-                    const int    data_idx     = (y * width + x) * 3;
-                    bool         paint_pixel  = true;
-                    if (geometry_mode() == GeometryMode::Triangle || geometry_mode() == GeometryMode::TriangleWithCenter)
-                        paint_pixel = point_in_triangle(make_vec(normalized_x, normalized_y), simplex_vertices());
-
-                    const std::vector<double> raw_weights = raw_weights_from_pos(normalized_x, normalized_y);
-                    wxColour                  color       = paint_pixel ? blend_multi_filament_mixer(m_colors, raw_weights) : background;
-                    if (paint_pixel && m_min_component_percent > 0 &&
-                        !color_match_raw_weights_within_range(raw_weights, m_min_component_percent)) {
-                        const bool   stripe = (((x + y) / 8) % 2) == 0;
-                        const double factor = stripe ? 0.12 : 0.38;
-                        color = wxColour(static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Red()) * factor)), 0, 255)),
-                                         static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Green()) * factor)), 0, 255)),
-                                         static_cast<unsigned char>(std::clamp(int(std::lround(double(color.Blue()) * factor)), 0, 255)));
-                    }
-                    data[data_idx + 0] = color.Red();
-                    data[data_idx + 1] = color.Green();
-                    data[data_idx + 2] = color.Blue();
-                }
-            }
-        }
-
-        m_cached_bitmap      = wxBitmap(image);
-        m_cached_bitmap_size = size;
-        m_cached_background  = background;
-    }
-
-    void draw_cached_bitmap(wxAutoBufferedPaintDC& dc, const wxRect& rect)
-    {
-        if (!m_cached_bitmap.IsOk())
-            return;
-
-        if (m_cached_bitmap_size == rect.GetSize()) {
-            dc.DrawBitmap(m_cached_bitmap, rect.GetLeft(), rect.GetTop(), false);
-            return;
-        }
-
-        wxMemoryDC memdc;
-        memdc.SelectObject(m_cached_bitmap);
-        dc.StretchBlit(rect.GetLeft(), rect.GetTop(), rect.GetWidth(), rect.GetHeight(), &memdc, 0, 0, m_cached_bitmap_size.GetWidth(),
-                       m_cached_bitmap_size.GetHeight());
-        memdc.SelectObject(wxNullBitmap);
-    }
-
-    void on_paint(wxPaintEvent&)
-    {
-        wxAutoBufferedPaintDC dc(this);
-        dc.SetBackground(wxBrush(GetBackgroundColour()));
-        dc.Clear();
-
-        const wxRect rect   = canvas_rect();
-        const int    width  = rect.GetWidth();
-        const int    height = rect.GetHeight();
-        if (width <= 0 || height <= 0)
-            return;
-
-        const wxColour background = canvas_background_color();
-        if (!cached_bitmap_matches(rect.GetSize(), background)) {
-            if (!m_cached_bitmap.IsOk())
-                render_cached_bitmap(rect.GetSize(), background);
-            else
-                schedule_cached_bitmap_render();
-        }
-
-        const bool is_triangle_mode = geometry_mode() == GeometryMode::Triangle ||
-                                      geometry_mode() == GeometryMode::TriangleWithCenter;
-
-        if (is_triangle_mode) {
-            const auto triangle = simplex_vertices();
-            wxPoint    points[3] = {
-                wxPoint(rect.GetLeft() + int(std::lround(triangle[0].x * double(std::max(1, width - 1)))),
-                        rect.GetTop()  + int(std::lround(triangle[0].y * double(std::max(1, height - 1))))),
-                wxPoint(rect.GetLeft() + int(std::lround(triangle[1].x * double(std::max(1, width - 1)))),
-                        rect.GetTop()  + int(std::lround(triangle[1].y * double(std::max(1, height - 1))))),
-                wxPoint(rect.GetLeft() + int(std::lround(triangle[2].x * double(std::max(1, width - 1)))),
-                        rect.GetTop()  + int(std::lround(triangle[2].y * double(std::max(1, height - 1)))))};
-
-            // Clip bitmap to triangle; dc.Clear() already filled outside with background.
-            dc.SetClippingRegion(wxRegion(3, points));
-            draw_cached_bitmap(dc, rect);
-            dc.DestroyClippingRegion();
-
-            // Triangle outline.
-            dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
-            dc.SetBrush(*wxTRANSPARENT_BRUSH);
-            dc.DrawPolygon(3, points);
-
-            if (geometry_mode() == GeometryMode::TriangleWithCenter) {
-                const Vec2    center = simplex_center();
-                const wxPoint center_pt(rect.GetLeft() + int(std::lround(center.x * double(std::max(1, width - 1)))),
-                                        rect.GetTop()  + int(std::lround(center.y * double(std::max(1, height - 1)))));
-                dc.SetPen(wxPen(wxColour(180, 180, 180), 1, wxPENSTYLE_DOT));
-                for (const wxPoint& vertex : points)
-                    dc.DrawLine(center_pt, vertex);
-            }
-        } else {
-            draw_cached_bitmap(dc, rect);
-            dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
-            dc.SetBrush(*wxTRANSPARENT_BRUSH);
-            dc.DrawRectangle(rect);
-        }
-
-        dc.SetPen(wxPen(wxColour(160, 160, 160), 1));
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-
-        const auto anchors = anchor_points();
-        for (size_t idx = 0; idx < anchors.size() && idx < m_colors.size(); ++idx) {
-            const int anchor_x = rect.GetLeft() + int(std::lround(anchors[idx].x * double(std::max(1, width - 1))));
-            const int anchor_y = rect.GetTop()  + int(std::lround(anchors[idx].y * double(std::max(1, height - 1))));
-            dc.SetPen(wxPen(wxColour(30, 30, 30), 1));
-            dc.SetBrush(wxBrush(m_colors[idx]));
-            dc.DrawCircle(wxPoint(anchor_x, anchor_y), FromDIP(4));
-        }
-
-        const int cursor_x = rect.GetLeft() + int(std::lround(m_cursor_x * double(std::max(1, width - 1))));
-        const int cursor_y = rect.GetTop()  + int(std::lround(m_cursor_y * double(std::max(1, height - 1))));
-        dc.SetPen(wxPen(wxColour(255, 255, 255), 3));
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.DrawCircle(wxPoint(cursor_x, cursor_y), FromDIP(7));
-        dc.SetPen(wxPen(wxColour(30, 30, 30), 1));
-        dc.DrawCircle(wxPoint(cursor_x, cursor_y), FromDIP(7));
-    }
-
-    void on_left_down(wxMouseEvent& evt)
-    {
-        if (!HasCapture())
-            CaptureMouse();
-        m_dragging = true;
-        update_from_mouse(evt, true);
-    }
-
-    void on_left_up(wxMouseEvent& evt)
-    {
-        if (m_dragging)
-            update_from_mouse(evt, true);
-        m_dragging = false;
-        if (HasCapture())
-            ReleaseMouse();
-    }
-
-    void on_mouse_move(wxMouseEvent& evt)
-    {
-        if (m_dragging && evt.LeftIsDown())
-            update_from_mouse(evt, true);
-    }
-
-    void on_capture_lost(wxMouseCaptureLostEvent&) { m_dragging = false; }
-
-    void on_size(wxSizeEvent& evt)
-    {
-        if (m_cached_bitmap.IsOk())
-            schedule_cached_bitmap_render();
-        Refresh(false);
-        evt.Skip();
-    }
-
-    void on_render_timer(wxTimerEvent&)
-    {
-        const wxRect rect = canvas_rect();
-        render_cached_bitmap(rect.GetSize(), canvas_background_color());
-        Refresh(false);
-    }
-
-private:
     std::vector<wxColour> m_colors;
     std::vector<int>      m_weights;
     wxBitmap              m_cached_bitmap;

--- a/src/slic3r/GUI/MixedGradientSelector.cpp
+++ b/src/slic3r/GUI/MixedGradientSelector.cpp
@@ -1,0 +1,181 @@
+#include "MixedGradientSelector.hpp"
+
+namespace Slic3r { namespace GUI {
+
+wxColour blend_pair_filament_mixer(const wxColour &left, const wxColour &right, float t)
+{
+    const wxColour safe_left  = left.IsOk()  ? left  : wxColour("#26A69A");
+    const wxColour safe_right = right.IsOk() ? right : wxColour("#26A69A");
+
+    unsigned char out_r = static_cast<unsigned char>(safe_left.Red());
+    unsigned char out_g = static_cast<unsigned char>(safe_left.Green());
+    unsigned char out_b = static_cast<unsigned char>(safe_left.Blue());
+    ::Slic3r::filament_mixer_lerp(
+        static_cast<unsigned char>(safe_left.Red()),
+        static_cast<unsigned char>(safe_left.Green()),
+        static_cast<unsigned char>(safe_left.Blue()),
+        static_cast<unsigned char>(safe_right.Red()),
+        static_cast<unsigned char>(safe_right.Green()),
+        static_cast<unsigned char>(safe_right.Blue()),
+        std::clamp(t, 0.f, 1.f),
+        &out_r, &out_g, &out_b);
+    return wxColour(out_r, out_g, out_b);
+}
+
+wxRect MixedGradientSelector::gradient_rect() const
+{
+    const int margin_x = FromDIP(2);
+    const int margin_y = FromDIP(1);
+    const wxSize sz = GetClientSize();
+    return wxRect(margin_x, margin_y,
+                  std::max(1, sz.GetWidth()  - margin_x * 2),
+                  std::max(1, sz.GetHeight() - margin_y * 2));
+}
+
+int MixedGradientSelector::value_from_x(int x) const
+{
+    const wxRect rect = gradient_rect();
+    const int min_x   = rect.GetLeft();
+    const int max_x   = rect.GetLeft() + rect.GetWidth();
+    const int cx      = std::clamp(x, min_x, max_x);
+    return ((cx - min_x) * 100 + rect.GetWidth() / 2) / rect.GetWidth();
+}
+
+void MixedGradientSelector::update_from_x(int x, bool notify)
+{
+    m_value = value_from_x(x);
+    Refresh();
+    if (notify) {
+        wxCommandEvent evt(wxEVT_SLIDER, GetId());
+        evt.SetInt(m_value);
+        evt.SetEventObject(this);
+        ProcessWindowEvent(evt);
+    }
+}
+
+void MixedGradientSelector::on_paint(wxPaintEvent &)
+{
+    wxAutoBufferedPaintDC dc(this);
+    dc.SetBackground(wxBrush(GetBackgroundColour()));
+    dc.Clear();
+    const bool is_dark = wxGetApp().dark_mode();
+
+    const wxRect rect = gradient_rect();
+    if (m_multi_mode && m_multi_colors.size() >= 3) {
+        const wxPoint tl(rect.GetLeft(),  rect.GetTop());
+        const wxPoint tr(rect.GetRight(), rect.GetTop());
+        const wxPoint br(rect.GetRight(), rect.GetBottom());
+        const wxPoint bl(rect.GetLeft(),  rect.GetBottom());
+        const wxPoint cc(rect.GetLeft() + rect.GetWidth() / 2,
+                         rect.GetTop()  + rect.GetHeight() / 2);
+        auto draw_tri = [&dc](const wxColour &color,
+                              const wxPoint &a, const wxPoint &b, const wxPoint &c) {
+            wxPoint pts[3] = {a, b, c};
+            dc.SetPen(*wxTRANSPARENT_PEN);
+            dc.SetBrush(wxBrush(color));
+            dc.DrawPolygon(3, pts);
+        };
+        if (m_multi_colors.size() >= 4) {
+            draw_tri(m_multi_colors[0], tl, tr, cc);
+            draw_tri(m_multi_colors[1], tr, br, cc);
+            draw_tri(m_multi_colors[2], br, bl, cc);
+            draw_tri(m_multi_colors[3], bl, tl, cc);
+        } else {
+            draw_tri(m_multi_colors[0], tl, bl, cc);
+            draw_tri(m_multi_colors[1], tl, tr, cc);
+            draw_tri(m_multi_colors[2], bl, br, cc);
+        }
+        if (m_multi_weights.size() == m_multi_colors.size()) {
+            dc.SetTextForeground(is_dark ? wxColour(236,236,236) : wxColour(20,20,20));
+            dc.SetFont(Label::Body_10);
+            const int pad = FromDIP(2);
+            if (m_multi_colors.size() >= 4) {
+                dc.DrawText(wxString::Format("%d%%", m_multi_weights[0]), rect.GetLeft()  + pad,          rect.GetTop()    + pad);
+                dc.DrawText(wxString::Format("%d%%", m_multi_weights[1]), rect.GetRight() - FromDIP(28),  rect.GetTop()    + pad);
+                dc.DrawText(wxString::Format("%d%%", m_multi_weights[2]), rect.GetRight() - FromDIP(28),  rect.GetBottom() - FromDIP(14));
+                dc.DrawText(wxString::Format("%d%%", m_multi_weights[3]), rect.GetLeft()  + pad,          rect.GetBottom() - FromDIP(14));
+            } else {
+                dc.DrawText(wxString::Format("%d%%", m_multi_weights[0]), rect.GetLeft()  + pad,         rect.GetTop() + rect.GetHeight()/2 - FromDIP(6));
+                dc.DrawText(wxString::Format("%d%%", m_multi_weights[1]), rect.GetRight() - FromDIP(28), rect.GetTop()    + pad);
+                dc.DrawText(wxString::Format("%d%%", m_multi_weights[2]), rect.GetRight() - FromDIP(28), rect.GetBottom() - FromDIP(14));
+            }
+        }
+    } else {
+        const int w = rect.GetWidth();
+        const int h = rect.GetHeight();
+        wxImage img(w, h);
+        unsigned char *data = img.GetData();
+        if (data != nullptr) {
+            for (int x = 0; x < w; ++x) {
+                const float t   = (w > 1) ? float(x) / float(w - 1) : 0.5f;
+                const wxColour col = blend_pair_filament_mixer(m_left, m_right, t);
+                const unsigned char r = static_cast<unsigned char>(col.Red());
+                const unsigned char g = static_cast<unsigned char>(col.Green());
+                const unsigned char b = static_cast<unsigned char>(col.Blue());
+                for (int y = 0; y < h; ++y) {
+                    const int idx = (y * w + x) * 3;
+                    data[idx + 0] = r;
+                    data[idx + 1] = g;
+                    data[idx + 2] = b;
+                }
+            }
+            dc.DrawBitmap(wxBitmap(img), rect.GetLeft(), rect.GetTop(), false);
+        } else {
+            dc.GradientFillLinear(rect, m_left, m_right, wxEAST);
+        }
+    }
+
+    dc.SetPen(wxPen(is_dark ? wxColour(100,100,106) : wxColour(170,170,170), 1));
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.DrawRectangle(rect);
+
+    if (m_multi_mode) {
+        dc.SetTextForeground(is_dark ? wxColour(236,236,236) : wxColour(30,30,30));
+        dc.SetFont(Label::Body_10);
+        const wxString hint = _L("Click to edit");
+        wxSize text_sz = dc.GetTextExtent(hint);
+        dc.DrawText(hint, rect.GetRight() - text_sz.GetWidth() - FromDIP(4), rect.GetTop() + FromDIP(2));
+        return;
+    }
+
+    int marker_x = rect.GetLeft() + (rect.GetWidth() * m_value + 50) / 100;
+    marker_x = std::clamp(marker_x, rect.GetLeft(), rect.GetRight());
+    dc.SetPen(wxPen(wxColour(255,255,255), 3));
+    dc.DrawLine(marker_x, rect.GetTop(), marker_x, rect.GetBottom());
+    dc.SetPen(wxPen(wxColour(33,33,33), 1));
+    dc.DrawLine(marker_x, rect.GetTop(), marker_x, rect.GetBottom());
+}
+
+void MixedGradientSelector::on_left_down(wxMouseEvent &evt)
+{
+    if (m_multi_mode) return;
+    if (!HasCapture()) CaptureMouse();
+    m_dragging = true;
+    update_from_x(evt.GetX(), false);
+}
+
+void MixedGradientSelector::on_left_up(wxMouseEvent &evt)
+{
+    if (m_multi_mode) {
+        wxCommandEvent click_evt(wxEVT_BUTTON, GetId());
+        click_evt.SetEventObject(this);
+        ProcessWindowEvent(click_evt);
+        return;
+    }
+    if (m_dragging) update_from_x(evt.GetX(), true);
+    m_dragging = false;
+    if (HasCapture()) ReleaseMouse();
+}
+
+void MixedGradientSelector::on_mouse_move(wxMouseEvent &evt)
+{
+    if (m_dragging && evt.LeftIsDown())
+        update_from_x(evt.GetX(), false);
+}
+
+void MixedGradientSelector::on_capture_lost(wxMouseCaptureLostEvent &) 
+{ 
+    m_dragging = false; 
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedGradientSelector.hpp
+++ b/src/slic3r/GUI/MixedGradientSelector.hpp
@@ -13,25 +13,7 @@
 
 namespace Slic3r { namespace GUI {
 
-inline wxColour blend_pair_filament_mixer(const wxColour &left, const wxColour &right, float t)
-{
-    const wxColour safe_left  = left.IsOk()  ? left  : wxColour("#26A69A");
-    const wxColour safe_right = right.IsOk() ? right : wxColour("#26A69A");
-
-    unsigned char out_r = static_cast<unsigned char>(safe_left.Red());
-    unsigned char out_g = static_cast<unsigned char>(safe_left.Green());
-    unsigned char out_b = static_cast<unsigned char>(safe_left.Blue());
-    ::Slic3r::filament_mixer_lerp(
-        static_cast<unsigned char>(safe_left.Red()),
-        static_cast<unsigned char>(safe_left.Green()),
-        static_cast<unsigned char>(safe_left.Blue()),
-        static_cast<unsigned char>(safe_right.Red()),
-        static_cast<unsigned char>(safe_right.Green()),
-        static_cast<unsigned char>(safe_right.Blue()),
-        std::clamp(t, 0.f, 1.f),
-        &out_r, &out_g, &out_b);
-    return wxColour(out_r, out_g, out_b);
-}
+wxColour blend_pair_filament_mixer(const wxColour &left, const wxColour &right, float t);
 
 class MixedGradientSelector : public wxPanel
 {
@@ -57,8 +39,14 @@ public:
             ReleaseMouse();
     }
 
-    int  value()        const { return m_value; }
+    int  value()         const { return m_value; }
     bool is_multi_mode() const { return m_multi_mode; }
+
+    void set_value(int value_percent)
+    {
+        m_value = std::clamp(value_percent, 0, 100);
+        Refresh();
+    }
 
     void set_colors(const wxColour &left, const wxColour &right)
     {
@@ -79,158 +67,15 @@ public:
     }
 
 private:
-    wxRect gradient_rect() const
-    {
-        const int margin_x = FromDIP(2);
-        const int margin_y = FromDIP(1);
-        const wxSize sz = GetClientSize();
-        return wxRect(margin_x, margin_y,
-                      std::max(1, sz.GetWidth()  - margin_x * 2),
-                      std::max(1, sz.GetHeight() - margin_y * 2));
-    }
+    wxRect gradient_rect() const;
+    int    value_from_x(int x) const;
+    void   update_from_x(int x, bool notify);
 
-    int value_from_x(int x) const
-    {
-        const wxRect rect = gradient_rect();
-        const int min_x   = rect.GetLeft();
-        const int max_x   = rect.GetLeft() + rect.GetWidth();
-        const int cx      = std::clamp(x, min_x, max_x);
-        return ((cx - min_x) * 100 + rect.GetWidth() / 2) / rect.GetWidth();
-    }
-
-    void update_from_x(int x, bool notify)
-    {
-        m_value = value_from_x(x);
-        Refresh();
-        if (notify) {
-            wxCommandEvent evt(wxEVT_SLIDER, GetId());
-            evt.SetInt(m_value);
-            evt.SetEventObject(this);
-            ProcessWindowEvent(evt);
-        }
-    }
-
-    void on_paint(wxPaintEvent &)
-    {
-        wxAutoBufferedPaintDC dc(this);
-        dc.SetBackground(wxBrush(GetBackgroundColour()));
-        dc.Clear();
-        const bool is_dark = wxGetApp().dark_mode();
-
-        const wxRect rect = gradient_rect();
-        if (m_multi_mode && m_multi_colors.size() >= 3) {
-            const wxPoint tl(rect.GetLeft(),  rect.GetTop());
-            const wxPoint tr(rect.GetRight(), rect.GetTop());
-            const wxPoint br(rect.GetRight(), rect.GetBottom());
-            const wxPoint bl(rect.GetLeft(),  rect.GetBottom());
-            const wxPoint cc(rect.GetLeft() + rect.GetWidth() / 2,
-                             rect.GetTop()  + rect.GetHeight() / 2);
-            auto draw_tri = [&dc](const wxColour &color,
-                                  const wxPoint &a, const wxPoint &b, const wxPoint &c) {
-                wxPoint pts[3] = {a, b, c};
-                dc.SetPen(*wxTRANSPARENT_PEN);
-                dc.SetBrush(wxBrush(color));
-                dc.DrawPolygon(3, pts);
-            };
-            if (m_multi_colors.size() >= 4) {
-                draw_tri(m_multi_colors[0], tl, tr, cc);
-                draw_tri(m_multi_colors[1], tr, br, cc);
-                draw_tri(m_multi_colors[2], br, bl, cc);
-                draw_tri(m_multi_colors[3], bl, tl, cc);
-            } else {
-                draw_tri(m_multi_colors[0], tl, bl, cc);
-                draw_tri(m_multi_colors[1], tl, tr, cc);
-                draw_tri(m_multi_colors[2], bl, br, cc);
-            }
-            if (m_multi_weights.size() == m_multi_colors.size()) {
-                dc.SetTextForeground(is_dark ? wxColour(236,236,236) : wxColour(20,20,20));
-                dc.SetFont(Label::Body_10);
-                const int pad = FromDIP(2);
-                if (m_multi_colors.size() >= 4) {
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[0]), rect.GetLeft()  + pad,          rect.GetTop()    + pad);
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[1]), rect.GetRight() - FromDIP(28),  rect.GetTop()    + pad);
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[2]), rect.GetRight() - FromDIP(28),  rect.GetBottom() - FromDIP(14));
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[3]), rect.GetLeft()  + pad,          rect.GetBottom() - FromDIP(14));
-                } else {
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[0]), rect.GetLeft()  + pad,         rect.GetTop() + rect.GetHeight()/2 - FromDIP(6));
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[1]), rect.GetRight() - FromDIP(28), rect.GetTop()    + pad);
-                    dc.DrawText(wxString::Format("%d%%", m_multi_weights[2]), rect.GetRight() - FromDIP(28), rect.GetBottom() - FromDIP(14));
-                }
-            }
-        } else {
-            const int w = rect.GetWidth();
-            const int h = rect.GetHeight();
-            wxImage img(w, h);
-            unsigned char *data = img.GetData();
-            if (data != nullptr) {
-                for (int x = 0; x < w; ++x) {
-                    const float t   = (w > 1) ? float(x) / float(w - 1) : 0.5f;
-                    const wxColour col = blend_pair_filament_mixer(m_left, m_right, t);
-                    const unsigned char r = static_cast<unsigned char>(col.Red());
-                    const unsigned char g = static_cast<unsigned char>(col.Green());
-                    const unsigned char b = static_cast<unsigned char>(col.Blue());
-                    for (int y = 0; y < h; ++y) {
-                        const int idx = (y * w + x) * 3;
-                        data[idx + 0] = r;
-                        data[idx + 1] = g;
-                        data[idx + 2] = b;
-                    }
-                }
-                dc.DrawBitmap(wxBitmap(img), rect.GetLeft(), rect.GetTop(), false);
-            } else {
-                dc.GradientFillLinear(rect, m_left, m_right, wxEAST);
-            }
-        }
-
-        dc.SetPen(wxPen(is_dark ? wxColour(100,100,106) : wxColour(170,170,170), 1));
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.DrawRectangle(rect);
-
-        if (m_multi_mode) {
-            dc.SetTextForeground(is_dark ? wxColour(236,236,236) : wxColour(30,30,30));
-            dc.SetFont(Label::Body_10);
-            const wxString hint = _L("Click to edit");
-            wxSize text_sz = dc.GetTextExtent(hint);
-            dc.DrawText(hint, rect.GetRight() - text_sz.GetWidth() - FromDIP(4), rect.GetTop() + FromDIP(2));
-            return;
-        }
-
-        int marker_x = rect.GetLeft() + (rect.GetWidth() * m_value + 50) / 100;
-        marker_x = std::clamp(marker_x, rect.GetLeft(), rect.GetRight());
-        dc.SetPen(wxPen(wxColour(255,255,255), 3));
-        dc.DrawLine(marker_x, rect.GetTop(), marker_x, rect.GetBottom());
-        dc.SetPen(wxPen(wxColour(33,33,33), 1));
-        dc.DrawLine(marker_x, rect.GetTop(), marker_x, rect.GetBottom());
-    }
-
-    void on_left_down(wxMouseEvent &evt)
-    {
-        if (m_multi_mode) return;
-        if (!HasCapture()) CaptureMouse();
-        m_dragging = true;
-        update_from_x(evt.GetX(), false);
-    }
-
-    void on_left_up(wxMouseEvent &evt)
-    {
-        if (m_multi_mode) {
-            wxCommandEvent click_evt(wxEVT_BUTTON, GetId());
-            click_evt.SetEventObject(this);
-            ProcessWindowEvent(click_evt);
-            return;
-        }
-        if (m_dragging) update_from_x(evt.GetX(), true);
-        m_dragging = false;
-        if (HasCapture()) ReleaseMouse();
-    }
-
-    void on_mouse_move(wxMouseEvent &evt)
-    {
-        if (m_dragging && evt.LeftIsDown())
-            update_from_x(evt.GetX(), false);
-    }
-
-    void on_capture_lost(wxMouseCaptureLostEvent &) { m_dragging = false; }
+    void on_paint(wxPaintEvent &);
+    void on_left_down(wxMouseEvent &evt);
+    void on_left_up(wxMouseEvent &evt);
+    void on_mouse_move(wxMouseEvent &evt);
+    void on_capture_lost(wxMouseCaptureLostEvent &);
 
     wxColour              m_left;
     wxColour              m_right;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -985,6 +985,526 @@ struct DynamicFilamentList1Based : DynamicFilamentList
 
 };
 
+class MixedFilamentColorMatchDialog : public DPIDialog
+{
+public:
+    MixedFilamentColorMatchDialog(wxWindow* parent, const std::vector<std::string>& physical_colors, const wxColour& initial_color)
+        : DPIDialog(parent ? parent : static_cast<wxWindow*>(wxGetApp().mainframe),
+                    wxID_ANY,
+                    _L("Add Color"),
+                    wxDefaultPosition,
+                    wxDefaultSize,
+                    wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+        , m_physical_colors(physical_colors)
+    {
+        m_recipe_timer.SetOwner(this);
+        m_loading_timer.SetOwner(this);
+        m_display_context = build_mixed_filament_display_context(m_physical_colors);
+
+        m_palette.reserve(m_physical_colors.size());
+        for (const std::string& hex : m_physical_colors)
+            m_palette.emplace_back(parse_mixed_color(hex));
+
+        const wxColour   safe_initial = initial_color.IsOk() ?
+                                            initial_color :
+                                            (m_palette.size() >= 2 ? blend_pair_filament_mixer(m_palette[0], m_palette[1], 0.5f) :
+                                                                     wxColour("#26A69A"));
+        std::vector<int> initial_weights(m_palette.size(), 0);
+        if (!initial_weights.empty())
+            initial_weights[0] = 100;
+        if (initial_weights.size() >= 2) {
+            initial_weights[0] = 50;
+            initial_weights[1] = 50;
+        }
+
+        std::vector<unsigned int> filament_ids;
+        filament_ids.reserve(m_palette.size());
+        for (size_t idx = 0; idx < m_palette.size(); ++idx)
+            filament_ids.emplace_back(unsigned(idx + 1));
+
+        SetMinSize(wxSize(FromDIP(430), FromDIP(520)));
+
+        auto* root        = new wxBoxSizer(wxVERTICAL);
+        auto* description = new wxStaticText(this, wxID_ANY,
+                                             _L("Pick from the current filament gamut. The dialog previews the closest 2-color, 3-color, "
+                                                "or 4-color FilamentMixer recipe before it is added."));
+        description->Wrap(FromDIP(390));
+        root->Add(description, 0, wxEXPAND | wxALL, FromDIP(12));
+
+        m_color_map = new MixedFilamentColorMapPanel(this, filament_ids, m_palette, initial_weights, wxSize(FromDIP(260), FromDIP(260)));
+        root->Add(m_color_map, 1, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(12));
+
+        auto* hex_row = new wxBoxSizer(wxHORIZONTAL);
+        hex_row->Add(new wxStaticText(this, wxID_ANY, _L("Hex")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+        m_hex_input = new wxTextCtrl(this, wxID_ANY, normalize_color_match_hex(safe_initial.GetAsString(wxC2S_HTML_SYNTAX)),
+                                     wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+        m_hex_input->SetToolTip(_L("Enter a hex color like #00FF88. The picker will snap to the closest supported FilamentMixer color."));
+        hex_row->Add(m_hex_input, 1, wxALIGN_CENTER_VERTICAL);
+        hex_row->AddSpacer(FromDIP(8));
+        m_classic_picker = new wxColourPickerCtrl(this, wxID_ANY, safe_initial);
+        m_classic_picker->SetToolTip(_L("Classic color picker. The result will snap to the closest supported FilamentMixer color."));
+        hex_row->Add(m_classic_picker, 0, wxALIGN_CENTER_VERTICAL);
+        root->Add(hex_row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
+
+        auto* range_row = new wxBoxSizer(wxHORIZONTAL);
+        range_row->Add(new wxStaticText(this, wxID_ANY, _L("Range")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+        m_range_slider = new wxSlider(this, wxID_ANY, m_min_component_percent, 0, 50);
+        m_range_slider->SetToolTip(_L("Minimum percent for each participating color. Higher values block highly skewed mixes."));
+        range_row->Add(m_range_slider, 1, wxALIGN_CENTER_VERTICAL);
+        range_row->AddSpacer(FromDIP(8));
+        m_range_value = new wxStaticText(this, wxID_ANY, wxEmptyString);
+        range_row->Add(m_range_value, 0, wxALIGN_CENTER_VERTICAL);
+        root->Add(range_row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
+
+        auto* summary_grid = new wxFlexGridSizer(2, FromDIP(8), FromDIP(8));
+        summary_grid->AddGrowableCol(1, 1);
+
+        summary_grid->Add(new wxStaticText(this, wxID_ANY, _L("Requested")), 0, wxALIGN_CENTER_VERTICAL);
+        auto* selected_row = new wxBoxSizer(wxHORIZONTAL);
+        m_selected_preview = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(72), FromDIP(24)), wxBORDER_SIMPLE);
+        selected_row->Add(m_selected_preview, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+        m_selected_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
+        selected_row->Add(m_selected_label, 1, wxALIGN_CENTER_VERTICAL);
+        summary_grid->Add(selected_row, 1, wxEXPAND);
+
+        summary_grid->Add(new wxStaticText(this, wxID_ANY, _L("Creates")), 0, wxALIGN_CENTER_VERTICAL);
+        auto* recipe_row = new wxBoxSizer(wxHORIZONTAL);
+        m_recipe_preview = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(72), FromDIP(24)), wxBORDER_SIMPLE);
+        recipe_row->Add(m_recipe_preview, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+        m_recipe_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
+        m_recipe_label->Wrap(FromDIP(280));
+        recipe_row->Add(m_recipe_label, 1, wxALIGN_CENTER_VERTICAL);
+        summary_grid->Add(recipe_row, 1, wxEXPAND);
+
+        root->Add(summary_grid, 0, wxEXPAND | wxALL, FromDIP(12));
+
+        m_delta_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
+        root->Add(m_delta_label, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(12));
+
+        m_presets_label = new wxStaticText(this, wxID_ANY, _L("Exact preset mixes"));
+        root->Add(m_presets_label, 0, wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
+        m_presets_host = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(-1, FromDIP(96)), wxVSCROLL | wxBORDER_SIMPLE);
+        m_presets_host->SetScrollRate(FromDIP(6), FromDIP(6));
+        m_presets_sizer = new wxWrapSizer(wxHORIZONTAL, wxWRAPSIZER_DEFAULT_FLAGS);
+        m_presets_host->SetSizer(m_presets_sizer);
+        root->Add(m_presets_host, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
+
+        m_error_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
+        m_error_label->SetForegroundColour(wxColour(196, 67, 63));
+        root->Add(m_error_label, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
+
+        if (wxSizer* button_sizer = CreateStdDialogButtonSizer(wxOK | wxCANCEL))
+            root->Add(button_sizer, 0, wxEXPAND | wxALL, FromDIP(12));
+
+        m_loading_panel = new wxPanel(this, wxID_ANY);
+        m_loading_panel->SetMinSize(wxSize(-1, FromDIP(24)));
+        auto* loading_row = new wxBoxSizer(wxHORIZONTAL);
+        m_loading_label   = new wxStaticText(m_loading_panel, wxID_ANY, " ");
+        loading_row->Add(m_loading_label, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+        m_loading_gauge = new wxGauge(m_loading_panel, wxID_ANY, 100, wxDefaultPosition, wxSize(FromDIP(150), FromDIP(8)),
+                                      wxGA_HORIZONTAL | wxGA_SMOOTH);
+        m_loading_gauge->SetValue(0);
+        m_loading_gauge->Enable(false);
+        loading_row->Add(m_loading_gauge, 0, wxALIGN_CENTER_VERTICAL);
+        m_loading_panel->SetSizer(loading_row);
+        root->Add(m_loading_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(12));
+
+        SetSizerAndFit(root);
+
+        m_selected_target  = safe_initial;
+        m_requested_target = safe_initial;
+        if (m_color_map)
+            m_color_map->set_min_component_percent(m_min_component_percent);
+        update_range_label();
+        rebuild_presets_ui();
+        sync_inputs_to_requested();
+        update_dialog_state();
+
+        if (m_color_map) {
+            m_color_map->Bind(wxEVT_SLIDER, [this](wxCommandEvent&) {
+                if (!m_color_map)
+                    return;
+                request_recipe_match(m_color_map->selected_color(), true, _L("Matching closest supported mix..."));
+            });
+        }
+
+        if (m_hex_input) {
+            m_hex_input->Bind(wxEVT_TEXT_ENTER, [this](wxCommandEvent&) { apply_hex_input(true); });
+            m_hex_input->Bind(wxEVT_KILL_FOCUS, [this](wxFocusEvent& evt) {
+                apply_hex_input(false);
+                evt.Skip();
+            });
+        }
+        if (m_classic_picker) {
+            m_classic_picker->Bind(wxEVT_COLOURPICKER_CHANGED, [this](wxColourPickerEvent& evt) {
+                if (m_syncing_inputs)
+                    return;
+                apply_requested_target(evt.GetColour());
+            });
+        }
+        if (m_range_slider) {
+            m_range_slider->Bind(wxEVT_SLIDER, [this](wxCommandEvent&) {
+                m_min_component_percent = m_range_slider ? std::clamp(m_range_slider->GetValue(), 0, 50) : m_min_component_percent;
+                update_range_label();
+                if (m_color_map)
+                    m_color_map->set_min_component_percent(m_min_component_percent);
+                rebuild_presets_ui();
+                request_recipe_match(m_requested_target, true, _L("Matching closest supported mix..."));
+            });
+        }
+
+        Bind(wxEVT_TIMER, [this](wxTimerEvent&) { refresh_selected_recipe(); }, m_recipe_timer.GetId());
+        Bind(
+            wxEVT_TIMER,
+            [this](wxTimerEvent&) {
+                if (m_loading_gauge && m_recipe_loading)
+                    m_loading_gauge->Pulse();
+            },
+            m_loading_timer.GetId());
+        if (wxWindow* ok_button = FindWindow(wxID_OK)) {
+            ok_button->Bind(wxEVT_BUTTON, [this](wxCommandEvent& evt) {
+                if (m_recipe_refresh_pending)
+                    refresh_selected_recipe();
+                if (m_recipe_loading || !m_selected_recipe.valid)
+                    return;
+                evt.Skip();
+            });
+        }
+
+        CentreOnParent();
+        wxGetApp().UpdateDlgDarkUI(this);
+    }
+
+    ~MixedFilamentColorMatchDialog() override
+    {
+        if (m_recipe_timer.IsRunning())
+            m_recipe_timer.Stop();
+        if (m_loading_timer.IsRunning())
+            m_loading_timer.Stop();
+    }
+
+    void begin_initial_recipe_load() { request_recipe_match(m_requested_target, false, _L("Calculating closest supported mix...")); }
+
+    MixedColorMatchRecipeResult selected_recipe() const { return m_selected_recipe; }
+
+    void on_dpi_changed(const wxRect& suggested_rect) override
+    {
+        wxUnusedVar(suggested_rect);
+        Layout();
+        Fit();
+        Refresh();
+    }
+
+private:
+    void sync_recipe_preview(MixedColorMatchRecipeResult& recipe, const wxColour* requested_target = nullptr)
+    {
+        if (!recipe.valid)
+            return;
+
+        recipe.preview_color = compute_color_match_recipe_display_color(recipe, m_display_context);
+        if (requested_target != nullptr && requested_target->IsOk())
+            recipe.delta_e = color_delta_e00(*requested_target, recipe.preview_color);
+    }
+
+    void update_range_label()
+    {
+        if (m_range_value)
+            m_range_value->SetLabel(wxString::Format(_L("%d%% min"), m_min_component_percent));
+    }
+
+    void rebuild_presets_ui()
+    {
+        if (!m_presets_host || !m_presets_sizer || !m_presets_label)
+            return;
+
+        m_presets = build_color_match_presets(m_physical_colors, m_min_component_percent);
+        for (MixedColorMatchRecipeResult& preset : m_presets)
+            sync_recipe_preview(preset);
+
+        m_presets_host->Freeze();
+        while (m_presets_sizer->GetItemCount() > 0) {
+            wxSizerItem* item   = m_presets_sizer->GetItem(size_t(0));
+            wxWindow*    window = item ? item->GetWindow() : nullptr;
+            m_presets_sizer->Remove(0);
+            if (window)
+                window->Destroy();
+        }
+
+        for (const MixedColorMatchRecipeResult& preset : m_presets) {
+            auto*          button  = new wxBitmapButton(m_presets_host, wxID_ANY,
+                                                        make_color_match_swatch_bitmap(preset.preview_color, wxSize(FromDIP(30), FromDIP(20))),
+                                                        wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+            const wxString tooltip = from_u8(summarize_color_match_recipe(preset)) + "\n" +
+                                     normalize_color_match_hex(preset.preview_color.GetAsString(wxC2S_HTML_SYNTAX));
+            button->SetToolTip(tooltip);
+            button->Bind(wxEVT_BUTTON, [this, preset](wxCommandEvent&) { apply_preset(preset); });
+            m_presets_sizer->Add(button, 0, wxALL, FromDIP(2));
+        }
+
+        m_presets_host->FitInside();
+        const bool show_presets = !m_presets.empty();
+        m_presets_label->Show(show_presets);
+        m_presets_host->Show(show_presets);
+        m_presets_host->Thaw();
+    }
+
+    void set_recipe_loading(bool loading, const wxString& message)
+    {
+        m_recipe_loading = loading;
+        if (!message.empty())
+            m_loading_message = message;
+
+        if (m_loading_label)
+            m_loading_label->SetLabel(loading ? m_loading_message : wxString(" "));
+        if (m_loading_gauge) {
+            if (loading) {
+                m_loading_gauge->Enable(true);
+                m_loading_gauge->Pulse();
+                if (!m_loading_timer.IsRunning())
+                    m_loading_timer.Start(100);
+            } else {
+                if (m_loading_timer.IsRunning())
+                    m_loading_timer.Stop();
+                m_loading_gauge->SetValue(0);
+                m_loading_gauge->Enable(false);
+            }
+        }
+    }
+
+    void sync_inputs_to_requested()
+    {
+        m_syncing_inputs = true;
+        if (m_hex_input)
+            m_hex_input->ChangeValue(normalize_color_match_hex(m_requested_target.GetAsString(wxC2S_HTML_SYNTAX)));
+        if (m_classic_picker)
+            m_classic_picker->SetColour(m_requested_target);
+        m_syncing_inputs = false;
+    }
+
+    bool apply_requested_target(const wxColour& requested_target)
+    {
+        request_recipe_match(requested_target, false, _L("Matching closest supported mix..."));
+        return true;
+    }
+
+    bool apply_hex_input(bool show_invalid_error)
+    {
+        if (!m_hex_input || m_syncing_inputs)
+            return false;
+
+        wxColour parsed;
+        if (!try_parse_color_match_hex(m_hex_input->GetValue(), parsed)) {
+            if (show_invalid_error && m_error_label)
+                m_error_label->SetLabel(_L("Use a valid hex color like #00FF88."));
+            return false;
+        }
+
+        return apply_requested_target(parsed);
+    }
+
+    void request_recipe_match(const wxColour& requested_target, bool debounce, const wxString& loading_message)
+    {
+        m_requested_target = requested_target;
+        m_selected_target  = requested_target;
+        sync_inputs_to_requested();
+
+        ++m_recipe_request_token;
+        set_recipe_loading(true, loading_message);
+
+        if (m_recipe_timer.IsRunning())
+            m_recipe_timer.Stop();
+        m_recipe_refresh_pending = debounce;
+        update_dialog_state();
+
+        if (debounce) {
+            m_recipe_timer.StartOnce(120);
+            return;
+        }
+
+        launch_recipe_match(m_recipe_request_token, requested_target);
+    }
+
+    void refresh_selected_recipe()
+    {
+        m_recipe_refresh_pending = false;
+        launch_recipe_match(m_recipe_request_token, m_requested_target);
+    }
+
+    void launch_recipe_match(size_t request_token, const wxColour& requested_target)
+    {
+        const std::vector<std::string> physical_colors       = m_physical_colors;
+        const int                      min_component_percent = m_min_component_percent;
+        wxWeakRef<wxWindow>            weak_self(this);
+        std::thread([weak_self, physical_colors, requested_target, request_token, min_component_percent]() {
+            MixedColorMatchRecipeResult recipe = build_best_color_match_recipe(physical_colors, requested_target, min_component_percent);
+            wxGetApp().CallAfter([weak_self, requested_target, recipe = std::move(recipe), request_token]() mutable {
+                if (!weak_self)
+                    return;
+                auto* self = static_cast<MixedFilamentColorMatchDialog*>(weak_self.get());
+                self->handle_recipe_result(request_token, requested_target, std::move(recipe));
+            });
+        }).detach();
+    }
+
+    void handle_recipe_result(size_t request_token, const wxColour& requested_target, MixedColorMatchRecipeResult recipe)
+    {
+        if (request_token != m_recipe_request_token)
+            return;
+
+        m_has_recipe_result = true;
+        m_selected_recipe   = std::move(recipe);
+        sync_recipe_preview(m_selected_recipe, &requested_target);
+        set_recipe_loading(false, wxEmptyString);
+
+        if (m_selected_recipe.valid) {
+            m_selected_target = m_selected_recipe.preview_color;
+            if (m_color_map)
+                m_color_map->set_normalized_weights(expand_color_match_recipe_weights(m_selected_recipe, m_palette.size()), false);
+            sync_inputs_to_requested();
+        } else {
+            m_selected_target = requested_target;
+        }
+
+        update_dialog_state();
+    }
+
+    void apply_preset(MixedColorMatchRecipeResult preset)
+    {
+        preset.delta_e = 0.0;
+        sync_recipe_preview(preset);
+        ++m_recipe_request_token;
+        m_requested_target       = preset.preview_color;
+        m_selected_target        = preset.preview_color;
+        m_selected_recipe        = std::move(preset);
+        m_has_recipe_result      = true;
+        m_recipe_refresh_pending = false;
+        if (m_recipe_timer.IsRunning())
+            m_recipe_timer.Stop();
+        set_recipe_loading(false, wxEmptyString);
+        if (m_color_map)
+            m_color_map->set_normalized_weights(expand_color_match_recipe_weights(m_selected_recipe, m_palette.size()), false);
+        sync_inputs_to_requested();
+        update_dialog_state();
+    }
+
+    void update_dialog_state()
+    {
+        const wxColour fallback = wxColour("#26A69A");
+        if (m_selected_preview) {
+            m_selected_preview->SetBackgroundColour(m_requested_target.IsOk() ? m_requested_target : fallback);
+            m_selected_preview->Refresh();
+        }
+        if (m_selected_label)
+            m_selected_label->SetLabel(m_requested_target.IsOk() ?
+                                           normalize_color_match_hex(m_requested_target.GetAsString(wxC2S_HTML_SYNTAX)) :
+                                           normalize_color_match_hex(fallback.GetAsString(wxC2S_HTML_SYNTAX)));
+
+        const bool     valid        = m_selected_recipe.valid;
+        const wxColour recipe_color = (valid && m_selected_recipe.preview_color.IsOk()) ?
+                                          m_selected_recipe.preview_color :
+                                          (m_requested_target.IsOk() ? m_requested_target : fallback);
+        if (m_recipe_preview) {
+            m_recipe_preview->SetBackgroundColour(recipe_color);
+            m_recipe_preview->Refresh();
+        }
+        if (m_recipe_label) {
+            if (m_recipe_loading) {
+                m_recipe_label->SetLabel(m_loading_message);
+            } else if (valid) {
+                const wxString recipe_summary = from_u8(summarize_color_match_recipe(m_selected_recipe));
+                const wxString recipe_hex     = normalize_color_match_hex(recipe_color.GetAsString(wxC2S_HTML_SYNTAX));
+                m_recipe_label->SetLabel(recipe_summary + "  " + recipe_hex);
+            } else if (m_has_recipe_result) {
+                m_recipe_label->SetLabel(_L("No supported 2-color, 3-color, or 4-color recipe found."));
+            } else {
+                m_recipe_label->SetLabel(wxEmptyString);
+            }
+        }
+        if (m_delta_label) {
+            if (m_recipe_loading && m_requested_target.IsOk()) {
+                m_delta_label->SetLabel(
+                    wxString::Format(_L("Matching %s..."), normalize_color_match_hex(m_requested_target.GetAsString(wxC2S_HTML_SYNTAX))));
+            } else if (valid && m_requested_target.IsOk()) {
+                m_delta_label->SetLabel(wxString::Format(_L("Requested %s, closest recipe delta: %.2f"),
+                                                         normalize_color_match_hex(m_requested_target.GetAsString(wxC2S_HTML_SYNTAX)),
+                                                         m_selected_recipe.delta_e));
+            } else {
+                m_delta_label->SetLabel(wxEmptyString);
+            }
+        }
+        if (m_error_label) {
+            if (m_recipe_loading)
+                m_error_label->SetLabel(wxEmptyString);
+            else if (!valid && m_has_recipe_result)
+                m_error_label->SetLabel(
+                    _L("Unable to create a color mix from the current physical filament colors within the selected range."));
+            else if (m_hex_input && !m_syncing_inputs) {
+                wxColour parsed;
+                if (!try_parse_color_match_hex(m_hex_input->GetValue(), parsed))
+                    m_error_label->SetLabel(_L("Use a valid hex color like #00FF88."));
+                else
+                    m_error_label->SetLabel(wxEmptyString);
+            } else {
+                m_error_label->SetLabel(wxEmptyString);
+            }
+        }
+        if (wxWindow* ok_button = FindWindow(wxID_OK))
+            ok_button->Enable(valid && !m_recipe_loading && !m_recipe_refresh_pending);
+
+        Layout();
+    }
+
+private:
+    std::vector<std::string>                 m_physical_colors;
+    MixedFilamentDisplayContext              m_display_context;
+    std::vector<wxColour>                    m_palette;
+    std::vector<MixedColorMatchRecipeResult> m_presets;
+    MixedFilamentColorMapPanel*              m_color_map        = nullptr;
+    wxTextCtrl*                              m_hex_input        = nullptr;
+    wxColourPickerCtrl*                      m_classic_picker   = nullptr;
+    wxSlider*                                m_range_slider     = nullptr;
+    wxStaticText*                            m_range_value      = nullptr;
+    wxStaticText*                            m_presets_label    = nullptr;
+    wxScrolledWindow*                        m_presets_host     = nullptr;
+    wxWrapSizer*                             m_presets_sizer    = nullptr;
+    wxPanel*                                 m_loading_panel    = nullptr;
+    wxStaticText*                            m_loading_label    = nullptr;
+    wxGauge*                                 m_loading_gauge    = nullptr;
+    wxPanel*                                 m_selected_preview = nullptr;
+    wxStaticText*                            m_selected_label   = nullptr;
+    wxPanel*                                 m_recipe_preview   = nullptr;
+    wxStaticText*                            m_recipe_label     = nullptr;
+    wxStaticText*                            m_delta_label      = nullptr;
+    wxStaticText*                            m_error_label      = nullptr;
+    wxColour                                 m_requested_target{wxColour("#26A69A")};
+    wxColour                                 m_selected_target{wxColour("#26A69A")};
+    MixedColorMatchRecipeResult              m_selected_recipe;
+    wxTimer                                  m_recipe_timer;
+    wxTimer                                  m_loading_timer;
+    wxString                                 m_loading_message;
+    size_t                                   m_recipe_request_token{0};
+    int                                      m_min_component_percent{15};
+    bool                                     m_has_recipe_result{false};
+    bool                                     m_recipe_loading{false};
+    bool                                     m_recipe_refresh_pending{false};
+    bool                                     m_syncing_inputs{false};
+};
+
+
+MixedColorMatchRecipeResult prompt_best_color_match_recipe(wxWindow*                       parent,
+                                                           const std::vector<std::string>& physical_colors,
+                                                           const wxColour&                 initial_color)
+{
+    MixedFilamentColorMatchDialog dlg(parent, physical_colors, initial_color);
+    dlg.begin_initial_recipe_load();
+    if (dlg.ShowModal() != wxID_OK) {
+        MixedColorMatchRecipeResult cancelled;
+        cancelled.cancelled = true;
+        return cancelled;
+    }
+
+    return dlg.selected_recipe();
+}
 
 static DynamicFilamentList dynamic_filament_list;
 static DynamicFilamentList1Based dynamic_filament_list_1_based;
@@ -2399,1117 +2919,8 @@ void Sidebar::on_filaments_change(size_t num_filaments)
     update_ui_from_settings();
     update_dynamic_filament_list();
     update_mixed_filament_panel();
+    update_color_mix_panel();
 }
-
-wxColour parse_mixed_color(const std::string &value)
-{
-    wxColour color(value);
-    if (!color.IsOk())
-        color = wxColour("#26A69A");
-    return color;
-}
-
-wxString normalize_color_match_hex(const wxString &value)
-{
-    wxString normalized = value;
-    normalized.Trim(true);
-    normalized.Trim(false);
-    normalized.MakeUpper();
-    if (!normalized.empty() && normalized[0] != '#')
-        normalized.Prepend("#");
-    return normalized;
-}
-
-bool try_parse_color_match_hex(const wxString &value, wxColour &color_out)
-{
-    const wxString normalized = normalize_color_match_hex(value);
-    if (normalized.length() != 7)
-        return false;
-
-    for (size_t idx = 1; idx < normalized.length(); ++idx) {
-        const unsigned char ch = static_cast<unsigned char>(normalized[idx]);
-        if (!std::isxdigit(ch))
-            return false;
-    }
-
-    wxColour parsed(normalized);
-    if (!parsed.IsOk())
-        return false;
-
-    color_out = parsed;
-    return true;
-}
-
-namespace {
-
-std::vector<unsigned int> decode_color_match_gradient_ids(const std::string &value)
-{
-    std::vector<unsigned int> ids;
-    bool seen[10] = { false };
-    for (const char ch : value) {
-        if (ch < '1' || ch > '9')
-            continue;
-        const unsigned int id = unsigned(ch - '0');
-        if (seen[id])
-            continue;
-        seen[id] = true;
-        ids.emplace_back(id);
-    }
-    return ids;
-}
-
-std::vector<int> decode_color_match_gradient_weights(const std::string &value, size_t expected_components)
-{
-    std::vector<int> weights;
-    if (value.empty() || expected_components == 0)
-        return weights;
-
-    std::string token;
-    for (const char ch : value) {
-        if (ch >= '0' && ch <= '9') {
-            token.push_back(ch);
-            continue;
-        }
-        if (!token.empty()) {
-            weights.emplace_back(std::max(0, std::atoi(token.c_str())));
-            token.clear();
-        }
-    }
-    if (!token.empty())
-        weights.emplace_back(std::max(0, std::atoi(token.c_str())));
-    if (weights.size() != expected_components)
-        weights.clear();
-    return weights;
-}
-
-} // namespace
-
-std::vector<int> normalize_color_match_weights(const std::vector<int> &weights, size_t count)
-{
-    std::vector<int> out = weights;
-    if (out.size() != count)
-        out.assign(count, count > 0 ? int(100 / count) : 0);
-
-    int sum = 0;
-    for (int &value : out) {
-        value = std::max(0, value);
-        sum += value;
-    }
-    if (sum <= 0 && count > 0) {
-        out.assign(count, 0);
-        out[0] = 100;
-        return out;
-    }
-
-    std::vector<double> remainders(count, 0.0);
-    int assigned = 0;
-    for (size_t idx = 0; idx < count; ++idx) {
-        const double exact = 100.0 * double(out[idx]) / double(sum);
-        out[idx] = int(std::floor(exact));
-        remainders[idx] = exact - double(out[idx]);
-        assigned += out[idx];
-    }
-
-    int missing = std::max(0, 100 - assigned);
-    while (missing > 0) {
-        size_t best_idx = 0;
-        double best_remainder = -1.0;
-        for (size_t idx = 0; idx < remainders.size(); ++idx) {
-            if (remainders[idx] > best_remainder) {
-                best_remainder = remainders[idx];
-                best_idx = idx;
-            }
-        }
-        ++out[best_idx];
-        remainders[best_idx] = 0.0;
-        --missing;
-    }
-
-    return out;
-}
-
-std::vector<unsigned int> build_color_match_sequence(const std::vector<unsigned int> &ids, const std::vector<int> &weights);
-wxColour blend_sequence_filament_mixer(const std::vector<wxColour> &palette, const std::vector<unsigned int> &sequence);
-
-namespace {
-
-bool color_match_weights_within_range(const std::vector<int> &weights, int min_component_percent)
-{
-    if (min_component_percent <= 0)
-        return true;
-
-    const int min_allowed = std::clamp(min_component_percent, 0, 50);
-    int active_components = 0;
-    for (const int weight : weights) {
-        if (weight <= 0)
-            continue;
-        ++active_components;
-        if (weight < min_allowed)
-            return false;
-    }
-    return active_components >= 2;
-}
-
-MixedColorMatchRecipeResult build_pair_color_match_candidate(const std::vector<wxColour> &palette,
-                                                             unsigned int                  component_a,
-                                                             unsigned int                  component_b,
-                                                             int                           mix_b_percent,
-                                                             int                           min_component_percent = 0)
-{
-    MixedColorMatchRecipeResult candidate;
-    if (component_a == 0 || component_b == 0 || component_a == component_b)
-        return candidate;
-    if (component_a > palette.size() || component_b > palette.size())
-        return candidate;
-    if (!color_match_weights_within_range({ 100 - std::clamp(mix_b_percent, 0, 100), std::clamp(mix_b_percent, 0, 100) }, min_component_percent))
-        return candidate;
-
-    candidate.valid         = true;
-    candidate.component_a   = component_a;
-    candidate.component_b   = component_b;
-    candidate.mix_b_percent = std::clamp(mix_b_percent, 0, 100);
-    candidate.preview_color = blend_pair_filament_mixer(palette[component_a - 1], palette[component_b - 1],
-                                                        float(candidate.mix_b_percent) / 100.f);
-    return candidate;
-}
-
-MixedColorMatchRecipeResult build_multi_color_match_candidate(const std::vector<wxColour>      &palette,
-                                                              const std::vector<unsigned int> &ids,
-                                                              const std::vector<int>          &weights,
-                                                              int                              min_component_percent = 0)
-{
-    MixedColorMatchRecipeResult candidate;
-    if (ids.size() < 3 || ids.size() != weights.size())
-        return candidate;
-    if (!color_match_weights_within_range(weights, min_component_percent))
-        return candidate;
-
-    std::vector<std::pair<int, unsigned int>> weighted_ids;
-    weighted_ids.reserve(ids.size());
-    for (size_t idx = 0; idx < ids.size(); ++idx) {
-        if (ids[idx] == 0 || ids[idx] > palette.size() || ids[idx] > 9)
-            return candidate;
-        if (weights[idx] <= 0)
-            continue;
-        weighted_ids.emplace_back(weights[idx], ids[idx]);
-    }
-    if (weighted_ids.size() < 3)
-        return candidate;
-
-    std::sort(weighted_ids.begin(), weighted_ids.end(), [](const auto &lhs, const auto &rhs) {
-        if (lhs.first != rhs.first)
-            return lhs.first > rhs.first;
-        return lhs.second < rhs.second;
-    });
-
-    std::vector<unsigned int> ordered_ids;
-    std::vector<int>          ordered_weights;
-    ordered_ids.reserve(weighted_ids.size());
-    ordered_weights.reserve(weighted_ids.size());
-    for (const auto &[weight, filament_id] : weighted_ids) {
-        ordered_ids.emplace_back(filament_id);
-        ordered_weights.emplace_back(weight);
-    }
-
-    const std::vector<unsigned int> sequence = build_color_match_sequence(ordered_ids, ordered_weights);
-    if (sequence.empty())
-        return candidate;
-
-    candidate.valid       = true;
-    candidate.component_a = ordered_ids[0];
-    candidate.component_b = ordered_ids[1];
-    const int pair_weight_total = ordered_weights[0] + ordered_weights[1];
-    candidate.mix_b_percent = pair_weight_total > 0 ?
-        std::clamp(int(std::lround(100.0 * double(ordered_weights[1]) / double(pair_weight_total))), 0, 100) :
-        50;
-    for (const unsigned int filament_id : ordered_ids)
-        candidate.gradient_component_ids.push_back(char('0' + filament_id));
-    {
-        std::ostringstream weights_ss;
-        for (size_t weight_idx = 0; weight_idx < ordered_weights.size(); ++weight_idx) {
-            if (weight_idx > 0)
-                weights_ss << '/';
-            weights_ss << ordered_weights[weight_idx];
-        }
-        candidate.gradient_component_weights = weights_ss.str();
-    }
-    candidate.preview_color = blend_sequence_filament_mixer(palette, sequence);
-    return candidate;
-}
-
-} // namespace
-
-// Functions declared in MixedColorMatchHelpers.hpp — must be in Slic3r::GUI scope
-
-std::vector<int> expand_color_match_recipe_weights(const MixedColorMatchRecipeResult &recipe, size_t num_physical)
-{
-    std::vector<int> weights(num_physical, 0);
-    if (!recipe.valid || num_physical == 0)
-        return weights;
-
-    if (!recipe.gradient_component_ids.empty()) {
-        const std::vector<unsigned int> ids = decode_color_match_gradient_ids(recipe.gradient_component_ids);
-        const std::vector<int> raw_weights =
-            normalize_color_match_weights(decode_color_match_gradient_weights(recipe.gradient_component_weights, ids.size()), ids.size());
-        if (ids.size() != raw_weights.size())
-            return weights;
-        for (size_t idx = 0; idx < ids.size(); ++idx) {
-            if (ids[idx] >= 1 && ids[idx] <= num_physical)
-                weights[ids[idx] - 1] = raw_weights[idx];
-        }
-        return weights;
-    }
-
-    if (recipe.component_a >= 1 && recipe.component_a <= num_physical)
-        weights[recipe.component_a - 1] = std::max(0, 100 - std::clamp(recipe.mix_b_percent, 0, 100));
-    if (recipe.component_b >= 1 && recipe.component_b <= num_physical)
-        weights[recipe.component_b - 1] = std::max(0, std::clamp(recipe.mix_b_percent, 0, 100));
-    return weights;
-}
-
-std::string summarize_color_match_recipe(const MixedColorMatchRecipeResult &recipe)
-{
-    if (!recipe.valid)
-        return {};
-
-    std::vector<unsigned int> ids;
-    std::vector<int>          weights;
-    if (!recipe.gradient_component_ids.empty()) {
-        ids = decode_color_match_gradient_ids(recipe.gradient_component_ids);
-        weights = normalize_color_match_weights(
-            decode_color_match_gradient_weights(recipe.gradient_component_weights, ids.size()), ids.size());
-    } else {
-        ids = { recipe.component_a, recipe.component_b };
-        weights = { std::max(0, 100 - std::clamp(recipe.mix_b_percent, 0, 100)),
-                    std::max(0, std::clamp(recipe.mix_b_percent, 0, 100)) };
-    }
-    if (ids.empty() || ids.size() != weights.size())
-        return {};
-
-    std::ostringstream out;
-    for (size_t idx = 0; idx < ids.size(); ++idx) {
-        if (idx > 0)
-            out << '/';
-        out << 'F' << ids[idx];
-    }
-    out << ' ';
-    for (size_t idx = 0; idx < weights.size(); ++idx) {
-        if (idx > 0)
-            out << '/';
-        out << weights[idx] << '%';
-    }
-    return out.str();
-}
-
-wxBitmap make_color_match_swatch_bitmap(const wxColour &color, const wxSize &size)
-{
-    wxBitmap bmp(size.GetWidth(), size.GetHeight());
-    wxMemoryDC dc(bmp);
-    dc.SetBackground(wxBrush(wxColour(255, 255, 255)));
-    dc.Clear();
-    dc.SetPen(wxPen(wxColour(120, 120, 120), 1));
-    dc.SetBrush(wxBrush(color.IsOk() ? color : wxColour("#26A69A")));
-    dc.DrawRectangle(0, 0, size.GetWidth(), size.GetHeight());
-    dc.SelectObject(wxNullBitmap);
-    return bmp;
-}
-
-std::vector<MixedColorMatchRecipeResult> build_color_match_presets(const std::vector<std::string> &physical_colors,
-                                                                   int                             min_component_percent)
-{
-    std::vector<MixedColorMatchRecipeResult> presets;
-    if (physical_colors.size() < 2)
-        return presets;
-
-    std::vector<wxColour> palette;
-    palette.reserve(physical_colors.size());
-    for (const std::string &hex : physical_colors)
-        palette.emplace_back(parse_mixed_color(hex));
-
-    constexpr size_t k_max_presets = 48;
-    std::unordered_set<std::string> seen_colors;
-    auto add_candidate = [&presets, &seen_colors](MixedColorMatchRecipeResult candidate) {
-        if (!candidate.valid)
-            return;
-        const std::string color_key = normalize_color_match_hex(candidate.preview_color.GetAsString(wxC2S_HTML_SYNTAX)).ToStdString();
-        if (color_key.empty() || !seen_colors.insert(color_key).second)
-            return;
-        presets.emplace_back(std::move(candidate));
-    };
-
-    constexpr int pair_ratios[] = { 25, 50, 75 };
-    for (size_t left_idx = 0; left_idx < palette.size() && presets.size() < k_max_presets; ++left_idx) {
-        for (size_t right_idx = left_idx + 1; right_idx < palette.size() && presets.size() < k_max_presets; ++right_idx) {
-            for (const int mix_b_percent : pair_ratios) {
-                add_candidate(build_pair_color_match_candidate(palette, unsigned(left_idx + 1), unsigned(right_idx + 1),
-                                                               mix_b_percent, min_component_percent));
-                if (presets.size() >= k_max_presets)
-                    break;
-            }
-        }
-    }
-
-    const size_t triple_limit = std::min<size_t>(palette.size(), 6);
-    const std::vector<int> equal_triple_weights = normalize_color_match_weights({ 1, 1, 1 }, 3);
-    for (size_t first_idx = 0; first_idx + 2 < triple_limit && presets.size() < k_max_presets; ++first_idx) {
-        for (size_t second_idx = first_idx + 1; second_idx + 1 < triple_limit && presets.size() < k_max_presets; ++second_idx) {
-            for (size_t third_idx = second_idx + 1; third_idx < triple_limit && presets.size() < k_max_presets; ++third_idx) {
-                const std::vector<unsigned int> ids = {
-                    unsigned(first_idx + 1),
-                    unsigned(second_idx + 1),
-                    unsigned(third_idx + 1)
-                };
-                add_candidate(build_multi_color_match_candidate(palette, ids, equal_triple_weights, min_component_percent));
-                for (size_t dominant_idx = 0; dominant_idx < ids.size() && presets.size() < k_max_presets; ++dominant_idx) {
-                    std::vector<int> dominant_weights(ids.size(), 25);
-                    dominant_weights[dominant_idx] = 50;
-                    add_candidate(build_multi_color_match_candidate(palette, ids, dominant_weights, min_component_percent));
-                }
-            }
-        }
-    }
-
-    const size_t quad_limit = std::min<size_t>(palette.size(), 5);
-    for (size_t first_idx = 0; first_idx + 3 < quad_limit && presets.size() < k_max_presets; ++first_idx) {
-        for (size_t second_idx = first_idx + 1; second_idx + 2 < quad_limit && presets.size() < k_max_presets; ++second_idx) {
-            for (size_t third_idx = second_idx + 1; third_idx + 1 < quad_limit && presets.size() < k_max_presets; ++third_idx) {
-                for (size_t fourth_idx = third_idx + 1; fourth_idx < quad_limit && presets.size() < k_max_presets; ++fourth_idx) {
-                    add_candidate(build_multi_color_match_candidate(
-                        palette,
-                        { unsigned(first_idx + 1), unsigned(second_idx + 1), unsigned(third_idx + 1), unsigned(fourth_idx + 1) },
-                        { 25, 25, 25, 25 },
-                        min_component_percent));
-                }
-            }
-        }
-    }
-
-    return presets;
-}
-
-double color_delta_e00(const wxColour &lhs, const wxColour &rhs)
-{
-    float lhs_l = 0.f, lhs_a = 0.f, lhs_b = 0.f;
-    float rhs_l = 0.f, rhs_a = 0.f, rhs_b = 0.f;
-    RGB2Lab(float(lhs.Red()), float(lhs.Green()), float(lhs.Blue()), &lhs_l, &lhs_a, &lhs_b);
-    RGB2Lab(float(rhs.Red()), float(rhs.Green()), float(rhs.Blue()), &rhs_l, &rhs_a, &rhs_b);
-    return double(DeltaE00(lhs_l, lhs_a, lhs_b, rhs_l, rhs_a, rhs_b));
-}
-
-std::vector<unsigned int> build_color_match_sequence(const std::vector<unsigned int> &ids, const std::vector<int> &weights)
-{
-    if (ids.empty() || ids.size() != weights.size())
-        return {};
-
-    constexpr int k_max_cycle = 48;
-
-    std::vector<unsigned int> filtered_ids;
-    std::vector<int>          counts;
-    filtered_ids.reserve(ids.size());
-    counts.reserve(weights.size());
-    for (size_t idx = 0; idx < ids.size(); ++idx) {
-        const int weight = std::max(0, weights[idx]);
-        if (weight <= 0)
-            continue;
-        filtered_ids.emplace_back(ids[idx]);
-        counts.emplace_back(std::max(1, int(std::round((double(weight) / 100.0) * k_max_cycle))));
-    }
-
-    if (filtered_ids.empty())
-        return {};
-
-    int cycle = std::accumulate(counts.begin(), counts.end(), 0);
-    while (cycle > k_max_cycle) {
-        auto it = std::max_element(counts.begin(), counts.end());
-        if (it == counts.end() || *it <= 1)
-            break;
-        --(*it);
-        --cycle;
-    }
-
-    if (cycle <= 0)
-        return {};
-
-    std::vector<unsigned int> sequence;
-    sequence.reserve(size_t(cycle));
-    std::vector<int> emitted(counts.size(), 0);
-    for (int pos = 0; pos < cycle; ++pos) {
-        size_t best_idx = 0;
-        double best_score = -1e9;
-        for (size_t idx = 0; idx < counts.size(); ++idx) {
-            const double target = double((pos + 1) * counts[idx]) / double(std::max(1, cycle));
-            const double score  = target - double(emitted[idx]);
-            if (score > best_score) {
-                best_score = score;
-                best_idx   = idx;
-            }
-        }
-        ++emitted[best_idx];
-        sequence.emplace_back(filtered_ids[best_idx]);
-    }
-
-    return sequence;
-}
-
-wxColour blend_sequence_filament_mixer(const std::vector<wxColour> &palette, const std::vector<unsigned int> &sequence)
-{
-    if (palette.empty() || sequence.empty())
-        return wxColour("#26A69A");
-
-    std::vector<int> counts(palette.size() + 1, 0);
-    for (const unsigned int filament_id : sequence) {
-        if (filament_id == 0 || filament_id > palette.size())
-            continue;
-        ++counts[filament_id];
-    }
-
-    std::vector<wxColour> colors;
-    std::vector<double>   weights;
-    colors.reserve(palette.size());
-    weights.reserve(palette.size());
-    for (size_t filament_id = 1; filament_id <= palette.size(); ++filament_id) {
-        if (counts[filament_id] <= 0)
-            continue;
-        colors.emplace_back(palette[filament_id - 1]);
-        weights.emplace_back(double(counts[filament_id]));
-    }
-
-    return blend_multi_filament_mixer(colors, weights);
-}
-
-MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std::string> &physical_colors,
-                                                          const wxColour                 &target_color,
-                                                          int                             min_component_percent)
-{
-    MixedColorMatchRecipeResult best;
-    if (!target_color.IsOk() || physical_colors.size() < 2)
-        return best;
-
-    std::vector<wxColour> palette;
-    palette.reserve(physical_colors.size());
-    for (const std::string &hex : physical_colors)
-        palette.emplace_back(parse_mixed_color(hex));
-
-    auto consider_candidate = [&best, &target_color](MixedColorMatchRecipeResult candidate) {
-        if (!candidate.valid)
-            return;
-        candidate.delta_e = color_delta_e00(target_color, candidate.preview_color);
-        if (!best.valid || candidate.delta_e + 1e-6 < best.delta_e)
-            best = std::move(candidate);
-    };
-
-    const int loop_min_weight = std::max(1, std::clamp(min_component_percent, 0, 50));
-    const int loop_max_pair_weight = 100 - loop_min_weight;
-
-    for (size_t left_idx = 0; left_idx < palette.size(); ++left_idx) {
-        for (size_t right_idx = left_idx + 1; right_idx < palette.size(); ++right_idx) {
-            for (int mix_b_percent = loop_min_weight; mix_b_percent <= loop_max_pair_weight; ++mix_b_percent)
-                consider_candidate(build_pair_color_match_candidate(palette, unsigned(left_idx + 1), unsigned(right_idx + 1),
-                                                                    mix_b_percent, min_component_percent));
-        }
-    }
-
-    std::vector<std::pair<double, unsigned int>> ranked_ids;
-    ranked_ids.reserve(palette.size());
-    for (size_t idx = 0; idx < palette.size(); ++idx)
-        ranked_ids.emplace_back(color_delta_e00(target_color, palette[idx]), unsigned(idx + 1));
-    std::sort(ranked_ids.begin(), ranked_ids.end(), [](const auto &lhs, const auto &rhs) {
-        if (lhs.first != rhs.first)
-            return lhs.first < rhs.first;
-        return lhs.second < rhs.second;
-    });
-
-    std::vector<unsigned int> candidate_pool;
-    candidate_pool.reserve(std::min<size_t>(palette.size(), 12));
-    auto push_unique_id = [&candidate_pool](unsigned int filament_id) {
-        if (filament_id == 0 || filament_id > 9)
-            return;
-        if (std::find(candidate_pool.begin(), candidate_pool.end(), filament_id) == candidate_pool.end())
-            candidate_pool.emplace_back(filament_id);
-    };
-
-    const size_t general_pool_limit = std::min<size_t>(ranked_ids.size(), 8);
-    for (size_t idx = 0; idx < general_pool_limit; ++idx)
-        push_unique_id(ranked_ids[idx].second);
-
-    size_t direct_token_count = 0;
-    for (const auto &[distance, filament_id] : ranked_ids) {
-        (void) distance;
-        if (filament_id < 3 || filament_id > 9)
-            continue;
-        push_unique_id(filament_id);
-        if (++direct_token_count >= 4)
-            break;
-    }
-
-    if (candidate_pool.size() < 3)
-        return best;
-
-    std::vector<unsigned int> triple_pool = candidate_pool;
-    std::sort(triple_pool.begin(), triple_pool.end());
-    for (size_t first_idx = 0; first_idx + 2 < triple_pool.size(); ++first_idx) {
-        for (size_t second_idx = first_idx + 1; second_idx + 1 < triple_pool.size(); ++second_idx) {
-            for (size_t third_idx = second_idx + 1; third_idx < triple_pool.size(); ++third_idx) {
-                const std::vector<unsigned int> ids = {
-                    triple_pool[first_idx],
-                    triple_pool[second_idx],
-                    triple_pool[third_idx]
-                };
-                if (std::any_of(ids.begin(), ids.end(), [](unsigned int filament_id) { return filament_id == 0 || filament_id > 9; }))
-                    continue;
-
-                for (int weight_a = loop_min_weight; weight_a <= 100 - 2 * loop_min_weight; ++weight_a) {
-                    for (int weight_b = loop_min_weight; weight_a + weight_b <= 100 - loop_min_weight; ++weight_b) {
-                        const int weight_c = 100 - weight_a - weight_b;
-                        consider_candidate(build_multi_color_match_candidate(palette, ids, { weight_a, weight_b, weight_c },
-                                                                            min_component_percent));
-                    }
-                }
-            }
-        }
-    }
-
-    if (candidate_pool.size() < 4)
-        return best;
-
-    std::vector<unsigned int> quad_pool(candidate_pool.begin(),
-                                        candidate_pool.begin() + std::min<size_t>(candidate_pool.size(), 6));
-    std::sort(quad_pool.begin(), quad_pool.end());
-    for (size_t first_idx = 0; first_idx + 3 < quad_pool.size(); ++first_idx) {
-        for (size_t second_idx = first_idx + 1; second_idx + 2 < quad_pool.size(); ++second_idx) {
-            for (size_t third_idx = second_idx + 1; third_idx + 1 < quad_pool.size(); ++third_idx) {
-                for (size_t fourth_idx = third_idx + 1; fourth_idx < quad_pool.size(); ++fourth_idx) {
-                    const std::vector<unsigned int> ids = {
-                        quad_pool[first_idx],
-                        quad_pool[second_idx],
-                        quad_pool[third_idx],
-                        quad_pool[fourth_idx]
-                    };
-
-                    for (int weight_a = loop_min_weight; weight_a <= 100 - 3 * loop_min_weight; ++weight_a) {
-                        for (int weight_b = loop_min_weight; weight_a + weight_b <= 100 - 2 * loop_min_weight; ++weight_b) {
-                            for (int weight_c = loop_min_weight; weight_a + weight_b + weight_c <= 100 - loop_min_weight; ++weight_c) {
-                                const int weight_d = 100 - weight_a - weight_b - weight_c;
-                                consider_candidate(build_multi_color_match_candidate(
-                                    palette, ids, { weight_a, weight_b, weight_c, weight_d }, min_component_percent));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    return best;
-}
-
-class MixedFilamentColorMatchDialog : public DPIDialog
-{
-public:
-    MixedFilamentColorMatchDialog(wxWindow *parent,
-                                  const std::vector<std::string> &physical_colors,
-                                  const wxColour &initial_color)
-        : DPIDialog(parent ? parent : static_cast<wxWindow *>(wxGetApp().mainframe),
-                    wxID_ANY,
-                    _L("Add Color"),
-                    wxDefaultPosition,
-                    wxDefaultSize,
-                    wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
-        , m_physical_colors(physical_colors)
-    {
-        m_recipe_timer.SetOwner(this);
-        m_loading_timer.SetOwner(this);
-        m_display_context = build_mixed_filament_display_context(m_physical_colors);
-
-        m_palette.reserve(m_physical_colors.size());
-        for (const std::string &hex : m_physical_colors)
-            m_palette.emplace_back(parse_mixed_color(hex));
-
-        const wxColour safe_initial = initial_color.IsOk() ? initial_color :
-            (m_palette.size() >= 2 ? blend_pair_filament_mixer(m_palette[0], m_palette[1], 0.5f) : wxColour("#26A69A"));
-        std::vector<int> initial_weights(m_palette.size(), 0);
-        if (!initial_weights.empty())
-            initial_weights[0] = 100;
-        if (initial_weights.size() >= 2) {
-            initial_weights[0] = 50;
-            initial_weights[1] = 50;
-        }
-
-        std::vector<unsigned int> filament_ids;
-        filament_ids.reserve(m_palette.size());
-        for (size_t idx = 0; idx < m_palette.size(); ++idx)
-            filament_ids.emplace_back(unsigned(idx + 1));
-
-        SetMinSize(wxSize(FromDIP(430), FromDIP(520)));
-
-        auto *root = new wxBoxSizer(wxVERTICAL);
-        auto *description = new wxStaticText(
-            this, wxID_ANY,
-            _L("Pick from the current filament gamut. The dialog previews the closest 2-color, 3-color, or 4-color FilamentMixer recipe before it is added."));
-        description->Wrap(FromDIP(390));
-        root->Add(description, 0, wxEXPAND | wxALL, FromDIP(12));
-
-        m_color_map = new MixedFilamentColorMapPanel(this, filament_ids, m_palette, initial_weights,
-                                                     wxSize(FromDIP(260), FromDIP(260)));
-        root->Add(m_color_map, 1, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(12));
-
-        auto *hex_row = new wxBoxSizer(wxHORIZONTAL);
-        hex_row->Add(new wxStaticText(this, wxID_ANY, _L("Hex")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
-        m_hex_input = new wxTextCtrl(this, wxID_ANY, normalize_color_match_hex(safe_initial.GetAsString(wxC2S_HTML_SYNTAX)),
-                                     wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
-        m_hex_input->SetToolTip(_L("Enter a hex color like #00FF88. The picker will snap to the closest supported FilamentMixer color."));
-        hex_row->Add(m_hex_input, 1, wxALIGN_CENTER_VERTICAL);
-        hex_row->AddSpacer(FromDIP(8));
-        m_classic_picker = new wxColourPickerCtrl(this, wxID_ANY, safe_initial);
-        m_classic_picker->SetToolTip(_L("Classic color picker. The result will snap to the closest supported FilamentMixer color."));
-        hex_row->Add(m_classic_picker, 0, wxALIGN_CENTER_VERTICAL);
-        root->Add(hex_row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
-
-        auto *range_row = new wxBoxSizer(wxHORIZONTAL);
-        range_row->Add(new wxStaticText(this, wxID_ANY, _L("Range")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
-        m_range_slider = new wxSlider(this, wxID_ANY, m_min_component_percent, 0, 50);
-        m_range_slider->SetToolTip(_L("Minimum percent for each participating color. Higher values block highly skewed mixes."));
-        range_row->Add(m_range_slider, 1, wxALIGN_CENTER_VERTICAL);
-        range_row->AddSpacer(FromDIP(8));
-        m_range_value = new wxStaticText(this, wxID_ANY, wxEmptyString);
-        range_row->Add(m_range_value, 0, wxALIGN_CENTER_VERTICAL);
-        root->Add(range_row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
-
-        auto *summary_grid = new wxFlexGridSizer(2, FromDIP(8), FromDIP(8));
-        summary_grid->AddGrowableCol(1, 1);
-
-        summary_grid->Add(new wxStaticText(this, wxID_ANY, _L("Requested")), 0, wxALIGN_CENTER_VERTICAL);
-        auto *selected_row = new wxBoxSizer(wxHORIZONTAL);
-        m_selected_preview = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(72), FromDIP(24)), wxBORDER_SIMPLE);
-        selected_row->Add(m_selected_preview, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
-        m_selected_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
-        selected_row->Add(m_selected_label, 1, wxALIGN_CENTER_VERTICAL);
-        summary_grid->Add(selected_row, 1, wxEXPAND);
-
-        summary_grid->Add(new wxStaticText(this, wxID_ANY, _L("Creates")), 0, wxALIGN_CENTER_VERTICAL);
-        auto *recipe_row = new wxBoxSizer(wxHORIZONTAL);
-        m_recipe_preview = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(72), FromDIP(24)), wxBORDER_SIMPLE);
-        recipe_row->Add(m_recipe_preview, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
-        m_recipe_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
-        m_recipe_label->Wrap(FromDIP(280));
-        recipe_row->Add(m_recipe_label, 1, wxALIGN_CENTER_VERTICAL);
-        summary_grid->Add(recipe_row, 1, wxEXPAND);
-
-        root->Add(summary_grid, 0, wxEXPAND | wxALL, FromDIP(12));
-
-        m_delta_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
-        root->Add(m_delta_label, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(12));
-
-        m_presets_label = new wxStaticText(this, wxID_ANY, _L("Exact preset mixes"));
-        root->Add(m_presets_label, 0, wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
-        m_presets_host = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(-1, FromDIP(96)),
-                                              wxVSCROLL | wxBORDER_SIMPLE);
-        m_presets_host->SetScrollRate(FromDIP(6), FromDIP(6));
-        m_presets_sizer = new wxWrapSizer(wxHORIZONTAL, wxWRAPSIZER_DEFAULT_FLAGS);
-        m_presets_host->SetSizer(m_presets_sizer);
-        root->Add(m_presets_host, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
-
-        m_error_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
-        m_error_label->SetForegroundColour(wxColour(196, 67, 63));
-        root->Add(m_error_label, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
-
-        if (wxSizer *button_sizer = CreateStdDialogButtonSizer(wxOK | wxCANCEL))
-            root->Add(button_sizer, 0, wxEXPAND | wxALL, FromDIP(12));
-
-        m_loading_panel = new wxPanel(this, wxID_ANY);
-        m_loading_panel->SetMinSize(wxSize(-1, FromDIP(24)));
-        auto *loading_row = new wxBoxSizer(wxHORIZONTAL);
-        m_loading_label = new wxStaticText(m_loading_panel, wxID_ANY, " ");
-        loading_row->Add(m_loading_label, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
-        m_loading_gauge = new wxGauge(m_loading_panel, wxID_ANY, 100, wxDefaultPosition, wxSize(FromDIP(150), FromDIP(8)),
-                                      wxGA_HORIZONTAL | wxGA_SMOOTH);
-        m_loading_gauge->SetValue(0);
-        m_loading_gauge->Enable(false);
-        loading_row->Add(m_loading_gauge, 0, wxALIGN_CENTER_VERTICAL);
-        m_loading_panel->SetSizer(loading_row);
-        root->Add(m_loading_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(12));
-
-        SetSizerAndFit(root);
-
-        m_selected_target = safe_initial;
-        m_requested_target = safe_initial;
-        if (m_color_map)
-            m_color_map->set_min_component_percent(m_min_component_percent);
-        update_range_label();
-        rebuild_presets_ui();
-        sync_inputs_to_requested();
-        update_dialog_state();
-
-        if (m_color_map) {
-            m_color_map->Bind(wxEVT_SLIDER, [this](wxCommandEvent &) {
-                if (!m_color_map)
-                    return;
-                request_recipe_match(m_color_map->selected_color(), true, _L("Matching closest supported mix..."));
-            });
-        }
-
-        if (m_hex_input) {
-            m_hex_input->Bind(wxEVT_TEXT_ENTER, [this](wxCommandEvent &) {
-                apply_hex_input(true);
-            });
-            m_hex_input->Bind(wxEVT_KILL_FOCUS, [this](wxFocusEvent &evt) {
-                apply_hex_input(false);
-                evt.Skip();
-            });
-        }
-        if (m_classic_picker) {
-            m_classic_picker->Bind(wxEVT_COLOURPICKER_CHANGED, [this](wxColourPickerEvent &evt) {
-                if (m_syncing_inputs)
-                    return;
-                apply_requested_target(evt.GetColour());
-            });
-        }
-        if (m_range_slider) {
-            m_range_slider->Bind(wxEVT_SLIDER, [this](wxCommandEvent &) {
-                m_min_component_percent = m_range_slider ? std::clamp(m_range_slider->GetValue(), 0, 50) : m_min_component_percent;
-                update_range_label();
-                if (m_color_map)
-                    m_color_map->set_min_component_percent(m_min_component_percent);
-                rebuild_presets_ui();
-                request_recipe_match(m_requested_target, true, _L("Matching closest supported mix..."));
-            });
-        }
-
-        Bind(wxEVT_TIMER, [this](wxTimerEvent &) { refresh_selected_recipe(); }, m_recipe_timer.GetId());
-        Bind(wxEVT_TIMER, [this](wxTimerEvent &) {
-            if (m_loading_gauge && m_recipe_loading)
-                m_loading_gauge->Pulse();
-        }, m_loading_timer.GetId());
-        if (wxWindow *ok_button = FindWindow(wxID_OK)) {
-            ok_button->Bind(wxEVT_BUTTON, [this](wxCommandEvent &evt) {
-                if (m_recipe_refresh_pending)
-                    refresh_selected_recipe();
-                if (m_recipe_loading || !m_selected_recipe.valid)
-                    return;
-                evt.Skip();
-            });
-        }
-
-        CentreOnParent();
-        wxGetApp().UpdateDlgDarkUI(this);
-    }
-
-    ~MixedFilamentColorMatchDialog() override
-    {
-        if (m_recipe_timer.IsRunning())
-            m_recipe_timer.Stop();
-        if (m_loading_timer.IsRunning())
-            m_loading_timer.Stop();
-    }
-
-    void begin_initial_recipe_load()
-    {
-        request_recipe_match(m_requested_target, false, _L("Calculating closest supported mix..."));
-    }
-
-    MixedColorMatchRecipeResult selected_recipe() const { return m_selected_recipe; }
-
-    void on_dpi_changed(const wxRect &suggested_rect) override
-    {
-        wxUnusedVar(suggested_rect);
-        Layout();
-        Fit();
-        Refresh();
-    }
-
-private:
-    void sync_recipe_preview(MixedColorMatchRecipeResult &recipe, const wxColour *requested_target = nullptr)
-    {
-        if (!recipe.valid)
-            return;
-
-        recipe.preview_color = compute_color_match_recipe_display_color(recipe, m_display_context);
-        if (requested_target != nullptr && requested_target->IsOk())
-            recipe.delta_e = color_delta_e00(*requested_target, recipe.preview_color);
-    }
-
-    void update_range_label()
-    {
-        if (m_range_value)
-            m_range_value->SetLabel(wxString::Format(_L("%d%% min"), m_min_component_percent));
-    }
-
-    void rebuild_presets_ui()
-    {
-        if (!m_presets_host || !m_presets_sizer || !m_presets_label)
-            return;
-
-        m_presets = build_color_match_presets(m_physical_colors, m_min_component_percent);
-        for (MixedColorMatchRecipeResult &preset : m_presets)
-            sync_recipe_preview(preset);
-
-        m_presets_host->Freeze();
-        while (m_presets_sizer->GetItemCount() > 0) {
-            wxSizerItem *item = m_presets_sizer->GetItem(size_t(0));
-            wxWindow *window = item ? item->GetWindow() : nullptr;
-            m_presets_sizer->Remove(0);
-            if (window)
-                window->Destroy();
-        }
-
-        for (const MixedColorMatchRecipeResult &preset : m_presets) {
-            auto *button = new wxBitmapButton(m_presets_host, wxID_ANY,
-                                              make_color_match_swatch_bitmap(preset.preview_color, wxSize(FromDIP(30), FromDIP(20))),
-                                              wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
-            const wxString tooltip = from_u8(summarize_color_match_recipe(preset)) + "\n" +
-                normalize_color_match_hex(preset.preview_color.GetAsString(wxC2S_HTML_SYNTAX));
-            button->SetToolTip(tooltip);
-            button->Bind(wxEVT_BUTTON, [this, preset](wxCommandEvent &) { apply_preset(preset); });
-            m_presets_sizer->Add(button, 0, wxALL, FromDIP(2));
-        }
-
-        m_presets_host->FitInside();
-        const bool show_presets = !m_presets.empty();
-        m_presets_label->Show(show_presets);
-        m_presets_host->Show(show_presets);
-        m_presets_host->Thaw();
-    }
-
-    void set_recipe_loading(bool loading, const wxString &message)
-    {
-        m_recipe_loading = loading;
-        if (!message.empty())
-            m_loading_message = message;
-
-        if (m_loading_label)
-            m_loading_label->SetLabel(loading ? m_loading_message : wxString(" "));
-        if (m_loading_gauge) {
-            if (loading) {
-                m_loading_gauge->Enable(true);
-                m_loading_gauge->Pulse();
-                if (!m_loading_timer.IsRunning())
-                    m_loading_timer.Start(100);
-            } else {
-                if (m_loading_timer.IsRunning())
-                    m_loading_timer.Stop();
-                m_loading_gauge->SetValue(0);
-                m_loading_gauge->Enable(false);
-            }
-        }
-    }
-
-    void sync_inputs_to_requested()
-    {
-        m_syncing_inputs = true;
-        if (m_hex_input)
-            m_hex_input->ChangeValue(normalize_color_match_hex(m_requested_target.GetAsString(wxC2S_HTML_SYNTAX)));
-        if (m_classic_picker)
-            m_classic_picker->SetColour(m_requested_target);
-        m_syncing_inputs = false;
-    }
-
-    bool apply_requested_target(const wxColour &requested_target)
-    {
-        request_recipe_match(requested_target, false, _L("Matching closest supported mix..."));
-        return true;
-    }
-
-    bool apply_hex_input(bool show_invalid_error)
-    {
-        if (!m_hex_input || m_syncing_inputs)
-            return false;
-
-        wxColour parsed;
-        if (!try_parse_color_match_hex(m_hex_input->GetValue(), parsed)) {
-            if (show_invalid_error && m_error_label)
-                m_error_label->SetLabel(_L("Use a valid hex color like #00FF88."));
-            return false;
-        }
-
-        return apply_requested_target(parsed);
-    }
-
-    void request_recipe_match(const wxColour &requested_target, bool debounce, const wxString &loading_message)
-    {
-        m_requested_target = requested_target;
-        m_selected_target = requested_target;
-        sync_inputs_to_requested();
-
-        ++m_recipe_request_token;
-        set_recipe_loading(true, loading_message);
-
-        if (m_recipe_timer.IsRunning())
-            m_recipe_timer.Stop();
-        m_recipe_refresh_pending = debounce;
-        update_dialog_state();
-
-        if (debounce) {
-            m_recipe_timer.StartOnce(120);
-            return;
-        }
-
-        launch_recipe_match(m_recipe_request_token, requested_target);
-    }
-
-    void refresh_selected_recipe()
-    {
-        m_recipe_refresh_pending = false;
-        launch_recipe_match(m_recipe_request_token, m_requested_target);
-    }
-
-    void launch_recipe_match(size_t request_token, const wxColour &requested_target)
-    {
-        const std::vector<std::string> physical_colors = m_physical_colors;
-        const int min_component_percent = m_min_component_percent;
-        wxWeakRef<wxWindow> weak_self(this);
-        std::thread([weak_self, physical_colors, requested_target, request_token, min_component_percent]() {
-            MixedColorMatchRecipeResult recipe = build_best_color_match_recipe(physical_colors, requested_target, min_component_percent);
-            wxGetApp().CallAfter([weak_self, requested_target, recipe = std::move(recipe), request_token]() mutable {
-                if (!weak_self)
-                    return;
-                auto *self = static_cast<MixedFilamentColorMatchDialog *>(weak_self.get());
-                self->handle_recipe_result(request_token, requested_target, std::move(recipe));
-            });
-        }).detach();
-    }
-
-    void handle_recipe_result(size_t request_token, const wxColour &requested_target, MixedColorMatchRecipeResult recipe)
-    {
-        if (request_token != m_recipe_request_token)
-            return;
-
-        m_has_recipe_result = true;
-        m_selected_recipe = std::move(recipe);
-        sync_recipe_preview(m_selected_recipe, &requested_target);
-        set_recipe_loading(false, wxEmptyString);
-
-        if (m_selected_recipe.valid) {
-            m_selected_target = m_selected_recipe.preview_color;
-            if (m_color_map)
-                m_color_map->set_normalized_weights(expand_color_match_recipe_weights(m_selected_recipe, m_palette.size()), false);
-            sync_inputs_to_requested();
-        } else {
-            m_selected_target = requested_target;
-        }
-
-        update_dialog_state();
-    }
-
-    void apply_preset(MixedColorMatchRecipeResult preset)
-    {
-        preset.delta_e = 0.0;
-        sync_recipe_preview(preset);
-        ++m_recipe_request_token;
-        m_requested_target = preset.preview_color;
-        m_selected_target = preset.preview_color;
-        m_selected_recipe = std::move(preset);
-        m_has_recipe_result = true;
-        m_recipe_refresh_pending = false;
-        if (m_recipe_timer.IsRunning())
-            m_recipe_timer.Stop();
-        set_recipe_loading(false, wxEmptyString);
-        if (m_color_map)
-            m_color_map->set_normalized_weights(expand_color_match_recipe_weights(m_selected_recipe, m_palette.size()), false);
-        sync_inputs_to_requested();
-        update_dialog_state();
-    }
-
-    void update_dialog_state()
-    {
-        const wxColour fallback = wxColour("#26A69A");
-        if (m_selected_preview) {
-            m_selected_preview->SetBackgroundColour(m_requested_target.IsOk() ? m_requested_target : fallback);
-            m_selected_preview->Refresh();
-        }
-        if (m_selected_label)
-            m_selected_label->SetLabel(m_requested_target.IsOk() ?
-                normalize_color_match_hex(m_requested_target.GetAsString(wxC2S_HTML_SYNTAX)) :
-                normalize_color_match_hex(fallback.GetAsString(wxC2S_HTML_SYNTAX)));
-
-        const bool valid = m_selected_recipe.valid;
-        const wxColour recipe_color = (valid && m_selected_recipe.preview_color.IsOk()) ?
-            m_selected_recipe.preview_color :
-            (m_requested_target.IsOk() ? m_requested_target : fallback);
-        if (m_recipe_preview) {
-            m_recipe_preview->SetBackgroundColour(recipe_color);
-            m_recipe_preview->Refresh();
-        }
-        if (m_recipe_label) {
-            if (m_recipe_loading) {
-                m_recipe_label->SetLabel(m_loading_message);
-            } else if (valid) {
-                const wxString recipe_summary = from_u8(summarize_color_match_recipe(m_selected_recipe));
-                const wxString recipe_hex = normalize_color_match_hex(recipe_color.GetAsString(wxC2S_HTML_SYNTAX));
-                m_recipe_label->SetLabel(recipe_summary + "  " + recipe_hex);
-            } else if (m_has_recipe_result) {
-                m_recipe_label->SetLabel(_L("No supported 2-color, 3-color, or 4-color recipe found."));
-            } else {
-                m_recipe_label->SetLabel(wxEmptyString);
-            }
-        }
-        if (m_delta_label) {
-            if (m_recipe_loading && m_requested_target.IsOk()) {
-                m_delta_label->SetLabel(wxString::Format(_L("Matching %s..."),
-                                                         normalize_color_match_hex(m_requested_target.GetAsString(wxC2S_HTML_SYNTAX))));
-            } else if (valid && m_requested_target.IsOk()) {
-                m_delta_label->SetLabel(wxString::Format(_L("Requested %s, closest recipe delta: %.2f"),
-                                                         normalize_color_match_hex(m_requested_target.GetAsString(wxC2S_HTML_SYNTAX)),
-                                                         m_selected_recipe.delta_e));
-            } else {
-                m_delta_label->SetLabel(wxEmptyString);
-            }
-        }
-        if (m_error_label) {
-            if (m_recipe_loading)
-                m_error_label->SetLabel(wxEmptyString);
-            else if (!valid && m_has_recipe_result)
-                m_error_label->SetLabel(_L("Unable to create a color mix from the current physical filament colors within the selected range."));
-            else if (m_hex_input && !m_syncing_inputs) {
-                wxColour parsed;
-                if (!try_parse_color_match_hex(m_hex_input->GetValue(), parsed))
-                    m_error_label->SetLabel(_L("Use a valid hex color like #00FF88."));
-                else
-                    m_error_label->SetLabel(wxEmptyString);
-            } else {
-                m_error_label->SetLabel(wxEmptyString);
-            }
-        }
-        if (wxWindow *ok_button = FindWindow(wxID_OK))
-            ok_button->Enable(valid && !m_recipe_loading && !m_recipe_refresh_pending);
-
-        Layout();
-    }
-
-private:
-    std::vector<std::string>                m_physical_colors;
-    MixedFilamentDisplayContext             m_display_context;
-    std::vector<wxColour>                   m_palette;
-    std::vector<MixedColorMatchRecipeResult> m_presets;
-    MixedFilamentColorMapPanel             *m_color_map        = nullptr;
-    wxTextCtrl                             *m_hex_input        = nullptr;
-    wxColourPickerCtrl                     *m_classic_picker   = nullptr;
-    wxSlider                               *m_range_slider     = nullptr;
-    wxStaticText                           *m_range_value      = nullptr;
-    wxStaticText                           *m_presets_label    = nullptr;
-    wxScrolledWindow                       *m_presets_host     = nullptr;
-    wxWrapSizer                            *m_presets_sizer    = nullptr;
-    wxPanel                                *m_loading_panel    = nullptr;
-    wxStaticText                           *m_loading_label    = nullptr;
-    wxGauge                                *m_loading_gauge    = nullptr;
-    wxPanel                                *m_selected_preview = nullptr;
-    wxStaticText                           *m_selected_label   = nullptr;
-    wxPanel                                *m_recipe_preview   = nullptr;
-    wxStaticText                           *m_recipe_label     = nullptr;
-    wxStaticText                           *m_delta_label      = nullptr;
-    wxStaticText                           *m_error_label      = nullptr;
-    wxColour                                m_requested_target { wxColour("#26A69A") };
-    wxColour                                m_selected_target { wxColour("#26A69A") };
-    MixedColorMatchRecipeResult             m_selected_recipe;
-    wxTimer                                 m_recipe_timer;
-    wxTimer                                 m_loading_timer;
-    wxString                                m_loading_message;
-    size_t                                  m_recipe_request_token { 0 };
-    int                                     m_min_component_percent { 15 };
-    bool                                    m_has_recipe_result { false };
-    bool                                    m_recipe_loading { false };
-    bool                                    m_recipe_refresh_pending { false };
-    bool                                    m_syncing_inputs { false };
-};
 
 
 class MixedGradientWeightsDialog : public wxDialog
@@ -4628,66 +4039,6 @@ static std::string mixed_filament_apparent_pair_summary(const MixedFilament     
     return ss.str();
 }
 
-MixedFilamentDisplayContext build_mixed_filament_display_context(const std::vector<std::string> &physical_colors)
-{
-    MixedFilamentDisplayContext context;
-    context.num_physical = physical_colors.size();
-    context.physical_colors = physical_colors;
-    context.nozzle_diameters.assign(context.num_physical, 0.4);
-
-    auto *preset_bundle = wxGetApp().preset_bundle;
-    if (preset_bundle == nullptr)
-        return context;
-
-    DynamicPrintConfig *print_cfg = &preset_bundle->prints.get_edited_preset().config;
-    if (const ConfigOptionFloats *opt = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionFloats>("nozzle_diameter")) {
-        const size_t opt_count = opt->values.size();
-        if (opt_count > 0) {
-            for (size_t i = 0; i < context.num_physical; ++i)
-                context.nozzle_diameters[i] = std::max(0.05, opt->get_at(unsigned(std::min(i, opt_count - 1))));
-        }
-    }
-
-    auto get_mixed_bool = [preset_bundle, print_cfg](const std::string &key, bool fallback) {
-        if (const ConfigOptionBool *opt = preset_bundle->project_config.option<ConfigOptionBool>(key))
-            return opt->value;
-        if (const ConfigOptionInt *opt = preset_bundle->project_config.option<ConfigOptionInt>(key))
-            return opt->value != 0;
-        if (print_cfg != nullptr) {
-            if (const ConfigOptionBool *opt = print_cfg->option<ConfigOptionBool>(key))
-                return opt->value;
-            if (const ConfigOptionInt *opt = print_cfg->option<ConfigOptionInt>(key))
-                return opt->value != 0;
-        }
-        return fallback;
-    };
-    auto get_mixed_float = [preset_bundle, print_cfg](const std::string &key, float fallback) {
-        if (preset_bundle->project_config.has(key))
-            return float(preset_bundle->project_config.opt_float(key));
-        if (print_cfg != nullptr && print_cfg->has(key))
-            return float(print_cfg->opt_float(key));
-        return fallback;
-    };
-
-    context.preview_settings.mixed_lower_bound = std::max(0.01, double(get_mixed_float("mixed_filament_height_lower_bound", 0.04f)));
-    context.preview_settings.mixed_upper_bound = std::max(context.preview_settings.mixed_lower_bound,
-                                                          double(get_mixed_float("mixed_filament_height_upper_bound", 0.16f)));
-    context.preview_settings.preferred_a_height = std::max(0.0, double(get_mixed_float("mixed_color_layer_height_a", 0.f)));
-    context.preview_settings.preferred_b_height = std::max(0.0, double(get_mixed_float("mixed_color_layer_height_b", 0.f)));
-    context.preview_settings.nominal_layer_height = 0.2;
-    if (print_cfg != nullptr && print_cfg->has("layer_height"))
-        context.preview_settings.nominal_layer_height = std::max(0.01, print_cfg->opt_float("layer_height"));
-    if (print_cfg != nullptr && print_cfg->has("wall_loops"))
-        context.preview_settings.wall_loops = std::max<size_t>(1, size_t(std::max(1, print_cfg->opt_int("wall_loops"))));
-    context.preview_settings.local_z_mode = get_mixed_bool("dithering_local_z_mode", false);
-    context.preview_settings.local_z_direct_multicolor =
-        get_mixed_bool("dithering_local_z_direct_multicolor", false) &&
-        context.preview_settings.preferred_a_height <= EPSILON &&
-        context.preview_settings.preferred_b_height <= EPSILON;
-    context.component_bias_enabled = get_mixed_bool("mixed_filament_component_bias_enabled", false);
-
-    return context;
-}
 
 static std::vector<unsigned int> build_display_weighted_multi_sequence(const std::vector<unsigned int> &ids,
                                                                        const std::vector<int>          &weights,
@@ -4811,22 +4162,6 @@ static std::string blend_display_color_from_sequence(const std::vector<std::stri
     return blended;
 }
 
-wxColour compute_color_match_recipe_display_color(const MixedColorMatchRecipeResult &recipe, const MixedFilamentDisplayContext &context)
-{
-    if (!recipe.valid)
-        return recipe.preview_color.IsOk() ? recipe.preview_color : wxColour("#26A69A");
-
-    MixedFilament entry;
-    entry.component_a = recipe.component_a;
-    entry.component_b = recipe.component_b;
-    entry.mix_b_percent = recipe.mix_b_percent;
-    entry.manual_pattern = recipe.manual_pattern;
-    entry.gradient_component_ids = recipe.gradient_component_ids;
-    entry.gradient_component_weights = recipe.gradient_component_weights;
-    entry.distribution_mode = recipe.gradient_component_ids.empty() ? int(MixedFilament::Simple) : int(MixedFilament::LayerCycle);
-
-    return parse_mixed_color(compute_mixed_filament_display_color(entry, context));
-}
 
 std::string MixedFilamentConfigPanel::summarize_sequence(const std::vector<unsigned int> &seq)
 {
@@ -5939,21 +5274,6 @@ static std::vector<size_t> build_mixed_filament_ui_indices(const std::vector<Mix
     }
 
     return ordered_indices;
-}
-
-MixedColorMatchRecipeResult prompt_best_color_match_recipe(wxWindow *parent,
-                                                           const std::vector<std::string> &physical_colors,
-                                                           const wxColour &initial_color)
-{
-    MixedFilamentColorMatchDialog dlg(parent, physical_colors, initial_color);
-    dlg.begin_initial_recipe_load();
-    if (dlg.ShowModal() != wxID_OK) {
-        MixedColorMatchRecipeResult cancelled;
-        cancelled.cancelled = true;
-        return cancelled;
-    }
-
-    return dlg.selected_recipe();
 }
 
 void Sidebar::init_color_mix_panel(wxWindow* parent, wxSizer* sizer)


### PR DESCRIPTION
# Description
- Move MixedFilamentColorMapPanel, MixedGradientSelector, and MixedColorMatchHelpers implementations from header-only to proper .cpp/.hpp pairs, and register them in CMakeLists.txt
- Fix duplicate wxEVT_TEXT binding on pattern control
- Clamp gradient mode to exactly 2 filament rows and hide add/remove buttons in gradient mode
- Replace fixed-pixel strip preview with Bresenham-scheduled 24-segment rendering for consistent cross-DPI behavior
- Guard against division-by-zero when the pattern vector is empty in draw_strip

## Tests
- Open AddColorMixDialog, switch between Ratio / Cycle / Match modes, verify strip preview renders correctly
-  Confirm gradient mode shows exactly 2 filament rows with no add/remove buttons
-  Edit pattern input, confirm preview updates in real time with no duplicate refresh
-  Verify consistent segment count across different DPI scaling levels
-  Build passes with no new warnings