### PR TITLE
feat: add interface to get software basic info

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -466,6 +466,8 @@ void SSWCP_Instance::process() {
         sw_OpenBrowser();
     } else if (m_cmd == "sw_OpenNetworkDialog"){
         sw_OpenNetworkDialog();
+    } else if (m_cmd == "sw_GetSoftwareInfo") {
+        sw_GetSoftwareInfo();
     }
     else {
         handle_general_fail();
@@ -510,6 +512,20 @@ void SSWCP_Instance::sw_UploadEvent() {
     }
 }
 
+void SSWCP_Instance::sw_GetSoftwareInfo()
+{
+    try {
+        m_res_data["version"] = std::string(Snapmaker_VERSION);
+
+        auto& server = wxGetApp().m_page_http_server;
+        m_res_data["http_host"] = std::string("127.0.0.1:") + std::to_string(server.get_port());
+
+        send_to_js();
+        finish_job();
+    } catch (std::exception& e) {
+        handle_general_fail();
+    }
+}
 
 void SSWCP_Instance::sw_OpenNetworkDialog() {
     try {

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -29,6 +29,7 @@
 #include "MoonRaker.hpp"
 
 #include "slic3r/GUI/WebPresetDialog.hpp"
+#include "slic3r/GUI/HttpServer.hpp"
 #include <mutex>
 
 #include "slic3r/GUI/SMPhysicalPrinterDialog.hpp"
@@ -518,7 +519,7 @@ void SSWCP_Instance::sw_GetSoftwareInfo()
         m_res_data["version"] = std::string(Snapmaker_VERSION);
 
         auto& server = wxGetApp().m_page_http_server;
-        m_res_data["http_host"] = std::string("127.0.0.1:") + std::to_string(server.get_port());
+        m_res_data["http_host"] = std::string(LOCALHOST_URL) + std::to_string(server.get_port());
 
         send_to_js();
         finish_job();

--- a/src/slic3r/GUI/SSWCP.hpp
+++ b/src/slic3r/GUI/SSWCP.hpp
@@ -188,6 +188,9 @@ private:
     // Sentry
     void sw_UploadEvent();
 
+    // Get software basic info
+    void sw_GetSoftwareInfo();
+
     // open network dialog
     void sw_OpenNetworkDialog();
 


### PR DESCRIPTION
## 概述
新增 `sw_GetSoftwareInfo` 命令，供 Flutter Web 端获取软件基础信息。

## 改动内容
- `SSWCP.hpp`: 声明 `sw_GetSoftwareInfo()` 方法
- `SSWCP.cpp`: 在 `process()` 中添加命令分发，实现 `sw_GetSoftwareInfo()` 逻辑

## 接口说明
- **命令**: `sw_GetSoftwareInfo`
- **参数**: 无
- **返回**:
  - `version`: 软件版本号
  - `http_host`: 本地 HTTP 服务器地址

## 测试计划
- [x] Flutter Web 端调用接口确认返回数据正确
- [x] 版本号与 `version.inc` 一致
- [x] `http_host` 端口与 `PAGE_HTTP_PORT` 一致


_____________________________________________________________________________________________________________

## Summary
Add `sw_GetSoftwareInfo` command to provide software basic information to the Flutter Web frontend.

## Changes
- `SSWCP.hpp`: Declare `sw_GetSoftwareInfo()` method
- `SSWCP.cpp`: Add command dispatch in `process()` and implement `sw_GetSoftwareInfo()`

## API
- **Command**: `sw_GetSoftwareInfo`
- **Parameters**: none
- **Response**:
  - `version`: Software version string
  - `http_host`: Local HTTP server address

## Test plan
- [x] Verify response data from Flutter Web side
- [x] Confirm version matches `version.inc`
- [x] Confirm `http_host` port matches `PAGE_HTTP_PORT`
