### PR TITLE
feature: sync network test logs to file and enhance version info logging

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -764,8 +764,57 @@ static void register_win32_device_notification_event()
 }
 #endif // WIN32
 
+// Windows 11 build number threshold: build >= 22000 = Windows 11
+constexpr int kWindows11BuildNumber = 22000;
+
+static void log_version_info()
+{
+    BOOST_LOG_TRIVIAL(warning) << "========================================";
+    BOOST_LOG_TRIVIAL(warning) << "Snapmaker Orca Version Information";
+    BOOST_LOG_TRIVIAL(warning) << "========================================";
+
+    BOOST_LOG_TRIVIAL(warning) << "[Version] Snapmaker Orca: " << Snapmaker_VERSION
+                               << ", Build: " << SLIC3R_VERSION;
+
+    std::string flutter_ver = common::get_flutter_version();
+    BOOST_LOG_TRIVIAL(warning) << "[Version] Orca Web: " << (flutter_ver.empty() ? "N/A" : flutter_ver);
+
+    std::string profile_ver = common::get_profile_version();
+    BOOST_LOG_TRIVIAL(warning) << "[Version] Profile: " << (profile_ver.empty() ? "N/A" : profile_ver);
+
+    std::string os_desc{};
+#if defined(__LINUX__) || defined(__linux__)
+    wxLinuxDistributionInfo distro = wxGetLinuxDistributionInfo();
+    if (!distro.Id.empty()) {
+        os_desc = distro.Id.ToStdString();
+        if (!distro.Release.empty())
+            os_desc += " " + distro.Release.ToStdString();
+    }
+#endif
+    if (os_desc.empty()) {
+        os_desc = wxGetOsDescription().ToStdString();
+    }
+
+#if defined(_WIN32)
+    // Append Windows version numbers (major.minor.build) for all Windows versions.
+    // Also correct "Windows 10" → "Windows 11" for builds >= 22000.
+    int major = 0, minor = 0, micro = 0;
+    wxGetOsVersion(&major, &minor, &micro);
+    if (micro >= kWindows11BuildNumber) {
+        size_t pos = os_desc.find("Windows 10");
+        if (pos != std::string::npos)
+            os_desc.replace(pos, 10, "Windows 11");
+    }
+    os_desc += " (" + std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(micro) + ")";
+#endif
+    BOOST_LOG_TRIVIAL(warning) << "[Version] OS: " << os_desc;
+
+    BOOST_LOG_TRIVIAL(warning) << "========================================";
+}
+
 static void generic_exception_handle()
 {
+    log_version_info();
     // Note: Some wxWidgets APIs use wxLogError() to report errors, eg. wxImage
     // - see https://docs.wxwidgets.org/3.1/classwx_image.html#aa249e657259fe6518d68a5208b9043d0
     //
@@ -1893,6 +1942,7 @@ GUI_App::~GUI_App()
 {
     GUI_App::m_app_alive.store(false);
 
+    log_version_info();
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< boost::format(": enter");
     if (app_config != nullptr) {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< boost::format(": destroy app_config");
@@ -2371,7 +2421,8 @@ bool GUI_App::on_init_inner()
 #endif
 
     BOOST_LOG_TRIVIAL(info) << boost::format("gui mode, Current Snapmaker_Orca Version %1%")%Snapmaker_VERSION;
-    
+    log_version_info();
+
 #if defined(__WINDOWS__)
     HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");
     m_is_arm64 = false;
@@ -4574,12 +4625,10 @@ std::string detect_updater_os_info()
         description = wxGetOsDescription();
 
     //Orca: workaround: wxGetOsVersion can't recognize Windows 11
-    // For Windows, use actual version numbers to properly detect Windows 11
-    // Windows 11 starts at build 22000
 #if defined(_WIN32)
     int major = 0, minor = 0, micro = 0;
     wxGetOsVersion(&major, &minor, &micro);
-    if (micro >= 22000) {
+    if (micro >= kWindows11BuildNumber) {
         // replace Windows 10 with Windows 11
         description.Replace("Windows 10", "Windows 11");
     }

--- a/src/slic3r/GUI/NetworkTestDialog.cpp
+++ b/src/slic3r/GUI/NetworkTestDialog.cpp
@@ -28,6 +28,9 @@ wxDEFINE_EVENT(EVT_UPDATE_RESULT, wxCommandEvent);
 
 static wxString NA_STR = _L("N/A");
 
+// Searchable tag for network test log entries in file logs.
+#define NETWORK_TEST_LOG_TAG "[NetworkTest]"
+
 NetworkTestDialog::NetworkTestDialog(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style)
     : DPIDialog(parent,wxID_ANY,from_u8((boost::format(_utf8(L("Network Test")))).str()),wxDefaultPosition,
             wxSize(1000, 700),
@@ -369,6 +372,8 @@ wxString NetworkTestDialog::get_dns_info()
 
 void NetworkTestDialog::start_all_job()
 {
+	log_section_header(_L("Network test started"));
+
 	start_test_github_thread();
 	start_test_bing_thread();
 	start_test_lan_mqtt_thread();
@@ -399,10 +404,7 @@ void NetworkTestDialog::start_all_job_sequence()
 	m_sequence_job = new boost::thread([weak_this = weak_this, device_ip] {
 		auto self = weak_this.lock();
 		if (!self) return;
-		self->update_status(-1, "========================================");
-		self->update_status(-1, "Start sequence test (single-thread mode)");
-		self->update_status(-1, "========================================");
-		self->update_status(-1, "");
+		self->log_section_header("Start sequence test (single-thread mode)");
 
         self->start_test_url(TEST_BING_JOB, "Bing", "http://www.bing.com");
         if (self->m_closing.load()) return;
@@ -440,10 +442,7 @@ void NetworkTestDialog::start_all_job_sequence()
 		self->start_test_url(TEST_UPLOAD_API_JOB, "Upload API", upload_api_url);
 		if (self->m_closing.load()) return;
 
-		self->update_status(-1, "");
-		self->update_status(-1, "========================================");
-		self->update_status(-1, "Sequence test completed");
-		self->update_status(-1, "========================================");
+		self->log_section_header("Sequence test completed");
 	});
 }
 
@@ -1186,8 +1185,22 @@ void NetworkTestDialog::on_dpi_changed(const wxRect &suggested_rect)
     ;
 }
 
+void NetworkTestDialog::log_section_header(const wxString& title)
+{
+	static const wxString sep("========================================");
+	update_status(-1, wxEmptyString);
+	update_status(-1, sep);
+	update_status(-1, title);
+	update_status(-1, sep);
+	update_status(-1, wxEmptyString);
+}
+
 void NetworkTestDialog::update_status(int job_id, wxString info)
 {
+	// Sync to file log with a searchable tag so users can find
+	// network test results in the log file using "[NetworkTest]".
+	BOOST_LOG_TRIVIAL(warning) << NETWORK_TEST_LOG_TAG " " << into_u8(info);
+
 	// Early exit if dialog is closing - don't access any members
 	if (m_closing.load()) return;
 

--- a/src/slic3r/GUI/NetworkTestDialog.hpp
+++ b/src/slic3r/GUI/NetworkTestDialog.hpp
@@ -129,6 +129,9 @@ public:
 
 	wxString get_cloud_server_address();
 
+	// Print a section header with separator lines to both UI and file log.
+	void log_section_header(const wxString& title);
+
 private:
 	void cleanup_threads();
 };


### PR DESCRIPTION
# Description
- Sync NetworkTestDialog UI logs to Boost.Log file log with [NetworkTest] tag
- Add log_section_header() helper for formatted section headers in test output
- Add separator lines around version info block at startup and exit
- Log version info on normal exit (~GUI_App) and abnormal exit (generic_exception_handle)