### PR TITLE
Feature filament extruder special

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -830,11 +830,7 @@ std::string WipeTowerIntegration::post_process_wipe_tower_moves(const WipeTower:
                                                                 const Vec2f&                       translation,
                                                                 float                              angle) const
 {
-    Vec2f extruder_offset;
-    if (m_single_extruder_multi_material)
-        extruder_offset = m_extruder_offsets[0].cast<float>();
-    else
-        extruder_offset = m_extruder_offsets[tcr.initial_tool].cast<float>();
+    Vec2f extruder_offset = extruder_offset_at(tcr.initial_tool).cast<float>();
 
     std::istringstream gcode_str(tcr.gcode);
     std::string        gcode_out;
@@ -894,10 +890,10 @@ std::string WipeTowerIntegration::post_process_wipe_tower_moves(const WipeTower:
         if (line == "[change_filament_gcode]") {
             // BBS
             if (!m_single_extruder_multi_material) {
-                extruder_offset = m_extruder_offsets[tcr.new_tool].cast<float>();
+                extruder_offset = extruder_offset_at(tcr.new_tool).cast<float>();
 
                 // If the extruder offset changed, add an extra move so everything is continuous
-                if (extruder_offset != m_extruder_offsets[tcr.initial_tool].cast<float>()) {
+                if (extruder_offset != extruder_offset_at(tcr.initial_tool).cast<float>()) {
                     std::ostringstream oss;
                     oss << std::fixed << std::setprecision(3) << "G1 X" << transformed_pos.x() - extruder_offset.x() << " Y"
                         << transformed_pos.y() - extruder_offset.y() << "\n";
@@ -907,6 +903,19 @@ std::string WipeTowerIntegration::post_process_wipe_tower_moves(const WipeTower:
         }
     }
     return gcode_out;
+}
+
+Vec2d WipeTowerIntegration::extruder_offset_at(size_t extruder_id) const
+{
+    if (m_single_extruder_multi_material) {
+        return m_extruder_offsets[0];
+    } else {
+        // If the extruder_id is out of range, we return the offset of the first extruder. 
+        if (extruder_id >= m_extruder_offsets.size())
+            return m_extruder_offsets[0];
+        else
+            return m_extruder_offsets[extruder_id];
+    }
 }
 
 std::string WipeTowerIntegration::prime(GCode& gcodegen)

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -116,6 +116,10 @@ private:
     // Postprocesses gcode: rotates and moves G1 extrusions and returns result
     std::string post_process_wipe_tower_moves(const WipeTower::ToolChangeResult& tcr, const Vec2f& translation, float angle) const;
     // Left / right edges of the wipe tower, for the planning of wipe moves.
+
+    Vec2d extruder_offset_at(size_t extruder_id) const;
+
+private:
     const float                                                  m_left;
     const float                                                  m_right;
     const Vec2f                                                  m_wipe_tower_pos;

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -1106,14 +1106,12 @@ void GCodeViewer::refresh(const GCodeProcessorResult& gcode_result, const std::v
     if (m_view_type == EViewType::Tool && !gcode_result.extruder_colors.empty()) {
         // update tool colors from config stored in the gcode
         decode_colors(gcode_result.extruder_colors, m_tools.m_tool_colors);
-        m_tools.m_tool_visibles = std::vector<bool>(m_tools.m_tool_colors.size());
-        for (auto item: m_tools.m_tool_visibles) item = true;
+        m_tools.m_tool_visibles.assign(m_tools.m_tool_colors.size(), true);
     }
     else {
         // update tool colors
         decode_colors(str_tool_colors, m_tools.m_tool_colors);
-        m_tools.m_tool_visibles = std::vector<bool>(m_tools.m_tool_colors.size());
-        for (auto item : m_tools.m_tool_visibles) item = true;
+        m_tools.m_tool_visibles.assign(m_tools.m_tool_colors.size(), true);
     }
 
     for (int i = 0; i < m_tools.m_tool_colors.size(); i++) {

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -865,7 +865,7 @@ public:
                 m_extrusions.role_visibility_flags = m_extrusions.role_visibility_flags | (1 << role);
             }
         } else if (type == EViewType::ColorPrint){
-            for(auto item: m_tools.m_tool_visibles) item = true;
+            m_tools.m_tool_visibles.assign(m_tools.m_tool_visibles.size(), true);
         }
     }
 


### PR DESCRIPTION
Fixed the issue where slicing would crash when the color consumables exceeded 4 types, and the problem of out-of-bounds access in the extruder array causing a crash. When the index id of the extruder is greater than or equal to the total number of extruders, it defaults to the 0th extruder.