### PR TITLE
feat: improve cycle pattern display, ratio calculation, and compatibility warnings

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1518,6 +1518,9 @@ void MenuFactory::create_filament_action_menu(bool init, int active_filament_men
             nullptr, []() { return plater()->sidebar().combos_filament().size() > 1; }, m_parent);
     }
 
+    if (wxGetApp().preset_bundle == nullptr)
+        return;
+
     const int item_id = menu->FindItem(_L("Merge with"));
     if (item_id != wxNOT_FOUND)
         menu->Destroy(item_id);

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -982,4 +982,69 @@ CyclePatternParseResult parse_cycle_pattern(const std::string& normalized_patter
     return result;
 }
 
+std::string summarize_cycle_pattern_text(const std::string& normalized_pattern,
+                                         const MixedFilament& entry,
+                                         int num_physical)
+{
+    if (normalized_pattern.empty() || num_physical <= 0)
+        return {};
+
+    const auto groups = MixedFilamentManager::split_pattern_groups(normalized_pattern);
+    if (groups.empty())
+        return {};
+
+    std::map<unsigned int, int> counts;
+    int                         total = 0;
+    for (const auto& group : groups) {
+        const auto tokens = MixedFilamentManager::split_pattern_group_to_tokens(group, num_physical);
+        for (const auto& token : tokens) {
+            unsigned int eid = MixedFilamentManager::physical_filament_from_token(token, entry, num_physical);
+            if (eid >= 1 && eid <= (unsigned)num_physical) {
+                counts[eid]++;
+                total++;
+            }
+        }
+    }
+
+    if (total <= 0 || counts.empty())
+        return {};
+
+    std::vector<std::pair<unsigned int, int>> sorted(counts.begin(), counts.end());
+    std::sort(sorted.begin(), sorted.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    // Compute floor percentages; distribute remainder via largest remainders.
+    std::vector<int> pcts(sorted.size());
+    int              sum_pct = 0;
+    for (size_t i = 0; i < sorted.size(); ++i) {
+        pcts[i]  = int((static_cast<long long>(sorted[i].second) * 100) / total);
+        sum_pct += pcts[i];
+    }
+
+    if (sum_pct < 100) {
+        // Remainder indexed by original position, value = count * 100 % total
+        std::vector<std::pair<size_t, int>> rem;
+        rem.reserve(sorted.size());
+        for (size_t i = 0; i < sorted.size(); ++i)
+            rem.emplace_back(i, int((static_cast<long long>(sorted[i].second) * 100) % total));
+        // Sort descending by remainder, then by original index for stability
+        std::sort(rem.begin(), rem.end(), [](const auto& a, const auto& b) {
+            if (a.second != b.second) return a.second > b.second;
+            return a.first < b.first;
+        });
+        for (int extra = 100 - sum_pct; extra > 0; --extra) {
+            pcts[rem.front().first]++;
+            rem.erase(rem.begin());
+        }
+    }
+
+    std::ostringstream out;
+    for (size_t i = 0; i < sorted.size(); ++i) {
+        if (i > 0)
+            out << '+';
+        out << 'F' << sorted[i].first << ' ' << pcts[i] << '%';
+    }
+    return out.str();
+}
+
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedColorMatchHelpers.hpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.hpp
@@ -92,4 +92,10 @@ struct CyclePatternParseResult {
 // One-shot parse of a normalized cycle pattern: split→token→strtoul→validate.
 CyclePatternParseResult parse_cycle_pattern(const std::string& normalized_pattern, int num_physical);
 
+// Parse a normalized cycle pattern and produce a human-readable percentage summary.
+// Format: "F1 60%+F2 40%". Returns empty string on invalid input.
+std::string summarize_cycle_pattern_text(const std::string& normalized_pattern,
+                                         const MixedFilament& entry,
+                                         int num_physical);
+
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -1449,6 +1449,12 @@ void MixedFilamentDialog::update_compatibility_warning()
         m_btn_confirm->Disable();
     } else if (check_low_ratio_warning()) {
         // advisory warning shown, confirm stays enabled
+    } else if (m_current_mode == MODE_CYCLE && fids.size() == 1) {
+        display_warning(_L("Participating filaments have the same color and cannot produce different colors. Please select filaments with different colors for mixing."));
+        if (m_btn_confirm) m_btn_confirm->Enable();
+    } else if (m_current_mode == MODE_CYCLE && fids.size() > 4) {
+        display_warning(_L("Too many filaments participating in color mixing may affect the blending result. Please use with caution."));
+        if (m_btn_confirm) m_btn_confirm->Enable();
     } else {
         m_compat_warning_panel->Hide();
         m_btn_confirm->Enable();
@@ -1526,17 +1532,7 @@ bool MixedFilamentDialog::check_low_ratio_warning()
         }
         break;
     case MODE_CYCLE:
-        if (m_pattern_ctrl) {
-            const std::string raw = into_u8(m_pattern_ctrl->GetValue());
-            const std::string normalized = MixedFilamentManager::normalize_manual_pattern(raw);
-            auto parsed = parse_cycle_pattern(normalized, num_physical);
-            for (unsigned int id : parsed.ids) {
-                if (id < 1 || id > (unsigned)num_physical) continue;
-                ratios[id - 1] += 1.0;
-                total += 1.0;
-            }
-        }
-        break;
+        return false;
     }
 
     if (total <= 0.0)
@@ -1660,11 +1656,15 @@ void MixedFilamentDialog::draw_strip(wxDC& dc, wxPanel* panel)
             const bool b_major = pct_b >= pct_a;
             const int major = b_major ? pct_b : pct_a;
             const int minor = b_major ? pct_a : pct_b;
-            const int layers = std::min(std::max(1, (int)std::lround((double)major / (double)std::max(1, minor))), 20);
-            ratio_a = b_major ? 1 : layers;
-            ratio_b = b_major ? layers : 1;
-            const int g = std::gcd(ratio_a, ratio_b);
-            if (g > 1) { ratio_a /= g; ratio_b /= g; }
+            const int g = std::gcd(major, minor);
+            ratio_a = b_major ? (minor / g) : (major / g);
+            ratio_b = b_major ? (major / g) : (minor / g);
+            // Cap total stripes to 20 for visual clarity in preview
+            if (ratio_a + ratio_b > 20) {
+                const double scale = 20.0 / (ratio_a + ratio_b);
+                ratio_a = std::max(1, (int)std::round(ratio_a * scale));
+                ratio_b = std::max(1, (int)std::round(ratio_b * scale));
+            }
         }
         const int cycle = std::max(1, ratio_a + ratio_b);
         for (int pos = 0; pos < cycle; ++pos) {
@@ -2231,13 +2231,9 @@ void MixedFilamentDialog::collect_result()
                 const bool b_is_major = pct_b >= pct_a;
                 const int major_pct   = b_is_major ? pct_b : pct_a;
                 const int minor_pct   = b_is_major ? pct_a : pct_b;
-                const int major_layers = std::min(std::max(1, int(std::lround(double(major_pct) / double(std::max(1, minor_pct))))), 20);
-                ratio_a = b_is_major ? 1 : major_layers;
-                ratio_b = b_is_major ? major_layers : 1;
-            }
-            if (ratio_a > 0 && ratio_b > 0) {
-                const int g = std::gcd(ratio_a, ratio_b);
-                if (g > 1) { ratio_a /= g; ratio_b /= g; }
+                const int g = std::gcd(major_pct, minor_pct);
+                ratio_a = b_is_major ? (minor_pct / g) : (major_pct / g);
+                ratio_b = b_is_major ? (major_pct / g) : (minor_pct / g);
             }
             m_result.ratio_a = std::max(0, ratio_a);
             m_result.ratio_b = std::max(0, ratio_b);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -5650,6 +5650,7 @@ void Sidebar::init_color_mix_panel(wxWindow* parent, wxSizer* sizer)
         if (auto* opt = pb->project_config.option<ConfigOptionString>("mixed_filament_definitions"))
             opt->value = mgr.serialize_custom_entries();
         wxGetApp().plater()->post_slice_state_change_update();
+        wxGetApp().plater()->on_filaments_change(p->combos_filament.size());
         update_color_mix_panel();
         m_scrolled_sizer->Layout();
     });
@@ -5670,6 +5671,7 @@ void Sidebar::init_color_mix_panel(wxWindow* parent, wxSizer* sizer)
         if (auto* opt = pb->project_config.option<ConfigOptionString>("mixed_filament_definitions"))
             opt->value = mgr.serialize_custom_entries();
         wxGetApp().plater()->post_slice_state_change_update();
+        wxGetApp().plater()->on_filaments_change(p->combos_filament.size());
         update_color_mix_panel();
         m_scrolled_sizer->Layout();
     });
@@ -5774,7 +5776,7 @@ void Sidebar::update_color_mix_panel()
 
         wxString lbl;
         if (!normalized_pattern_cm.empty())
-            lbl = _L("Pattern");
+            lbl = wxString(summarize_cycle_pattern_text(normalized_pattern_cm, mf, int(num_physical)));
         else if (mf.gradient_component_ids.size() >= 3) {
             // parse weights
             const size_t n = mf.gradient_component_ids.size();
@@ -5889,6 +5891,7 @@ void Sidebar::update_color_mix_panel()
             if (auto* opt = wxGetApp().preset_bundle->project_config.option<ConfigOptionString>("mixed_filament_definitions"))
                 opt->value = mgr.serialize_custom_entries();
             wxGetApp().plater()->post_slice_state_change_update();
+            wxGetApp().plater()->on_filaments_change(p->combos_filament.size());
             wxTheApp->CallAfter([this]() {
                 update_color_mix_panel();
                 m_scrolled_sizer->Layout();
@@ -5930,6 +5933,7 @@ void Sidebar::update_color_mix_panel()
                 if (auto* opt = wxGetApp().preset_bundle->project_config.option<ConfigOptionString>("mixed_filament_definitions"))
                     opt->value = mgr.serialize_custom_entries();
                 wxGetApp().plater()->post_slice_state_change_update();
+                wxGetApp().plater()->on_filaments_change(p->combos_filament.size());
                 wxTheApp->CallAfter([this]() {
                     update_color_mix_panel();
                     m_scrolled_sizer->Layout();
@@ -6029,6 +6033,7 @@ void Sidebar::update_color_mix_panel()
                 if (auto* opt = wxGetApp().preset_bundle->project_config.option<ConfigOptionString>("mixed_filament_definitions"))
                     opt->value = mgr2.serialize_custom_entries();
                 wxGetApp().plater()->post_slice_state_change_update();
+                wxGetApp().plater()->on_filaments_change(p->combos_filament.size());
                 wxTheApp->CallAfter([this]() {
                     update_color_mix_panel();
                     m_scrolled_sizer->Layout();


### PR DESCRIPTION
### Summary
Enhancements to the mixed filament cycle mode: human-readable pattern summaries, corrected stripe ratio math, new compatibility warnings, and missing UI refresh callbacks.
### Changes

- New summarize_cycle_pattern_text() — Parses cycle patterns and renders a percentage breakdown (e.g. "F1 60%+F2 40%") in the sidebar, replacing the previous generic "Pattern" label.
- Fix stripe ratio calculation — Replaced the heuristic layer-count approach with a GCD-based method. Total stripes are capped at 20 for visual clarity in the preview strip.
- New compatibility warnings — Cycle mode now warns when all participating filaments share the same color, or when more than 4 filaments are involved.
- Missing on_filaments_change() callbacks — Fired after mixed filament add/delete/update operations to keep the filament combo and UI in sync.
- Null guard — Added preset_bundle null check in the filament action menu factory.