### PR TITLE
feat: local-Z wipe tower toolchange and fix single-color sublayer splitting

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -929,10 +929,14 @@ std::string WipeTowerIntegration::prime(GCode& gcodegen)
     return gcode;
 }
 
-std::string WipeTowerIntegration::tool_change(GCode& gcodegen, int extruder_id, bool finish_layer)
+std::string WipeTowerIntegration::tool_change(GCode& gcodegen, int extruder_id, bool finish_layer,
+                                              bool local_z_unplanned, double local_z_nominal_layer_z,
+                                              bool *was_wipe_tower_purge)
 {
     std::string gcode;
 
+    if (local_z_unplanned)
+        return emit_local_z_unplanned_toolchange(gcodegen, extruder_id, local_z_nominal_layer_z, was_wipe_tower_purge);
 
     assert(m_layer_idx >= 0);
     if (m_layer_idx >= (int) m_tool_changes.size())
@@ -992,6 +996,249 @@ std::string WipeTowerIntegration::tool_change(GCode& gcodegen, int extruder_id, 
         }
     }
 
+    return gcode;
+}
+
+
+std::string WipeTowerIntegration::emit_local_z_unplanned_toolchange(GCode &gcodegen, int extruder_id, double local_z_nominal_layer_z, bool *was_wipe_tower_purge)
+{
+    if (extruder_id < 0 || !gcodegen.writer().need_toolchange(extruder_id))
+        return "";
+    if (m_layer_idx < 0 || size_t(m_layer_idx) >= m_local_z_reserve_boxes.size() ||
+        size_t(m_layer_idx) >= m_local_z_reserve_slot_idx.size()) {
+        BOOST_LOG_TRIVIAL(debug) << "Local-Z unplanned toolchange using direct extruder switch"
+                                 << " layer_idx=" << m_layer_idx
+                                 << " extruder_id=" << extruder_id
+                                 << " tool_change_idx=" << m_tool_change_idx;
+        return gcodegen.set_extruder(unsigned(extruder_id),
+                                     gcodegen.writer().get_position().z() - gcodegen.config().z_offset.value);
+    }
+
+    size_t &slot_idx = m_local_z_reserve_slot_idx[size_t(m_layer_idx)];
+    const auto &layer_slots = m_local_z_reserve_boxes[size_t(m_layer_idx)];
+    if (slot_idx >= layer_slots.size() || layer_slots.empty()) {
+        BOOST_LOG_TRIVIAL(warning) << "Local-Z toolchange reserve exhausted"
+                                   << " layer_idx=" << m_layer_idx
+                                   << " extruder_id=" << extruder_id
+                                   << " reserved_slots=" << layer_slots.size()
+                                   << " consumed_slots=" << slot_idx;
+        return gcodegen.set_extruder(unsigned(extruder_id),
+                                     gcodegen.writer().get_position().z() - gcodegen.config().z_offset.value);
+    }
+
+    const WipeTower::box_coordinates &slot = layer_slots[slot_idx++];
+    const double current_z = gcodegen.writer().get_position().z();
+    const double tower_z   = local_z_nominal_layer_z >= 0. ? local_z_nominal_layer_z : current_z;
+    const double toolchange_print_z = tower_z - gcodegen.config().z_offset.value;
+
+    if (m_layer_idx >= (int)m_tool_changes.size() || m_tool_changes[m_layer_idx].empty()) {
+        BOOST_LOG_TRIVIAL(debug) << "Local-Z reserve has no matching wipe-tower layer metadata, using direct extruder switch"
+                                 << " layer_idx=" << m_layer_idx
+                                 << " extruder_id=" << extruder_id;
+        return gcodegen.set_extruder(unsigned(extruder_id), toolchange_print_z);
+    }
+
+    const float layer_height = m_tool_changes[m_layer_idx].front().layer_height;
+    if (gcodegen.m_curr_print != nullptr && gcodegen.writer().extruder() != nullptr) {
+        return emit_local_z_toolchange_via_wipe_tower(gcodegen, extruder_id,
+                                                       toolchange_print_z, tower_z,
+                                                       layer_height, slot, slot_idx,
+                                                       was_wipe_tower_purge);
+    }
+    return emit_local_z_toolchange_manual_purge(gcodegen, extruder_id,
+                                                 toolchange_print_z, tower_z,
+                                                 layer_height, slot, slot_idx,
+                                                 was_wipe_tower_purge);
+}
+
+std::string WipeTowerIntegration::emit_local_z_toolchange_via_wipe_tower(
+    GCode &gcodegen, int extruder_id,
+    double toolchange_print_z, double tower_z,
+    float layer_height, const WipeTower::box_coordinates &slot,
+    size_t slot_idx, bool *was_wipe_tower_purge)
+{
+    try {
+        const Print&       print        = *gcodegen.m_curr_print;
+        const PrintConfig& print_config = print.config();
+        const size_t       current_tool = gcodegen.writer().extruder()->id();
+        if (!m_wipe_volumes_cached) {
+            m_cached_wipe_volumes = WipeTower2::extract_wipe_volumes(print_config);
+            m_wipe_volumes_cached = true;
+        }
+        const std::vector<std::vector<float>>& wipe_volumes = m_cached_wipe_volumes;
+
+        WipeTower2 local_z_wipe_tower(print_config,
+                                      print.default_region_config(),
+                                      print.get_plate_index(),
+                                      print.get_plate_origin(),
+                                      wipe_volumes,
+                                      current_tool);
+        for (size_t extruder_idx = 0; extruder_idx < print_config.nozzle_diameter.size(); ++extruder_idx)
+            local_z_wipe_tower.set_extruder(extruder_idx, print_config);
+
+        local_z_wipe_tower.set_current_tool(current_tool);
+        local_z_wipe_tower.set_layer(float(toolchange_print_z), layer_height, 0, m_layer_idx == 0, false);
+
+        WipeTower::ToolChangeResult local_z_tcr =
+            local_z_wipe_tower.local_z_tool_change(size_t(extruder_id), slot, float(print_config.prime_volume));
+        BOOST_LOG_TRIVIAL(debug) << "Local-Z toolchange emitted via wipe tower mini-toolchange"
+                                 << " layer_idx=" << m_layer_idx
+                                 << " extruder_id=" << extruder_id
+                                 << " reserve_slot=" << (slot_idx - 1);
+        if (was_wipe_tower_purge)
+            *was_wipe_tower_purge = true;
+        return gcodegen.is_BBL_Printer() ? append_tcr(gcodegen, local_z_tcr, local_z_tcr.new_tool, tower_z) :
+                                           append_tcr2(gcodegen, local_z_tcr, local_z_tcr.new_tool, tower_z);
+    } catch (const std::exception &e) {
+        BOOST_LOG_TRIVIAL(warning) << "Local-Z toolchange via wipe tower failed, falling back to direct extruder switch"
+                                   << " layer_idx=" << m_layer_idx
+                                   << " extruder_id=" << extruder_id
+                                   << " error=" << e.what();
+    } catch (...) {
+        BOOST_LOG_TRIVIAL(warning) << "Local-Z toolchange via wipe tower failed (unknown exception), falling back to direct extruder switch"
+                                   << " layer_idx=" << m_layer_idx
+                                   << " extruder_id=" << extruder_id;
+    }
+    return gcodegen.set_extruder(unsigned(extruder_id), toolchange_print_z);
+}
+
+std::string WipeTowerIntegration::emit_local_z_toolchange_manual_purge(
+    GCode &gcodegen, int extruder_id,
+    double toolchange_print_z, double tower_z,
+    float layer_height, const WipeTower::box_coordinates &slot,
+    size_t slot_idx, bool *was_wipe_tower_purge)
+{
+    std::string gcode;
+
+    const float nozzle_diameter = float(gcodegen.config().nozzle_diameter.get_at(size_t(extruder_id)));
+    const float line_width = nozzle_diameter * 1.25f;
+    const float extra_flow = float(gcodegen.config().wipe_tower_extra_flow.value) / 100.f;
+    const float extra_spacing = float(gcodegen.config().wipe_tower_extra_spacing.value) / 100.f;
+    const float filament_area = float((M_PI / 4.f) * std::pow(gcodegen.config().filament_diameter.get_at(size_t(extruder_id)), 2));
+    const float flow_per_mm =
+        filament_area > 0.f ?
+            (layer_height * (line_width - layer_height * float(1.f - M_PI / 4.f)) / filament_area) * std::max(0.f, extra_flow) :
+            0.f;
+    if (line_width <= 0.f || flow_per_mm <= 0.f)
+        return gcodegen.set_extruder(unsigned(extruder_id), toolchange_print_z);
+
+    const float inset_x = std::min(line_width, std::max(0.f, (slot.ru.x() - slot.ld.x()) * 0.25f));
+    const float inset_y = std::min(line_width * 0.5f, std::max(0.f, (slot.ru.y() - slot.rd.y()) * 0.25f));
+    const float x_min   = slot.ld.x() + inset_x;
+    const float x_max   = slot.rd.x() - inset_x;
+    const float y_min   = slot.ld.y() + inset_y;
+    const float y_max   = slot.lu.y() - inset_y;
+    if (x_max - x_min <= float(EPSILON) || y_max - y_min <= float(EPSILON))
+        return gcodegen.set_extruder(unsigned(extruder_id), toolchange_print_z);
+
+    std::vector<Vec2f> local_path;
+    local_path.reserve(16);
+    local_path.emplace_back(x_min, y_min);
+    local_path.emplace_back(x_max, y_min);
+
+    bool  moving_left = true;
+    float y           = y_min;
+    const float line_spacing = std::max(line_width, line_width * std::max(1.f, extra_spacing));
+    while (y + line_spacing < y_max - float(EPSILON)) {
+        y = std::min(y + line_spacing, y_max);
+        local_path.emplace_back(moving_left ? x_max : x_min, y);
+        local_path.emplace_back(moving_left ? x_min : x_max, y);
+        moving_left = !moving_left;
+    }
+
+    const double current_z = gcodegen.writer().get_position().z();
+    const float alpha = m_wipe_tower_rotation / 180.f * float(M_PI);
+    auto transform_wt_pt = [&alpha, this](const Vec2f& pt) -> Vec2f {
+        return Eigen::Rotation2Df(alpha) * pt + m_wipe_tower_pos;
+    };
+    const Vec2f plate_origin_2d(m_plate_origin(0), m_plate_origin(1));
+    const Vec2f start_pos = transform_wt_pt(local_path.front());
+    const Vec2f start_machine = start_pos + plate_origin_2d;
+
+    gcodegen.m_next_wipe_x = start_pos.x();
+    gcodegen.m_next_wipe_y = start_pos.y();
+
+    gcode += gcodegen.writer().unlift();
+
+    if (gcodegen.writer().extruder() != nullptr) {
+        auto type = ZHopType(gcodegen.m_config.z_hop_types.get_at(gcodegen.m_writer.extruder()->id()));
+        if (type == ZHopType::zhtAuto)
+            type = ZHopType::zhtSpiral;
+        if (gcodegen.m_config.z_hop_when_prime.get_at(gcodegen.m_writer.extruder()->id()))
+            gcode += gcodegen.retract(false, false, gcodegen.to_lift_type(type));
+    }
+
+    gcodegen.m_avoid_crossing_perimeters.use_external_mp_once();
+    gcode += gcodegen.travel_to(wipe_tower_point_to_object_point(gcodegen, start_machine), erMixed,
+                                "Travel to Local-Z wipe tower reserve");
+    gcode += gcodegen.unretract();
+
+    if (!is_approx(tower_z, current_z)) {
+        gcode += gcodegen.writer().retract();
+        gcode += gcodegen.writer().travel_to_z(tower_z, "Travel to Local-Z tower layer");
+        gcode += gcodegen.writer().unretract();
+    }
+
+    gcode += gcodegen.set_extruder(unsigned(extruder_id), toolchange_print_z);
+    gcode += gcodegen.writer().travel_to_z(tower_z, "Force restore Local-Z tower Z", true);
+    {
+        Vec3d restored_position{gcodegen.writer().get_position()};
+        restored_position.z() = tower_z;
+        gcodegen.writer().set_position(restored_position);
+    }
+    gcode += gcodegen.unretract();
+    gcode += gcodegen.writer().travel_to_xy(start_machine.cast<double>(), "Return to Local-Z wipe tower reserve");
+
+    gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Height) + float_to_string_decimal_point(layer_height, 3) + "\n";
+    gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Role) + ExtrusionEntity::role_to_string(erWipeTower) + "\n";
+    gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Width) + float_to_string_decimal_point(line_width, 3) + "\n";
+
+    double feedrate = std::max(1.0, double(gcodegen.config().wipe_tower_max_purge_speed.value)) * 60.0;
+    if (m_layer_idx == 0)
+        feedrate = std::min(feedrate, std::max(1.0, double(gcodegen.config().initial_layer_speed.value)) * 60.0);
+    gcode += gcodegen.writer().set_speed(feedrate, "Local-Z wipe tower reserve");
+
+    for (size_t point_idx = 1; point_idx < local_path.size(); ++point_idx) {
+        const Vec2f machine_pt = transform_wt_pt(local_path[point_idx]) + plate_origin_2d;
+        const double length = (local_path[point_idx] - local_path[point_idx - 1]).norm();
+        if (length <= EPSILON)
+            continue;
+        gcode += gcodegen.writer().extrude_to_xy(machine_pt.cast<double>(), flow_per_mm * float(length),
+                                                 point_idx == 1 ? "Local-Z tower purge" : std::string());
+    }
+
+    const Vec2f end_machine = transform_wt_pt(local_path.back()) + plate_origin_2d;
+    gcodegen.set_last_pos(wipe_tower_point_to_object_point(gcodegen, end_machine));
+    gcodegen.m_wipe.reset_path();
+    for (size_t point_idx = local_path.size(); point_idx-- > 0;) {
+        const Vec2f machine_pt = transform_wt_pt(local_path[point_idx]) + plate_origin_2d;
+        gcodegen.m_wipe.path.points.emplace_back(wipe_tower_point_to_object_point(gcodegen, machine_pt));
+    }
+
+    if (!is_approx(tower_z, current_z)) {
+        const Extruder *active_extruder = gcodegen.writer().extruder();
+        const bool can_wipe = active_extruder != nullptr &&
+                              gcodegen.config().wipe.get_at(active_extruder->id()) &&
+                              gcodegen.m_wipe.has_path() &&
+                              scale_(gcodegen.config().wipe_distance.get_at(active_extruder->id())) > SCALED_EPSILON;
+        if (can_wipe) {
+            Wipe::RetractionValues wipe_retractions = gcodegen.m_wipe.calculateWipeRetractionLengths(gcodegen, false);
+            gcode += gcodegen.writer().retract(true, wipe_retractions.retractLengthBeforeWipe);
+            gcode += gcodegen.m_wipe.wipe(gcodegen, wipe_retractions.retractLengthDuringWipe, false, false);
+        }
+        gcode += gcodegen.writer().retract();
+        gcodegen.m_wipe.reset_path();
+        gcode += gcodegen.writer().travel_to_z(current_z, "Travel back to Local-Z pass");
+        gcode += gcodegen.writer().unretract();
+    }
+
+    gcodegen.m_avoid_crossing_perimeters.use_external_mp_once();
+    BOOST_LOG_TRIVIAL(debug) << "Local-Z toolchange emitted on wipe tower reserve"
+                             << " layer_idx=" << m_layer_idx
+                             << " extruder_id=" << extruder_id
+                             << " reserve_slot=" << (slot_idx - 1);
+    if (was_wipe_tower_purge)
+        *was_wipe_tower_purge = true;
     return gcode;
 }
 
@@ -5447,7 +5694,16 @@ LayerResult GCode::process_layer(const Print& print,
 
                     if (has_wipe_tower && m_writer.need_toolchange(local_extruder_id))
                         local_z_phase_b_changed_extruder = true;
-                    gcode += this->set_extruder(local_extruder_id, pass_plan.print_z);
+                    if (has_wipe_tower && m_wipe_tower) {
+                        bool was_wipe_tower_purge = false;
+                        gcode += m_wipe_tower->tool_change(*this, int(local_extruder_id), false, true,
+                                                           print_z + m_config.z_offset.value,
+                                                           &was_wipe_tower_purge);
+                        if (was_wipe_tower_purge)
+                            m_last_processor_extrusion_role = erWipeTower;
+                    } else {
+                        gcode += this->set_extruder(local_extruder_id, pass_plan.print_z);
+                    }
                     if (std::abs(m_writer.get_position().z() - pass_z) > EPSILON) {
                         BOOST_LOG_TRIVIAL(warning) << "Local-Z pass z restore"
                                                    << " print_z=" << print_z
@@ -5511,7 +5767,16 @@ LayerResult GCode::process_layer(const Print& print,
                                          << " print_z=" << print_z
                                          << " restore_extruder=" << local_z_phase_b_start_extruder;
                 gcode += "; local-z phase-b restore pre-pass extruder for wipe tower\n";
-                gcode += this->set_extruder(static_cast<unsigned int>(local_z_phase_b_start_extruder), print_z);
+                if (m_wipe_tower) {
+                    bool was_wipe_tower_purge = false;
+                    gcode += m_wipe_tower->tool_change(*this, local_z_phase_b_start_extruder, false, true,
+                                                       print_z + m_config.z_offset.value,
+                                                       &was_wipe_tower_purge);
+                    if (was_wipe_tower_purge)
+                        m_last_processor_extrusion_role = erWipeTower;
+                } else {
+                    gcode += this->set_extruder(static_cast<unsigned int>(local_z_phase_b_start_extruder), print_z);
+                }
             } else if (local_z_phase_b_start_extruder < 0) {
                 BOOST_LOG_TRIVIAL(warning) << "Local-Z phase-b cannot restore pre-pass extruder (undefined writer state)"
                                            << " print_z=" << print_z;

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -106,7 +106,10 @@ public:
         if (m_layer_idx >= 0 && size_t(m_layer_idx) < m_local_z_reserve_slot_idx.size())
             m_local_z_reserve_slot_idx[size_t(m_layer_idx)] = 0;
     }
-    std::string tool_change(GCode &gcodegen, int extruder_id, bool finish_layer);
+    std::string tool_change(GCode &gcodegen, int extruder_id, bool finish_layer,
+                            bool local_z_unplanned = false,
+                            double local_z_nominal_layer_z = -1.,
+                            bool *was_wipe_tower_purge = nullptr);
     bool is_empty_wipe_tower_gcode(GCode &gcodegen, int extruder_id, bool finish_layer);
     std::string finalize(GCode &gcodegen);
     std::vector<float> used_filament_length() const;
@@ -123,6 +126,15 @@ private:
 
     // Postprocesses gcode: rotates and moves G1 extrusions and returns result
     std::string post_process_wipe_tower_moves(const WipeTower::ToolChangeResult& tcr, const Vec2f& translation, float angle) const;
+    std::string emit_local_z_unplanned_toolchange(GCode &gcodegen, int extruder_id, double local_z_nominal_layer_z, bool *was_wipe_tower_purge = nullptr);
+    std::string emit_local_z_toolchange_via_wipe_tower(GCode &gcodegen, int extruder_id,
+                                                        double toolchange_print_z, double tower_z,
+                                                        float layer_height, const WipeTower::box_coordinates &slot,
+                                                        size_t slot_idx, bool *was_wipe_tower_purge);
+    std::string emit_local_z_toolchange_manual_purge(GCode &gcodegen, int extruder_id,
+                                                      double toolchange_print_z, double tower_z,
+                                                      float layer_height, const WipeTower::box_coordinates &slot,
+                                                      size_t slot_idx, bool *was_wipe_tower_purge);
     // Left / right edges of the wipe tower, for the planning of wipe moves.
     const float                                                  m_left;
     const float                                                  m_right;
@@ -146,6 +158,8 @@ private:
     bool                                                         m_single_extruder_multi_material;
     bool                                                         m_enable_timelapse_print;
     bool                                                         m_is_first_print;
+    std::vector<std::vector<float>>                              m_cached_wipe_volumes;
+    bool                                                         m_wipe_volumes_cached = false;
 };
 
 class ColorPrintColors

--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -1665,6 +1665,10 @@ WipeTower::ToolChangeResult WipeTower2::local_z_tool_change(size_t new_tool,
     if (m_current_tool < m_used_filament_length.size())
         m_used_filament_length[m_current_tool] += writer.get_and_reset_used_filament_length();
 
+    // toolchange_Change already updated m_current_tool, but be explicit
+    // so construct_tcr returns the correct new_tool for the caller.
+    m_current_tool = new_tool;
+
     WipeTower::ToolChangeResult result = construct_tcr(writer, false, old_tool, false);
     result.purge_volume                = wipe_volume;
     return result;

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -1993,6 +1993,15 @@ static std::vector<LocalZActivePair> build_local_z_pair_cycle_for_row(const Mixe
         pair_weights.emplace_back(std::max(1, gradient_weights[1] + gradient_weights[2]));
     }
 
+    if (!mf.gradient_enabled && gradient_ids.size() == 3) {
+        const int w1 = gradient_weights[0];
+        const int w2 = gradient_weights[1];
+        const int w3 = gradient_weights[2];
+        pair_weights[0] = std::max(1, w1 + w2 - w3);
+        pair_weights[1] = std::max(1, w1 + w3 - w2);
+        pair_weights[2] = std::max(1, w2 + w3 - w1);
+    }
+
     if (pair_options.size() < 2 || pair_options.size() != pair_weights.size())
         return {};
 
@@ -2991,6 +3000,32 @@ static std::vector<ExPolygons> build_local_z_transition_fixed_masks_for_pass(
     return pass_masks_by_extruder;
 }
 
+static bool append_fixed_masks_for_pass(
+    std::vector<ExPolygons>          &plan_fixed_masks_by_extruder,
+    const std::vector<ExPolygons>    &fixed_state_masks_by_extruder,
+    const std::vector<ExPolygons>    &prev_fixed_state_masks_by_extruder,
+    const std::vector<ExPolygons>    &next_fixed_state_masks_by_extruder,
+    const size_t                      pass_idx,
+    const size_t                      num_passes)
+{
+    const std::vector<ExPolygons> fixed_masks_for_pass =
+        build_local_z_transition_fixed_masks_for_pass(fixed_state_masks_by_extruder,
+                                                      prev_fixed_state_masks_by_extruder,
+                                                      next_fixed_state_masks_by_extruder,
+                                                      pass_idx,
+                                                      num_passes);
+    bool appended = false;
+    for (size_t extruder_idx = 0; extruder_idx < fixed_masks_for_pass.size() &&
+                                 extruder_idx < plan_fixed_masks_by_extruder.size();
+         ++extruder_idx) {
+        if (fixed_masks_for_pass[extruder_idx].empty())
+            continue;
+        append(plan_fixed_masks_by_extruder[extruder_idx], fixed_masks_for_pass[extruder_idx]);
+        appended = true;
+    }
+    return appended;
+}
+
 template<typename ThrowOnCancel>
 static void build_local_z_plan(PrintObject &print_object, const std::vector<std::vector<ExPolygons>> &segmentation, ThrowOnCancel throw_on_cancel)
 {
@@ -3251,9 +3286,7 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
             append(mixed_masks, state_masks);
 
             const double mixed_area = std::abs(area(state_masks));
-            double dummy_a = 0.0, dummy_b = 0.0;
-            const bool candidate_is_gradient = effective_gradient_heights_for_row(size_t(mixed_idx), layer_id, interval.base_height, dummy_a, dummy_b);
-            if (mixed_area > dominant_mixed_area && candidate_is_gradient) {
+            if (mixed_area > dominant_mixed_area) {
                 dominant_mixed_area = mixed_area;
                 dominant_mixed_idx  = size_t(mixed_idx);
             }
@@ -3371,7 +3404,7 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
                 append(fixed_state_masks_union, state_masks);
         if (fixed_state_masks_union.size() > 1)
             fixed_state_masks_union = union_ex(fixed_state_masks_union);
-        if (interval.has_mixed_paint && !fixed_state_masks_union.empty()) {
+        if (interval.has_mixed_paint && local_z_whole_objects && !fixed_state_masks_union.empty()) {
             if (!base_masks.empty()) {
                 base_masks = diff_ex(base_masks, fixed_state_masks_union);
                 if (!base_masks.empty()) {
@@ -3665,20 +3698,15 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
                         isolated_plans[idx].pass_index = idx;
                         min_flow_height = std::min(min_flow_height, isolated_plans[idx].flow_height);
                         max_flow_height = std::max(max_flow_height, isolated_plans[idx].flow_height);
-                        const std::vector<ExPolygons> fixed_masks_for_pass =
-                            build_local_z_transition_fixed_masks_for_pass(fixed_state_masks_by_extruder,
-                                                                          prev_fixed_state_masks_by_extruder,
-                                                                          next_fixed_state_masks_by_extruder,
-                                                                          idx,
-                                                                          isolated_plans.size());
                         bool plan_has_fixed_masks = false;
-                        for (size_t extruder_idx = 0; extruder_idx < fixed_masks_for_pass.size() &&
-                                                     extruder_idx < isolated_plans[idx].fixed_painted_masks_by_extruder.size();
-                             ++extruder_idx) {
-                            if (fixed_masks_for_pass[extruder_idx].empty())
-                                continue;
-                            append(isolated_plans[idx].fixed_painted_masks_by_extruder[extruder_idx], fixed_masks_for_pass[extruder_idx]);
-                            plan_has_fixed_masks = true;
+                        if (local_z_whole_objects) {
+                            plan_has_fixed_masks = append_fixed_masks_for_pass(
+                                isolated_plans[idx].fixed_painted_masks_by_extruder,
+                                fixed_state_masks_by_extruder,
+                                prev_fixed_state_masks_by_extruder,
+                                next_fixed_state_masks_by_extruder,
+                                idx,
+                                isolated_plans.size());
                         }
                         for (ExPolygons &masks : isolated_plans[idx].painted_masks_by_extruder)
                             if (masks.size() > 1)
@@ -3848,17 +3876,15 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
                         if (row_is_gradient_vec[row_idx] == 0)
                             non_gradient_row_done[row_idx] = uint8_t(1);
                     }
-                    const std::vector<ExPolygons> fixed_masks_for_pass =
-                        build_local_z_transition_fixed_masks_for_pass(fixed_state_masks_by_extruder,
-                                                                      prev_fixed_state_masks_by_extruder,
-                                                                      next_fixed_state_masks_by_extruder,
-                                                                      pass_idx,
-                                                                      pass_heights.size());
-                    for (size_t extruder_idx = 0; extruder_idx < fixed_masks_for_pass.size(); ++extruder_idx)
-                        if (!fixed_masks_for_pass[extruder_idx].empty()) {
-                            append(plan.fixed_painted_masks_by_extruder[extruder_idx], fixed_masks_for_pass[extruder_idx]);
-                            pass_has_painted_masks = true;
-                        }
+                    if (local_z_whole_objects) {
+                        pass_has_painted_masks |= append_fixed_masks_for_pass(
+                            plan.fixed_painted_masks_by_extruder,
+                            fixed_state_masks_by_extruder,
+                            prev_fixed_state_masks_by_extruder,
+                            next_fixed_state_masks_by_extruder,
+                            pass_idx,
+                            pass_heights.size());
+                    }
                     for (ExPolygons &masks : plan.painted_masks_by_extruder)
                         if (masks.size() > 1)
                             masks = union_ex(masks);


### PR DESCRIPTION
Description  
  Fixes:                                                                                                                    
  - Fix sub-layer proportions ignoring non-gradient mix ratios (67:33, 50:25:25
    etc.) — dominant row selection no longer requires candidate_is_gradient,
    and 3-component pair mix_b_percent override removed
  - Fix single-color layers incorrectly split into sublayers when local_z_whole_objects
    is off — add missing guard to fixed-state mask exclusion
  - Wrap WipeTower2 construction path with try/catch fallback to set_extruder()
  - Set erWipeTower role only when real wipe tower G-code is emitted via
    was_wipe_tower_purge output parameter
  Refactoring:
  - Extract emit_local_z_unplanned_toolchange from 193-line lambda to private method
  - Split into three methods: guards+routing, via_wipe_tower, manual_purge
  - Extract append_fixed_masks_for_pass helper to deduplicate plan generation code
  Performance:
  - Cache wipe_volumes extraction to avoid repeated filament config parsing
    across per-sublayer toolchanges