### PR TITLE
refactor: Add software version information when manually exporting logs

### DIFF
--- a/src/libslic3r/Utils.hpp
+++ b/src/libslic3r/Utils.hpp
@@ -161,6 +161,10 @@ bool makedir(const std::string path);
 std::string debug_out_path(const char *name, ...);
 // smaller level means less log. level=5 means saving all logs.
 void set_log_path_and_level(const std::string& file, unsigned int level);
+
+/*
+ * TODO : This interface may have truncation issues.
+ */
 void flush_logs();
 
 // A special type for strings encoded in the local Windows 8-bit code page.

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -366,8 +366,32 @@ void set_log_path_and_level(const std::string& file, unsigned int level)
 
 void flush_logs()
 {
-	if (g_log_sink)
+	if (g_log_sink) {
 		g_log_sink->flush();
+
+#ifdef _WIN32
+		// On Windows, std::ofstream::flush() writes data to the OS cache but
+		// does not update the file's directory-entry size metadata. Subsequent
+		// reads via std::ifstream may see a truncated file. FlushFileBuffers
+		// forces the file metadata (including size) to be committed to disk.
+		auto backend = g_log_sink->locked_backend();
+		auto file_path = backend->get_current_file_name();
+		if (!file_path.empty()) {
+			HANDLE hFile = CreateFileW(
+				file_path.native().c_str(),
+				GENERIC_WRITE,
+				FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+				NULL,
+				OPEN_EXISTING,
+				FILE_ATTRIBUTE_NORMAL,
+				NULL);
+			if (hFile != INVALID_HANDLE_VALUE) {
+				FlushFileBuffers(hFile);
+				CloseHandle(hFile);
+			}
+		}
+#endif
+	}
 
 	return;
 }

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -366,32 +366,8 @@ void set_log_path_and_level(const std::string& file, unsigned int level)
 
 void flush_logs()
 {
-	if (g_log_sink) {
+	if (g_log_sink) 
 		g_log_sink->flush();
-
-#ifdef _WIN32
-		// On Windows, std::ofstream::flush() writes data to the OS cache but
-		// does not update the file's directory-entry size metadata. Subsequent
-		// reads via std::ifstream may see a truncated file. FlushFileBuffers
-		// forces the file metadata (including size) to be committed to disk.
-		auto backend = g_log_sink->locked_backend();
-		auto file_path = backend->get_current_file_name();
-		if (!file_path.empty()) {
-			HANDLE hFile = CreateFileW(
-				file_path.native().c_str(),
-				GENERIC_WRITE,
-				FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-				NULL,
-				OPEN_EXISTING,
-				FILE_ATTRIBUTE_NORMAL,
-				NULL);
-			if (hFile != INVALID_HANDLE_VALUE) {
-				FlushFileBuffers(hFile);
-				CloseHandle(hFile);
-			}
-		}
-#endif
-	}
 
 	return;
 }

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -366,7 +366,7 @@ void set_log_path_and_level(const std::string& file, unsigned int level)
 
 void flush_logs()
 {
-	if (g_log_sink) 
+	if (g_log_sink)
 		g_log_sink->flush();
 
 	return;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -810,6 +810,8 @@ void GUI_App::log_version_info()
     BOOST_LOG_TRIVIAL(warning) << "[Version] OS: " << os_desc;
 
     BOOST_LOG_TRIVIAL(warning) << "========================================";
+
+    flush_logs();
 }
 
 static void generic_exception_handle()

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -767,7 +767,7 @@ static void register_win32_device_notification_event()
 // Windows 11 build number threshold: build >= 22000 = Windows 11
 constexpr int kWindows11BuildNumber = 22000;
 
-static void log_version_info()
+void GUI_App::log_version_info()
 {
     BOOST_LOG_TRIVIAL(warning) << "========================================";
     BOOST_LOG_TRIVIAL(warning) << "Snapmaker Orca Version Information";
@@ -814,7 +814,7 @@ static void log_version_info()
 
 static void generic_exception_handle()
 {
-    log_version_info();
+    GUI_App::log_version_info();
     // Note: Some wxWidgets APIs use wxLogError() to report errors, eg. wxImage
     // - see https://docs.wxwidgets.org/3.1/classwx_image.html#aa249e657259fe6518d68a5208b9043d0
     //
@@ -1942,7 +1942,7 @@ GUI_App::~GUI_App()
 {
     GUI_App::m_app_alive.store(false);
 
-    log_version_info();
+    GUI_App::log_version_info();
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< boost::format(": enter");
     if (app_config != nullptr) {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< boost::format(": destroy app_config");
@@ -2421,7 +2421,7 @@ bool GUI_App::on_init_inner()
 #endif
 
     BOOST_LOG_TRIVIAL(info) << boost::format("gui mode, Current Snapmaker_Orca Version %1%")%Snapmaker_VERSION;
-    log_version_info();
+    GUI_App::log_version_info();
 
 #if defined(__WINDOWS__)
     HMODULE hKernel32 = GetModuleHandleW(L"kernel32.dll");

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -246,6 +246,8 @@ public:
 
     static std::atomic<bool> m_app_alive; // 标记应用是否存活
 
+    static void log_version_info();
+
 private:
     bool            m_initialized { false };
     bool            m_post_initialized { false };

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -3973,8 +3973,6 @@ void MainFrame::show_sync_dialog()
 
 void MainFrame::export_logs()
 {
-    GUI_App::log_version_info();
-
     // 1. Get log folder path
     auto log_folder = boost::filesystem::path(data_dir()) / "log";
 
@@ -4005,6 +4003,9 @@ void MainFrame::export_logs()
         return;
 
     wxString zip_path = dlg.GetPath();
+
+    // Write version info and flush to log file before zipping
+    GUI_App::log_version_info();
 
     // 4. Create ZIP file and add all logs
     try {

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -3973,6 +3973,8 @@ void MainFrame::show_sync_dialog()
 
 void MainFrame::export_logs()
 {
+    GUI_App::log_version_info();
+
     // 1. Get log folder path
     auto log_folder = boost::filesystem::path(data_dir()) / "log";
 


### PR DESCRIPTION
Make log_version_info() a static method of GUI_App instead of a global free function. Also call it from export_logs() so exported log files always include the version information block.