### PR TITLE
feat: add filament length field for Flutter-side filament exhaustion detection

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -3121,6 +3121,7 @@ void SSWCP_MachineOption_Instance::sw_GetFileFilamentMapping()
             std::vector<double> filament_used_g(filament_density.size(), 0);
             double              total_weight = 0;
             for (const auto& pr : result.print_statistics.total_volumes_per_extruder) {
+                if (pr.first >= filament_density.size()) continue;
                 filament_used_g[pr.first] = filament_density[pr.first] * pr.second * 0.001;
                 total_weight += filament_used_g[pr.first];
             }
@@ -3128,7 +3129,22 @@ void SSWCP_MachineOption_Instance::sw_GetFileFilamentMapping()
             response["filament_weight"] = filament_used_g;
             response["filament_weight_total"] = total_weight;
         }
-        
+
+        // filament used mm (length)
+        if (config.has("filament_diameter")) {
+            auto filament_diameter = config.option<ConfigOptionFloats>("filament_diameter")->values;
+
+            std::vector<double> filament_used_mm(filament_diameter.size(), 0);
+            for (const auto& pr : result.print_statistics.total_volumes_per_extruder) {
+                if (pr.first >= filament_diameter.size()) continue;
+                auto diameter = static_cast<double>(filament_diameter[pr.first]);
+                if (diameter > 0) {
+                    filament_used_mm[pr.first] = pr.second / (M_PI * (diameter * 0.5) * (diameter * 0.5));
+                }
+            }
+            response["filament_used_mm"] = filament_used_mm;
+        }
+
         // filament extruder
         auto& filament_extruder_map = wxGetApp().app_config->get_filament_extruder_map_ref();
         if (!filament_extruder_map.empty()) {

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -3121,7 +3121,9 @@ void SSWCP_MachineOption_Instance::sw_GetFileFilamentMapping()
             std::vector<double> filament_used_g(filament_density.size(), 0);
             double              total_weight = 0;
             for (const auto& pr : result.print_statistics.total_volumes_per_extruder) {
-                if (pr.first >= filament_density.size()) continue;
+                if (pr.first >= filament_density.size()) {
+                    continue;
+                }
                 filament_used_g[pr.first] = filament_density[pr.first] * pr.second * 0.001;
                 total_weight += filament_used_g[pr.first];
             }
@@ -3132,11 +3134,18 @@ void SSWCP_MachineOption_Instance::sw_GetFileFilamentMapping()
 
         // filament used mm (length)
         if (config.has("filament_diameter")) {
-            auto filament_diameter = config.option<ConfigOptionFloats>("filament_diameter")->values;
+            auto filament_diameter_opt = config.option<ConfigOptionFloats>("filament_diameter");
+            if (!filament_diameter_opt) {
+                handle_general_fail();
+                return;
+            }
+            auto filament_diameter = filament_diameter_opt->values;
 
             std::vector<double> filament_used_mm(filament_diameter.size(), 0);
             for (const auto& pr : result.print_statistics.total_volumes_per_extruder) {
-                if (pr.first >= filament_diameter.size()) continue;
+                if (pr.first >= filament_diameter.size()) {
+                    continue;
+                }
                 auto diameter = static_cast<double>(filament_diameter[pr.first]);
                 if (diameter > 0) {
                     filament_used_mm[pr.first] = pr.second / (M_PI * (diameter * 0.5) * (diameter * 0.5));


### PR DESCRIPTION
Add `filament_used_mm` field to `sw_GetFileFilamentMapping` API response, providing per-extruder filament length in millimeters for the Flutter UI to determine filament exhaustion by length instead of weight.

# Description

• Added filament_used_mm field to sw_GetFileFilamentMapping API response
• Provides per-extruder filament length (mm) calculated from extruded volume and filament diameter
• Enables Flutter UI to determine filament exhaustion by length instead of weight

# Test plan
• Verify filament_used_mm appears in the API response after slicing a model
• Verify filament_used_mm values match ; filament used [mm] = in the exported G-code file
• Verify unused extruder slots have filament_used_mm value of 0
• Verify filament_used_mm array length equals total extruder count