### PR TITLE
Fix: bypass 512MB postMessage limit for file transfer and add file integrity checksum

### DIFF
--- a/src/slic3r/GUI/HttpServer.cpp
+++ b/src/slic3r/GUI/HttpServer.cpp
@@ -759,7 +759,9 @@ std::string HttpServer::map_url_to_file_path(const std::string& url)
             }
         }
         // Pad to multiple of 4 for base64 decode
-        while (b64.size() % 4 != 0) b64 += '=';
+        while (b64.size() % 4 != 0) {
+            b64 += '=';
+        }
         std::string decoded;
         decoded.resize(boost::beast::detail::base64::decoded_size(b64.size()));
         auto result = boost::beast::detail::base64::decode(decoded.data(), b64.data(), b64.size());

--- a/src/slic3r/GUI/HttpServer.cpp
+++ b/src/slic3r/GUI/HttpServer.cpp
@@ -5,6 +5,7 @@
 #include "slic3r/Utils/Http.hpp"
 #include "slic3r/Utils/NetworkAgent.hpp"
 #include  "sentry_wrapper/SentryWrapper.hpp"
+#include <boost/beast/core/detail/base64.hpp>
 #ifdef _WIN32
 #include <windows.h>
 #include <io.h>
@@ -717,7 +718,8 @@ std::shared_ptr<HttpServer::Response> HttpServer::web_server_handle_request(cons
     }
 
     BOOST_LOG_TRIVIAL(info) << "Handling file_path request for URL: " << file_path;
-    return std::make_shared<ResponseFile>(file_path);
+    bool native_path = (url.find(WCP_DOWNLOAD_PREFIX) != std::string::npos);
+    return std::make_shared<ResponseFile>(file_path, native_path);
 }
 
 std::string HttpServer::map_url_to_file_path(const std::string& url)
@@ -745,6 +747,22 @@ std::string HttpServer::map_url_to_file_path(const std::string& url)
         }
 
         return realUTF8Path;
+    }
+    else if (trimmed_url.find(WCP_DOWNLOAD_PREFIX) == 0) {
+        // Decode URL-safe base64-encoded path: revert '-'→'+', '_'→'/', then pad
+        auto b64 = std::string(trimmed_url.substr(strlen(WCP_DOWNLOAD_PREFIX)).ToStdString(wxConvUTF8));
+        for (auto& c : b64) {
+            if (c == '-') c = '+';
+            else if (c == '_') c = '/';
+        }
+        // Pad to multiple of 4 for base64 decode
+        while (b64.size() % 4 != 0) b64 += '=';
+        std::string decoded;
+        decoded.resize(boost::beast::detail::base64::decoded_size(b64.size()));
+        auto result = boost::beast::detail::base64::decode(decoded.data(), b64.data(), b64.size());
+        decoded.resize(result.first);
+
+        return decoded;
     }
     auto data_web_path = boost::filesystem::path(data_dir()) / "web";
     if (!boost::filesystem::exists(data_web_path / "flutter_web")) {
@@ -803,11 +821,35 @@ void HttpServer::ResponseNotFound::write_response(std::stringstream& ssOut)
 
 void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
 {
-    // 将UTF-8路径转换为适合文件系统操作的编码，自动适配Windows的UTF-8模式
-    std::string system_file_path = utf8_to_filesystem_encoding(file_path);
-    
+    // Convert UTF-8 path to filesystem encoding (auto-adapts for Windows UTF-8 mode).
+    // If m_native_path is true, the path is already in system encoding (e.g., from base64 decode).
+    std::string system_file_path = m_native_path ? file_path : utf8_to_filesystem_encoding(file_path);
+
     std::ifstream file(system_file_path, std::ios::binary);
     if (!file) {
+        // Fallback: if the native path didn't work, try the raw UTF-8 path
+        if (m_native_path) {
+            std::ifstream file2(file_path, std::ios::binary);
+            if (file2.is_open()) {
+                // Use the UTF-8 path instead
+                std::ostringstream fileStream;
+                fileStream << file2.rdbuf();
+                std::string fileContent    = fileStream.str();
+                size_t      content_length = fileContent.size();
+                std::string content_type   = "application/octet-stream";
+                if (ends_with(file_path, ".gcode") || ends_with(file_path, ".gcode.zip"))
+                    content_type = "application/octet-stream";
+
+                ssOut << "HTTP/1.1 200 OK\r\n";
+                ssOut << "Content-Type: " << content_type << "\r\n";
+                ssOut << "Content-Length: " << content_length << "\r\n";
+                ssOut << "Content-Disposition: attachment\r\n";
+                ssOut << "Access-Control-Allow-Origin: *\r\n";
+                ssOut << "\r\n";
+                ssOut.write(fileContent.c_str(), content_length);
+                return;
+            }
+        }
         ResponseNotFound notFoundResponse;
         notFoundResponse.write_response(ssOut);
         return;

--- a/src/slic3r/GUI/HttpServer.cpp
+++ b/src/slic3r/GUI/HttpServer.cpp
@@ -826,30 +826,12 @@ void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
     std::string system_file_path = m_native_path ? file_path : utf8_to_filesystem_encoding(file_path);
 
     std::ifstream file(system_file_path, std::ios::binary);
+    if (!file && m_native_path) {
+        // Native path failed; retry with UTF-8 → filesystem encoding conversion
+        system_file_path = utf8_to_filesystem_encoding(file_path);
+        file.open(system_file_path, std::ios::binary);
+    }
     if (!file) {
-        // Fallback: if the native path didn't work, try the raw UTF-8 path
-        if (m_native_path) {
-            std::ifstream file2(file_path, std::ios::binary);
-            if (file2.is_open()) {
-                // Use the UTF-8 path instead
-                std::ostringstream fileStream;
-                fileStream << file2.rdbuf();
-                std::string fileContent    = fileStream.str();
-                size_t      content_length = fileContent.size();
-                std::string content_type   = "application/octet-stream";
-                if (ends_with(file_path, ".gcode") || ends_with(file_path, ".gcode.zip"))
-                    content_type = "application/octet-stream";
-
-                ssOut << "HTTP/1.1 200 OK\r\n";
-                ssOut << "Content-Type: " << content_type << "\r\n";
-                ssOut << "Content-Length: " << content_length << "\r\n";
-                ssOut << "Content-Disposition: attachment\r\n";
-                ssOut << "Access-Control-Allow-Origin: *\r\n";
-                ssOut << "\r\n";
-                ssOut.write(fileContent.c_str(), content_length);
-                return;
-            }
-        }
         ResponseNotFound notFoundResponse;
         notFoundResponse.write_response(ssOut);
         return;

--- a/src/slic3r/GUI/HttpServer.cpp
+++ b/src/slic3r/GUI/HttpServer.cpp
@@ -826,13 +826,15 @@ void HttpServer::ResponseNotFound::write_response(std::stringstream& ssOut)
 
 void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
 {
-    // Try UTF-8 → filesystem encoding conversion first.
-    // On UTF-8 systems this is a no-op; on non-UTF-8 Windows it converts to system encoding (e.g. GBK).
-    std::string system_file_path = utf8_to_filesystem_encoding(file_path);
-    std::ifstream file(system_file_path, std::ios::binary);
-    if (!file) {
-        // Fallback: try the raw path (handles paths already in system encoding, e.g. from base64 decode)
+    std::ifstream file;
+    if (m_native_path) {
         file.open(file_path, std::ios::binary);
+    } else {
+        std::string system_file_path = utf8_to_filesystem_encoding(file_path);
+        file.open(system_file_path, std::ios::binary);
+        if (!file) {
+            file.open(file_path, std::ios::binary);
+        }
     }
     if (!file) {
         ResponseNotFound notFoundResponse;

--- a/src/slic3r/GUI/HttpServer.cpp
+++ b/src/slic3r/GUI/HttpServer.cpp
@@ -752,8 +752,11 @@ std::string HttpServer::map_url_to_file_path(const std::string& url)
         // Decode URL-safe base64-encoded path: revert '-'→'+', '_'→'/', then pad
         auto b64 = std::string(trimmed_url.substr(strlen(WCP_DOWNLOAD_PREFIX)).ToStdString(wxConvUTF8));
         for (auto& c : b64) {
-            if (c == '-') c = '+';
-            else if (c == '_') c = '/';
+            if (c == '-') {
+                c = '+';
+            } else if (c == '_') {
+                c = '/';
+            }
         }
         // Pad to multiple of 4 for base64 decode
         while (b64.size() % 4 != 0) b64 += '=';
@@ -821,15 +824,13 @@ void HttpServer::ResponseNotFound::write_response(std::stringstream& ssOut)
 
 void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
 {
-    // Convert UTF-8 path to filesystem encoding (auto-adapts for Windows UTF-8 mode).
-    // If m_native_path is true, the path is already in system encoding (e.g., from base64 decode).
-    std::string system_file_path = m_native_path ? file_path : utf8_to_filesystem_encoding(file_path);
-
+    // Try UTF-8 → filesystem encoding conversion first.
+    // On UTF-8 systems this is a no-op; on non-UTF-8 Windows it converts to system encoding (e.g. GBK).
+    std::string system_file_path = utf8_to_filesystem_encoding(file_path);
     std::ifstream file(system_file_path, std::ios::binary);
-    if (!file && m_native_path) {
-        // Native path failed; retry with UTF-8 → filesystem encoding conversion
-        system_file_path = utf8_to_filesystem_encoding(file_path);
-        file.open(system_file_path, std::ios::binary);
+    if (!file) {
+        // Fallback: try the raw path (handles paths already in system encoding, e.g. from base64 decode)
+        file.open(file_path, std::ios::binary);
     }
     if (!file) {
         ResponseNotFound notFoundResponse;

--- a/src/slic3r/GUI/HttpServer.hpp
+++ b/src/slic3r/GUI/HttpServer.hpp
@@ -17,6 +17,7 @@
 #define LOCALHOST_PORT      13618
 #define PAGE_HTTP_PORT      13619
 #define LOCALHOST_URL       "http://127.0.0.1:"
+#define WCP_DOWNLOAD_PREFIX "/wcp_download/"
 
 namespace Slic3r { namespace GUI {
 
@@ -106,9 +107,10 @@ public:
     class ResponseFile : public Response
     {
         std::string file_path;
+        bool        m_native_path = false;  // true if path is already in system encoding, skip UTF-8 conversion
 
     public:
-        ResponseFile(const std::string& path) : file_path(path){}
+        ResponseFile(const std::string& path, bool native_path = false) : file_path(path), m_native_path(native_path) {}
         ~ResponseFile() override = default;
 
         void write_response(std::stringstream& ssOut) override;

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -402,9 +402,10 @@ static std::string calc_sha256_base64(const std::string& file_path)
     SHA256_CTX ctx;
     SHA256_Init(&ctx);
 
-    char buf[64 * 1024];
-    while (ifs.read(buf, sizeof(buf)) || ifs.gcount() > 0) {
-        SHA256_Update(&ctx, buf, ifs.gcount());
+    static constexpr size_t kChunkSize = 64 * 1024;
+    std::string             buf(kChunkSize, 0);
+    while (ifs.read(buf.data(), buf.size()) || ifs.gcount() > 0) {
+        SHA256_Update(&ctx, buf.data(), ifs.gcount());
     }
 
     unsigned char digest[SHA256_DIGEST_LENGTH];

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -388,8 +388,11 @@ std::string make_wcp_download_url(const std::string& file_path)
     auto& server = wxGetApp().m_page_http_server;
     std::string b64 = base64_encode(file_path.data(), file_path.size());
     for (auto& c : b64) {
-        if (c == '+') c = '-';
-        else if (c == '/') c = '_';
+        if (c == '+') {
+            c = '-';
+        } else if (c == '/') {
+            c = '_';
+        }
     }
     return std::string(LOCALHOST_URL) + std::to_string(server.get_port()) + WCP_DOWNLOAD_PREFIX + b64;
 }
@@ -398,7 +401,9 @@ std::string make_wcp_download_url(const std::string& file_path)
 static std::string calc_sha256_base64(const std::string& file_path)
 {
     std::ifstream ifs(file_path, std::ios::binary);
-    if (!ifs.is_open()) return "";
+    if (!ifs.is_open()) {
+        return "";
+    }
 
     SHA256_CTX ctx;
     SHA256_Init(&ctx);
@@ -826,12 +831,15 @@ void SSWCP_Instance::sw_GetFileStream() {
 
         if (isZip) {
             std::weak_ptr<SSWCP_Instance> weak_self = shared_from_this();
-            if (m_work_thread.joinable())
+            if (m_work_thread.joinable()) {
                 m_work_thread.join();
+            }
 
             m_work_thread = std::thread([file_path, file_name, weak_self]() {
                 auto self = weak_self.lock();
-                if (!self) return;
+                if (!self) {
+                    return;
+                }
 
                 try {
                     std::string zipname = generate_zip_path(file_path, file_name);
@@ -842,7 +850,9 @@ void SSWCP_Instance::sw_GetFileStream() {
                     if (name_index == std::string::npos || path_index == std::string::npos) {
                         wxGetApp().CallAfter([weak_self]() {
                             auto self = weak_self.lock();
-                            if (self) self->handle_general_fail();
+                            if (self) {
+                                self->handle_general_fail();
+                            }
                         });
                         return;
                     }
@@ -853,7 +863,9 @@ void SSWCP_Instance::sw_GetFileStream() {
 
                     wxGetApp().CallAfter([weak_self, zipname, zip_file_name, file_size, sha256_base64]() {
                         auto self = weak_self.lock();
-                        if (!self) return;
+                        if (!self) {
+                            return;
+                        }
 
                         self->m_res_data["file_name"]   = zip_file_name;
                         self->m_res_data["file_url"]    = make_wcp_download_url(zipname);
@@ -868,19 +880,24 @@ void SSWCP_Instance::sw_GetFileStream() {
                 } catch (std::exception&) {
                     wxGetApp().CallAfter([weak_self]() {
                         auto self = weak_self.lock();
-                        if (self) self->handle_general_fail();
+                        if (self) {
+                            self->handle_general_fail();
+                        }
                     });
                 }
             });
         } else {
             std::string download_url = make_wcp_download_url(file_path);
             std::weak_ptr<SSWCP_Instance> weak_self = shared_from_this();
-            if (m_work_thread.joinable())
+            if (m_work_thread.joinable()) {
                 m_work_thread.join();
+            }
 
             m_work_thread = std::thread([file_path, file_name, download_url, weak_self]() {
                 auto self = weak_self.lock();
-                if (!self) return;
+                if (!self) {
+                    return;
+                }
 
                 try {
                     long long file_size = boost::filesystem::file_size(file_path);
@@ -889,7 +906,9 @@ void SSWCP_Instance::sw_GetFileStream() {
 
                     wxGetApp().CallAfter([weak_self, download_url, file_name, file_size, sha256_base64]() {
                         auto self = weak_self.lock();
-                        if (!self) return;
+                        if (!self) {
+                            return;
+                        }
 
                         self->m_res_data["file_name"]   = file_name;
                         self->m_res_data["file_url"]    = download_url;
@@ -903,7 +922,9 @@ void SSWCP_Instance::sw_GetFileStream() {
                 } catch (std::exception&) {
                     wxGetApp().CallAfter([weak_self]() {
                         auto self = weak_self.lock();
-                        if (self) self->handle_general_fail();
+                        if (self) {
+                            self->handle_general_fail();
+                        }
                     });
                 }
             });

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -36,6 +36,10 @@
 
 #include "miniz/miniz.h"
 #include "slic3r/Utils/MQTT.hpp"
+#include "slic3r/Utils/Http.hpp"
+#include "libslic3r/Utils.hpp"
+#include <boost/filesystem/operations.hpp>
+#include <openssl/sha.h>
 
 namespace pt = boost::property_tree;
 
@@ -376,6 +380,39 @@ bool read_existing_zip(const std::string& zip_path, std::vector<char>& out_data)
     return true;
 }
 
+// Build a download URL served by the local HTTP server, bypassing the 512MB postMessage limit.
+// The file path is URL-safe base64-encoded to avoid issues with special characters (# \ : etc.).
+std::string make_wcp_download_url(const std::string& file_path)
+{
+    auto& server = wxGetApp().m_page_http_server;
+    std::string b64 = base64_encode(file_path.data(), file_path.size());
+    for (auto& c : b64) {
+        if (c == '+') c = '-';
+        else if (c == '/') c = '_';
+    }
+    return std::string(LOCALHOST_URL) + std::to_string(server.get_port()) + WCP_DOWNLOAD_PREFIX + b64;
+}
+
+// Compute SHA-256 digest → standard Base64, matching Flutter's base64Encode(sha256.convert(bytes).bytes)
+static std::string calc_sha256_base64(const std::string& file_path)
+{
+    std::ifstream ifs(file_path, std::ios::binary);
+    if (!ifs.is_open()) return "";
+
+    SHA256_CTX ctx;
+    SHA256_Init(&ctx);
+
+    char buf[64 * 1024];
+    while (ifs.read(buf, sizeof(buf)) || ifs.gcount() > 0) {
+        SHA256_Update(&ctx, buf, ifs.gcount());
+    }
+
+    unsigned char digest[SHA256_DIGEST_LENGTH];
+    SHA256_Final(digest, &ctx);
+
+    return base64_encode((const char*) digest, SHA256_DIGEST_LENGTH);
+}
+
 // 主逻辑函数
 json get_or_create_zip_json(const std::string& name1,   // 原文件路径（如 "1.gcode"）
                             const std::string& name2,   // 目标 ZIP 文件名（如 "target.gcode"）
@@ -661,7 +698,10 @@ void SSWCP_Instance::sw_GetActiveFile()
                     SSWCP::m_file_size_mutex.lock();
                     self->m_res_data["origin_size"] = SSWCP::m_active_file_size;
                     SSWCP::m_file_size_mutex.unlock();
-                    
+
+                    // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
+                    self->m_res_data["checksum"] = calc_sha256_base64(file_path);
+
                     wxGetApp().CallAfter([weak_self]() {
                         if (weak_self.lock()) {
                             weak_self.lock()->send_to_js();
@@ -681,6 +721,11 @@ void SSWCP_Instance::sw_GetActiveFile()
         } else {
             m_res_data["file_name"] = file_name;
             m_res_data["file_path"] = file_path;
+            m_res_data["origin_size"] = boost::filesystem::file_size(file_path);
+
+            // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
+            m_res_data["checksum"] = calc_sha256_base64(file_path);
+
             send_to_js();
             finish_job();
         }
@@ -759,78 +804,102 @@ void SSWCP_Instance::sw_Log()
 
 void SSWCP_Instance::sw_GetFileStream() {
     try {
+        std::string file_path = SSWCP::get_active_filename();
+        std::string file_name = SSWCP::get_display_filename();
+        if (file_path == "" || file_name == "") {
+            handle_general_fail();
+            return;
+        }
+
         bool isZip = false;
         if (m_param_data.count("is_zip")) {
             isZip = m_param_data["is_zip"].get<bool>();
-        } 
-        std::string file_path = SSWCP::get_active_filename();
+        }
 
-        std::weak_ptr<SSWCP_Instance> weak_self = shared_from_this();
         if (isZip) {
-            auto oriname    = SSWCP::get_active_filename();
-            auto targetname = SSWCP::get_display_filename();
-
             std::weak_ptr<SSWCP_Instance> weak_self = shared_from_this();
             if (m_work_thread.joinable())
                 m_work_thread.join();
-            m_work_thread                           = std::thread([oriname, targetname, weak_self]() {
-                auto self = weak_self.lock();
-                if (self) {
-                    std::string zipname = generate_zip_path(oriname, targetname);
-                    json        res     = get_or_create_zip_json(oriname, targetname, zipname);
-                    wxGetApp().CallAfter([weak_self, res]() {
-                        auto self = weak_self.lock();
-                        if (self) {
-                            self->m_res_data["name"]    = res["zip_name"];
-                            self->m_res_data["content"] = res["zip_data"];
 
-                            self->send_to_js();
-                            self->finish_job();
-                        }
+            m_work_thread = std::thread([file_path, file_name, weak_self]() {
+                auto self = weak_self.lock();
+                if (!self) return;
+
+                try {
+                    std::string zipname = generate_zip_path(file_path, file_name);
+                    get_or_create_zip_json(file_path, file_name, zipname);
+
+                    size_t name_index = file_name.find_last_of(".");
+                    size_t path_index = file_path.find_last_of(".");
+                    if (name_index == std::string::npos || path_index == std::string::npos) {
+                        wxGetApp().CallAfter([weak_self]() {
+                            auto self = weak_self.lock();
+                            if (self) self->handle_general_fail();
+                        });
+                        return;
+                    }
+
+                    std::string zip_file_name = file_name.substr(0, name_index) + ".zip";
+                    long long   file_size     = boost::filesystem::file_size(file_path);
+                    std::string sha256_base64 = calc_sha256_base64(file_path);
+
+                    wxGetApp().CallAfter([weak_self, zipname, zip_file_name, file_size, sha256_base64]() {
+                        auto self = weak_self.lock();
+                        if (!self) return;
+
+                        self->m_res_data["file_name"]   = zip_file_name;
+                        self->m_res_data["file_url"]    = make_wcp_download_url(zipname);
+                        self->m_res_data["origin_size"] = file_size;
+
+                        // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
+                        self->m_res_data["checksum"]    = sha256_base64;
+
+                        self->send_to_js();
+                        self->finish_job();
+                    });
+                } catch (std::exception&) {
+                    wxGetApp().CallAfter([weak_self]() {
+                        auto self = weak_self.lock();
+                        if (self) self->handle_general_fail();
                     });
                 }
             });
         } else {
+            std::string download_url = make_wcp_download_url(file_path);
+            std::weak_ptr<SSWCP_Instance> weak_self = shared_from_this();
             if (m_work_thread.joinable())
                 m_work_thread.join();
-            m_work_thread = std::thread([file_path, weak_self]() {
+
+            m_work_thread = std::thread([file_path, file_name, download_url, weak_self]() {
                 auto self = weak_self.lock();
-                if (self) {
-                    // 1. 读取原文件内容
-                    std::ifstream file(file_path, std::ios::binary);
-                    if (!file.is_open()) {
-                        self->handle_general_fail();
-                        return;
-                    }
-                    // 获取文件大小
-                    file.seekg(0, std::ios::end);
-                    std::streamsize file_size = file.tellg();
-                    file.seekg(0, std::ios::beg);
+                if (!self) return;
 
-                    // 预分配 std::string 空间
-                    std::string content;
-                    content.resize(file_size);
+                try {
+                    long long file_size = boost::filesystem::file_size(file_path);
 
-                    // 一次性读取整个文件
-                    if (!file.read(&content[0], file_size)) {
-                        std::cerr << "读取文件失败" << std::endl;
-                        self->handle_general_fail();
-                        return;
-                    }
+                    std::string sha256_base64 = calc_sha256_base64(file_path);
 
-                    self->m_res_data["content"] = wxString(content).ToUTF8();
+                    wxGetApp().CallAfter([weak_self, download_url, file_name, file_size, sha256_base64]() {
+                        auto self = weak_self.lock();
+                        if (!self) return;
 
+                        self->m_res_data["file_name"]   = file_name;
+                        self->m_res_data["file_url"]    = download_url;
+                        self->m_res_data["origin_size"] = file_size;
+                        // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
+                        self->m_res_data["checksum"]    = sha256_base64;
+
+                        self->send_to_js();
+                        self->finish_job();
+                    });
+                } catch (std::exception&) {
                     wxGetApp().CallAfter([weak_self]() {
                         auto self = weak_self.lock();
-                        if (self) {
-                            self->send_to_js();
-                            self->finish_job();
-                        }
+                        if (self) self->handle_general_fail();
                     });
                 }
             });
         }
-        
     }
     catch (std::exception& e) {
         handle_general_fail();

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -841,50 +841,41 @@ void SSWCP_Instance::sw_GetFileStream() {
                     return;
                 }
 
-                try {
-                    std::string zipname = generate_zip_path(file_path, file_name);
-                    get_or_create_zip_json(file_path, file_name, zipname);
+                std::string zipname = generate_zip_path(file_path, file_name);
+                get_or_create_zip_json(file_path, file_name, zipname);
 
-                    size_t name_index = file_name.find_last_of(".");
-                    size_t path_index = file_path.find_last_of(".");
-                    if (name_index == std::string::npos || path_index == std::string::npos) {
-                        wxGetApp().CallAfter([weak_self]() {
-                            auto self = weak_self.lock();
-                            if (self) {
-                                self->handle_general_fail();
-                            }
-                        });
-                        return;
-                    }
-
-                    std::string zip_file_name = file_name.substr(0, name_index) + ".zip";
-                    long long   file_size     = boost::filesystem::file_size(file_path);
-                    std::string sha256_base64 = calc_sha256_base64(file_path);
-
-                    wxGetApp().CallAfter([weak_self, zipname, zip_file_name, file_size, sha256_base64]() {
-                        auto self = weak_self.lock();
-                        if (!self) {
-                            return;
-                        }
-
-                        self->m_res_data["file_name"]   = zip_file_name;
-                        self->m_res_data["file_url"]    = make_wcp_download_url(zipname);
-                        self->m_res_data["origin_size"] = file_size;
-
-                        // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
-                        self->m_res_data["checksum"]    = sha256_base64;
-
-                        self->send_to_js();
-                        self->finish_job();
-                    });
-                } catch (std::exception&) {
+                size_t name_index = file_name.find_last_of(".");
+                size_t path_index = file_path.find_last_of(".");
+                if (name_index == std::string::npos || path_index == std::string::npos) {
                     wxGetApp().CallAfter([weak_self]() {
                         auto self = weak_self.lock();
                         if (self) {
                             self->handle_general_fail();
                         }
                     });
+                    return;
                 }
+
+                std::string zip_file_name = file_name.substr(0, name_index) + ".zip";
+                long long   file_size     = boost::filesystem::file_size(file_path);
+                std::string sha256_base64 = calc_sha256_base64(file_path);
+
+                wxGetApp().CallAfter([weak_self, zipname, zip_file_name, file_size, sha256_base64]() {
+                    auto self = weak_self.lock();
+                    if (!self) {
+                        return;
+                    }
+
+                    self->m_res_data["file_name"]   = zip_file_name;
+                    self->m_res_data["file_url"]    = make_wcp_download_url(zipname);
+                    self->m_res_data["origin_size"] = file_size;
+
+                    // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
+                    self->m_res_data["checksum"]    = sha256_base64;
+
+                    self->send_to_js();
+                    self->finish_job();
+                });
             });
         } else {
             std::string download_url = make_wcp_download_url(file_path);
@@ -899,34 +890,25 @@ void SSWCP_Instance::sw_GetFileStream() {
                     return;
                 }
 
-                try {
-                    long long file_size = boost::filesystem::file_size(file_path);
+                long long file_size = boost::filesystem::file_size(file_path);
 
-                    std::string sha256_base64 = calc_sha256_base64(file_path);
+                std::string sha256_base64 = calc_sha256_base64(file_path);
 
-                    wxGetApp().CallAfter([weak_self, download_url, file_name, file_size, sha256_base64]() {
-                        auto self = weak_self.lock();
-                        if (!self) {
-                            return;
-                        }
+                wxGetApp().CallAfter([weak_self, download_url, file_name, file_size, sha256_base64]() {
+                    auto self = weak_self.lock();
+                    if (!self) {
+                        return;
+                    }
 
-                        self->m_res_data["file_name"]   = file_name;
-                        self->m_res_data["file_url"]    = download_url;
-                        self->m_res_data["origin_size"] = file_size;
-                        // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
-                        self->m_res_data["checksum"]    = sha256_base64;
+                    self->m_res_data["file_name"]   = file_name;
+                    self->m_res_data["file_url"]    = download_url;
+                    self->m_res_data["origin_size"] = file_size;
+                    // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
+                    self->m_res_data["checksum"]    = sha256_base64;
 
-                        self->send_to_js();
-                        self->finish_job();
-                    });
-                } catch (std::exception&) {
-                    wxGetApp().CallAfter([weak_self]() {
-                        auto self = weak_self.lock();
-                        if (self) {
-                            self->handle_general_fail();
-                        }
-                    });
-                }
+                    self->send_to_js();
+                    self->finish_job();
+                });
             });
         }
     }


### PR DESCRIPTION
1. Add download URL for file transfer, bypassing 512MB postMessage limit
2. Add checksum field for file integrity verification
3. Add origin_size field
4. Use URL-safe base64 for path encoding in /wcp_download/ route

# Description

This PR addresses the file transfer failure for files larger than ~512MB. Previously,
both sw_GetFileStream and sw_GetActiveFile read entire file content into memory and
passed it through the WebView postMessage bridge, which has a hard limit around 512MB.
Files exceeding this size get silently truncated.

## Changes

### sw_GetFileStream
- Replace in-memory file content transfer with a local HTTP download URL
- Files are now served via HttpServer at /wcp_download/<url-safe-base64-path>
- The Flutter client downloads files via HTTP GET, avoiding the postMessage size limit

### sw_GetActiveFile
- Add origin_size (file size in bytes) and checksum fields to the response
- Client can display file size and verify download integrity without extra requests

### HttpServer
- Add /wcp_download/ route that decodes URL-safe base64 back to the native file path
- Add m_native_path flag to ResponseFile to skip UTF-8 encoding conversion for decoded paths
- Add fallback path opening when native path fails

### Checksum Algorithm
- SHA-256 digest → standard Base64 (matching Flutter's base64Encode(sha256.convert(bytes).bytes))
- Computed via streaming (64KB chunks) to handle large files without memory pressure

# Tests

- Verified sw_GetActiveFile returns correct file_name, file_path, origin_size, and checksum
- Verified sw_GetFileStream returns a downloadable file_url
- Downloaded a 16.7MB gcode file via the returned URL and verified SHA-256 checksum matches
- Tested with is_zip=false on Windows 11
