### PR TITLE
Revert "fix：Temporarily enable the ability to export gcode.3mf"

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1733,8 +1733,8 @@ wxBoxSizer* MainFrame::create_side_tools()
         {
         SidePopup* p = new SidePopup(this);
 
-        //if (wxGetApp().preset_bundle && !wxGetApp().preset_bundle->is_bbl_vendor())
-        if (0)
+        if (wxGetApp().preset_bundle && !wxGetApp().preset_bundle->is_bbl_vendor())
+        //if (0)
         {
             // ThirdParty Buttons
             SideButton* export_gcode_btn = new SideButton(p, _L("Export G-code file"), "");


### PR DESCRIPTION
This reverts commit a3c3e5e5400e0ca68847d7b6817aa85fa835eabb.

# Description
Revert "fix：Temporarily enable the ability to export gcode.3mf"
