### PR TITLE
feat: add material compatibility validation for mixed filament

### DIFF
--- a/localization/i18n/Snapmaker_Orca.pot
+++ b/localization/i18n/Snapmaker_Orca.pot
@@ -16255,3 +16255,6 @@ msgstr ""
 
 msgid "OrcaSlicer is forked from Bambu Studio by Bambu Lab."
 msgstr ""
+
+msgid "Incompatible filament types cannot be mixed. Please correct the selection."
+msgstr ""

--- a/localization/i18n/en/Snapmaker_Orca_en.po
+++ b/localization/i18n/en/Snapmaker_Orca_en.po
@@ -7231,6 +7231,9 @@ msgstr "Cannot send print tasks when an update is in progress"
 msgid "The selected printer is incompatible with the chosen printer presets."
 msgstr ""
 
+msgid "Incompatible filament types cannot be mixed. Please correct the selection."
+msgstr ""
+
 msgid "An SD card needs to be inserted before send to printer SD card."
 msgstr ""
 "A MicroSD card needs to be inserted before sending to the printer SD card."

--- a/localization/i18n/ja/Snapmaker_Orca_ja.po
+++ b/localization/i18n/ja/Snapmaker_Orca_ja.po
@@ -7255,6 +7255,9 @@ msgstr "アップデート中では造形タスクを送信できません"
 msgid "The selected printer is incompatible with the chosen printer presets."
 msgstr ""
 
+msgid "Incompatible filament types cannot be mixed. Please correct the selection."
+msgstr "互換性のないフィラメントタイプは混合できません。選択を修正してください。"
+
 msgid "An SD card needs to be inserted before send to printer SD card."
 msgstr ""
 

--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -6960,6 +6960,9 @@ msgstr "设备升级中，无法发送打印任务"
 msgid "The selected printer is incompatible with the chosen printer presets."
 msgstr "所选打印机与选择的打印机预设不兼容。"
 
+msgid "Incompatible filament types cannot be mixed. Please correct the selection."
+msgstr "不同类型耗材不可混色打印，请修正异常混色设置。"
+
 msgid "An SD card needs to be inserted before send to printer SD card."
 msgstr "发送到打印机需要插入SD卡"
 

--- a/localization/i18n/zh_TW/Snapmaker_Orca_zh_TW.po
+++ b/localization/i18n/zh_TW/Snapmaker_Orca_zh_TW.po
@@ -7317,6 +7317,9 @@ msgstr "設備升級中，無法傳送列印作業"
 msgid "The selected printer is incompatible with the chosen printer presets."
 msgstr "所選列印設備與選擇的列印設備預設檔不相容。"
 
+msgid "Incompatible filament types cannot be mixed. Please correct the selection."
+msgstr "不同類型耗材不可混色列印，請修正異常混色設定。"
+
 msgid "An SD card needs to be inserted before send to printer SD card."
 msgstr "傳送到列印設備需要插入 SD 記憶卡。"
 

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -3,6 +3,10 @@
 #include <unordered_set>
 #include <ColorSpaceConvert.hpp>
 #include "MixedFilamentColorMapPanel.hpp"
+#include "GUI_App.hpp"
+#include "PresetBundle.hpp"
+#include <algorithm>
+#include <boost/log/trivial.hpp>
 
 namespace Slic3r { namespace GUI {
 wxColour parse_mixed_color(const std::string& value)
@@ -648,6 +652,137 @@ wxColour blend_sequence_filament_mixer(const std::vector<wxColour>& palette, con
     }
 
     return blend_multi_filament_mixer(colors, weights);
+}
+
+// ---------------------------------------------------------------------------
+// Material compatibility
+// ---------------------------------------------------------------------------
+static const std::unordered_map<std::string, int>& filament_compatibility_group_map()
+{
+    static const std::unordered_map<std::string, int> m = {
+        {"PLA", 1}, {"PLA-AERO", 1}, {"PLA-CF", 1},
+        {"ABS", 2}, {"ABS-GF", 2},
+        {"ASA", 3}, {"ASA-Aero", 3},
+        {"PETG", 4}, {"PETG-CF", 4}, {"PETG-CF10", 4}, {"PETG-GF", 4},
+        {"TPU", 5}, {"FLEX", 5}, {"EVA", 5}, {"SBS", 5},
+        {"PCTG", 6},
+        {"HIPS", 7},
+        {"BVOH", 8}, {"PVA", 8}, {"PVB", 8},
+        {"PA", 9}, {"PA-CF", 9}, {"PA-GF", 9}, {"PA6-CF", 9}, {"PA11-CF", 9},
+        {"PC", 10}, {"PC-CF", 10},
+        {"PP", 11}, {"PP-CF", 11}, {"PP-GF", 11},
+        {"PE", 12}, {"PE-CF", 12},
+        {"PET-CF", 13},
+        {"PHA", 14},
+        {"PPS", 15}, {"PPS-CF", 15}, {"PPA", 15}, {"PPA-CF", 15}, {"PPA-GF", 15},
+    };
+    return m;
+}
+
+static std::string normalize_filament_type(const std::string& type)
+{
+    std::string normalized = type;
+    // Trim leading/trailing whitespace
+    size_t start = normalized.find_first_not_of(" \t\r\n");
+    size_t end = normalized.find_last_not_of(" \t\r\n");
+    if (start != std::string::npos && end != std::string::npos) {
+        normalized = normalized.substr(start, end - start + 1);
+    }
+    // Convert to uppercase
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(), ::toupper);
+    return normalized;
+}
+
+int get_filament_compatibility_group(const std::string& filament_type)
+{
+    if (filament_type.empty()) {
+        BOOST_LOG_TRIVIAL(warning) << "Empty filament type in compatibility check";
+        return -1;
+    }
+
+    const auto& m = filament_compatibility_group_map();
+    auto it = m.find(filament_type);
+    if (it != m.end()) return it->second;
+    std::string normalized = normalize_filament_type(filament_type);
+    it = m.find(normalized);
+    if (it != m.end()) return it->second;
+
+    // Assign stable unique group IDs to unknown types (no hash collision risk)
+    static std::unordered_map<std::string, int> unknown_groups;
+    static int next_unknown_group = 100;
+    auto uit = unknown_groups.find(normalized);
+    if (uit != unknown_groups.end()) return uit->second;
+    int group = next_unknown_group++;
+    unknown_groups[normalized] = group;
+    BOOST_LOG_TRIVIAL(info) << "Unknown filament type '" << filament_type
+                            << "' assigned to compatibility group " << group;
+    return group;
+}
+
+bool are_filaments_compatible(const std::vector<unsigned int>& filament_ids)
+{
+    if (filament_ids.size() <= 1) return true;
+
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    if (!preset_bundle) {
+        BOOST_LOG_TRIVIAL(error) << "PresetBundle is null in filament compatibility check";
+        return false;
+    }
+
+    const std::vector<std::string>& filament_presets = preset_bundle->filament_presets;
+    
+    int common_group = -1;
+    std::string first_type_name;
+    
+    for (unsigned int id : filament_ids) {
+        if (id >= filament_presets.size()) {
+            BOOST_LOG_TRIVIAL(warning) << "Filament ID " << id << " out of range (max: " 
+                                       << filament_presets.size() - 1 << ")";
+            continue;
+        }
+        
+        const Preset* preset = preset_bundle->filaments.find_preset(filament_presets[id]);
+        if (!preset) {
+            BOOST_LOG_TRIVIAL(warning) << "Preset not found for filament ID " << id;
+            continue;
+        }
+        
+        auto* type_opt = dynamic_cast<const ConfigOptionStrings*>(preset->config.option("filament_type"));
+        if (!type_opt || type_opt->values.empty()) {
+            BOOST_LOG_TRIVIAL(warning) << "Filament type not found for preset '" 
+                                       << preset->name << "'";
+            continue;
+        }
+        
+        const std::string& type_name = type_opt->values[0];
+        int group = get_filament_compatibility_group(type_name);
+        
+        if (group < 0) {
+            BOOST_LOG_TRIVIAL(warning) << "Invalid compatibility group for filament ID " << id;
+            continue;
+        }
+        
+        if (common_group < 0) {
+            common_group = group;
+            first_type_name = type_name;
+            BOOST_LOG_TRIVIAL(debug) << "Reference filament type: '" << type_name 
+                                     << "' (group " << group << ")";
+        }
+        else if (common_group != group) {
+            BOOST_LOG_TRIVIAL(info) << "Incompatible filament types detected: '" 
+                                    << first_type_name << "' (group " << common_group 
+                                    << ") vs '" << type_name << "' (group " << group << ")";
+            return false;
+        }
+    }
+    
+    if (common_group < 0) {
+        BOOST_LOG_TRIVIAL(warning) << "No valid filament types found in compatibility check";
+        return true;
+    }
+    
+    BOOST_LOG_TRIVIAL(debug) << "All filaments compatible (group " << common_group << ")";
+    return true;
 }
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedColorMatchHelpers.hpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.hpp
@@ -74,4 +74,9 @@ bool color_match_weights_within_range(const std::vector<int>& weights, int min_c
 std::vector<unsigned int>   build_color_match_sequence(const std::vector<unsigned int>& ids, const std::vector<int>& weights);
 wxColour                    blend_sequence_filament_mixer(const std::vector<wxColour>& palette, const std::vector<unsigned int>& sequence);
 
+// ---- material compatibility ----
+
+int  get_filament_compatibility_group(const std::string& filament_type);
+bool are_filaments_compatible(const std::vector<unsigned int>& filament_ids);
+
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -165,6 +165,7 @@ void MixedFilamentDialog::build_ui()
         resize_gradient_ids(new_count);
         wxTheApp->CallAfter([this]() {
             rebuild_filament_rows();
+            update_compatibility_warning();
             Layout(); Fit();
         });
     });
@@ -173,6 +174,7 @@ void MixedFilamentDialog::build_ui()
         resize_gradient_ids((int)m_filament_rows.size() + 1);
         wxTheApp->CallAfter([this]() {
             rebuild_filament_rows();
+            update_compatibility_warning();
             Layout(); Fit();
         });
     });
@@ -193,6 +195,21 @@ void MixedFilamentDialog::build_ui()
             m_preview_panel->Refresh();
     });
     
+    // Compatibility warning banner (hidden by default, shown when incompatible filaments are selected)
+    {
+        m_compat_warning_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition,
+                                              wxDefaultSize, wxBORDER_NONE | wxTAB_TRAVERSAL);
+        m_compat_warning_panel->SetBackgroundColour(wxColour("#FDE8E8"));
+        m_compat_warning_panel->Hide();
+        auto* warn_sizer = new wxBoxSizer(wxHORIZONTAL);
+        m_compat_warning_text = new wxStaticText(m_compat_warning_panel, wxID_ANY, wxEmptyString);
+        m_compat_warning_text->SetForegroundColour(wxColour("#D32F2F"));
+        m_compat_warning_text->Wrap(FromDIP(400));
+        warn_sizer->Add(m_compat_warning_text, 1, wxALL, FromDIP(8));
+        m_compat_warning_panel->SetSizer(warn_sizer);
+        left_col->Add(m_compat_warning_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(4));
+    }
+
     // Title row for left column: title + swap button + add/remove buttons
     auto* title_row = new wxBoxSizer(wxHORIZONTAL);
     m_filament_title = new wxStaticText(this, wxID_ANY, _L("Mixed Filament"));
@@ -440,6 +457,7 @@ void MixedFilamentDialog::build_ui()
     SetSizer(top_sizer);
 
     rebuild_filament_rows();
+    update_compatibility_warning();
 
     // RadioGroup fires wxEVT_BUTTON on its internal label buttons; bind at panel level
     m_mode_radio->Bind(wxEVT_COMMAND_RADIOBOX_SELECTED, [this](wxCommandEvent&) {
@@ -693,6 +711,7 @@ void MixedFilamentDialog::rebuild_filament_rows()
             // Update preview
             if (m_tri_picker) m_tri_picker->Refresh();
             update_preview();
+            update_compatibility_warning();
         });
 
         row->Add(cb, 1, wxALIGN_CENTER_VERTICAL);
@@ -926,6 +945,37 @@ void MixedFilamentDialog::sync_rows_to_result()
         ids += char('1' + std::max(0, s));
     }
     m_result.gradient_component_ids = ids;
+}
+
+void MixedFilamentDialog::update_compatibility_warning()
+{
+    if (!m_compat_warning_panel || !m_compat_warning_text || !m_btn_confirm)
+        return;
+
+    sync_rows_to_result();
+
+    std::vector<unsigned int> fids;
+    if (!m_result.gradient_component_ids.empty()) {
+        for (char c : m_result.gradient_component_ids) {
+            int idx = c - '1';
+            if (idx >= 0) fids.push_back(static_cast<unsigned int>(idx));
+        }
+    }
+    if (m_result.component_a >= 1) fids.push_back(m_result.component_a - 1);
+    if (m_result.component_b >= 1) fids.push_back(m_result.component_b - 1);
+
+    if (!are_filaments_compatible(fids)) {
+        m_compat_warning_text->SetLabel(_L("Incompatible filament types cannot be mixed. Please correct the selection."));
+        m_compat_warning_text->Wrap(FromDIP(360));
+        m_compat_warning_panel->Show();
+        m_btn_confirm->SetStyle(ButtonStyle::Disabled, ButtonType::Window);
+        m_btn_confirm->Disable();
+    } else {
+        m_compat_warning_panel->Hide();
+        m_btn_confirm->SetStyle(ButtonStyle::Confirm, ButtonType::Window);
+        m_btn_confirm->Enable();
+    }
+    Layout();
 }
 
 std::string MixedFilamentDialog::compute_preview_color()
@@ -1286,6 +1336,7 @@ void MixedFilamentDialog::build_swatch_grid()
                 m_tri_wz = cand.wz;
             }
             update_preview();
+            update_compatibility_warning();
         });
         grid->Add(btn);
     }
@@ -1315,6 +1366,7 @@ void MixedFilamentDialog::on_mode_changed(int mode_index)
     rebuild_filament_rows();
     update_ratio_or_tri_visibility();
     update_preview();
+    update_compatibility_warning();
     Layout(); Fit();
 }
 

--- a/src/slic3r/GUI/MixedFilamentDialog.hpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.hpp
@@ -41,6 +41,7 @@ private:
     void build_swatch_grid();
     void sync_rows_to_result();
     void resize_gradient_ids(int target_count);
+    void update_compatibility_warning();
     std::string compute_preview_color();
     wxBitmap make_color_bitmap(const wxColour& c, int size);
     int max_filaments_for_mode(int mode_index) const;
@@ -75,6 +76,8 @@ private:
     wxStaticLine*           m_line_above_swatch   = nullptr;
     wxStaticLine*           m_line_below_swatch   = nullptr;
     wxStaticText*           m_recommended_label   = nullptr;
+    wxPanel*                m_compat_warning_panel  = nullptr;
+    wxStaticText*           m_compat_warning_text   = nullptr;
     Button*                 m_btn_cancel          = nullptr;
     Button*                 m_btn_confirm         = nullptr;
     wxTextCtrl*             m_pattern_ctrl        = nullptr;


### PR DESCRIPTION
  This PR adds material compatibility validation for the mixed filament feature. Currently, users can mix incompatible      
  filament types (e.g., PLA + PETG) which can cause print failures due to different melting temperatures and poor
  inter-layer adhesion. This change blocks such combinations by checking a compatibility group table.