### PR TITLE
Feature opt gcode model contour

### DIFF
--- a/src/libslic3r/Polygon.cpp
+++ b/src/libslic3r/Polygon.cpp
@@ -99,6 +99,16 @@ void Polygon::douglas_peucker(double tolerance)
     this->points = std::move(p);
 }
 
+void Polygon::round_to_grid(double grid_size)
+{
+    if (grid_size <= 0.)
+        return;
+    for (Point &p : this->points) {
+        p.x() = coord_t(std::round(double(p.x()) / grid_size) * grid_size);
+        p.y() = coord_t(std::round(double(p.y()) / grid_size) * grid_size);
+    }
+}
+
 Polygons Polygon::simplify(double tolerance) const
 {
     // Works on CCW polygons only, CW contour will be reoriented to CCW by Clipper's simplify_polygons()!

--- a/src/libslic3r/Polygon.hpp
+++ b/src/libslic3r/Polygon.hpp
@@ -61,6 +61,7 @@ public:
     bool make_clockwise();
     bool is_valid() const { return this->points.size() >= 3; }
     void douglas_peucker(double tolerance);
+    void round_to_grid(double grid_size);
 
     // Does an unoriented polygon contain a point?
     bool contains(const Point &point) const { return Slic3r::contains(*this, point, true); }

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -4366,7 +4366,8 @@ BoundingBoxf3 PrintInstance::get_bounding_box() {
 
 Polygon PrintInstance::get_convex_hull_2d() {
     Polygon poly = print_object->model_object()->convex_hull_2d(model_instance->get_matrix());
-    poly.douglas_peucker(0.1);
+    // Change the distance threshold of the Douglas-Peucker algorithm to 1 millimeter and reduce the number of points
+    poly.douglas_peucker(scale_(1));
     return poly;
 }
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -4367,7 +4367,9 @@ BoundingBoxf3 PrintInstance::get_bounding_box() {
 Polygon PrintInstance::get_convex_hull_2d() {
     Polygon poly = print_object->model_object()->convex_hull_2d(model_instance->get_matrix());
     // Change the distance threshold of the Douglas-Peucker algorithm to 1 millimeter and reduce the number of points
-    poly.douglas_peucker(scale_(1));
+    poly.douglas_peucker(scale_(0.5));
+    // Round coordinates to 0.1mm grid to limit decimal places
+    poly.round_to_grid(scale_(0.1));
     return poly;
 }
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -4366,7 +4366,7 @@ BoundingBoxf3 PrintInstance::get_bounding_box() {
 
 Polygon PrintInstance::get_convex_hull_2d() {
     Polygon poly = print_object->model_object()->convex_hull_2d(model_instance->get_matrix());
-    // Change the distance threshold of the Douglas-Peucker algorithm to 1 millimeter and reduce the number of points
+    // Change the distance threshold of the Douglas-Peucker algorithm to 0.5 millimeter and reduce the number of points
     poly.douglas_peucker(scale_(0.5));
     // Round coordinates to 0.1mm grid to limit decimal places
     poly.round_to_grid(scale_(0.1));


### PR DESCRIPTION
Modify the distance threshold of the Douglas-Peucker algorithm to 0.5mm. Add decimal point optimization, remove the unnecessary digits after the decimal point, and retain only one decimal place.