### PR TITLE
Fix bed temperature drop on layer 2 in multi-material prints

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3968,8 +3968,14 @@ LayerResult GCode::process_layer(const Print& print,
                 gcode += m_writer.set_temperature(temperature, false, extruder.id());
         }
 
-        // BBS
-        int bed_temp = get_bed_temperature(first_extruder_id, false, print.config().curr_bed_type);
+        // BBS:
+        // snorca: use the maximum bed temperature across all extruders so that a mixed-material print
+        // does not change temperatures after the first layer. This was observed in mixed PLA and TPU prints
+        // where the bed temperature would fall to 35, causing PLA adhesion failures.
+        int bed_temp = 0;
+        for (const Extruder& extruder : m_writer.extruders()) {
+            bed_temp = std::max(bed_temp, get_bed_temperature(extruder.id(), false, print.config().curr_bed_type));
+        }
         gcode += m_writer.set_bed_temperature(bed_temp);
         // Mark the temperature transition from 1st to 2nd layer to be finished.
         m_second_layer_things_done = true;


### PR DESCRIPTION


# Description

In mixed-material prints (e.g. PLA at 65°C + TPU at 35°C), the bed temperature was set using only the first extruder's "other layers" value. When that happens to be the lower-temp material, the bed temp would drop on layer 2 and cause adhesion failures for the higher-temp one.

# Screenshots/Recordings/Graphs

No relevant UI changes.

## Tests

Manually tested as this code path is not unit tested.
