### PR TITLE
Fix Cool Plate temps for Snapmaker PLA SnapSpeed @U1 (60 -> 35 C)

### DIFF
--- a/resources/profiles/Snapmaker/filament/Snapmaker PLA SnapSpeed @U1 base.json
+++ b/resources/profiles/Snapmaker/filament/Snapmaker PLA SnapSpeed @U1 base.json
@@ -53,7 +53,7 @@
       "20"
   ],
   "cool_plate_temp" : [
-      "60"
+      "35"
   ],
   "eng_plate_temp" : [
       "60"
@@ -65,7 +65,7 @@
       "60"
   ],
   "cool_plate_temp_initial_layer" : [
-      "60"
+      "35"
   ],
   "eng_plate_temp_initial_layer" : [
       "60"

--- a/resources/profiles/Snapmaker/filament/Snapmaker PLA SnapSpeed @U1.json
+++ b/resources/profiles/Snapmaker/filament/Snapmaker PLA SnapSpeed @U1.json
@@ -42,10 +42,10 @@
         "70"
     ],
     "cool_plate_temp": [
-        "60"
+        "35"
     ],
     "cool_plate_temp_initial_layer": [
-        "60"
+        "35"
     ],
     "dont_slow_down_outer_wall": [
         "0"


### PR DESCRIPTION


# Description

The @U1 and @U1 base PLA SnapSpeed presets had cool_plate_temp and cool_plate_temp_initial_layer hardcoded to 60 C, inconsistent with the sibling @U1 base2 preset (35 C) and Snapmaker generic PLA defaults. This caused the bed to heat to 60 C during pre-leveling and the first layer when SnapSpeed PLA was the initial extruder in a multi-material print, even when other filaments were configured for a 35 C Cool Plate setpoint.

# Screenshots/Recordings/Graphs

Old situation this PR addresses. Note the temperature of 60C for the Coll Plate.

<img width="735" height="592" alt="image" src="https://github.com/user-attachments/assets/32b447d1-3422-4351-a12c-6699bbd83795" />

## Tests

None so far.
