### PR TITLE
fix wipe tower exceed limit bug

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -886,6 +886,9 @@ std::string WipeTowerIntegration::post_process_wipe_tower_moves(const WipeTower:
                 line.replace(line.find(cur_gcode_start), 3, oss.str());
                 old_pos = transformed_pos;
             }
+			else {
+				continue; // 过滤未经转换后的点
+			}
         }
 
         gcode_out += line + "\n";


### PR DESCRIPTION
Under certain configurations, the gcode code generated by the wipe tower may contain codes that exceed the range of the wipe tower.
