### PR TITLE
feat: add mixed filament unit tests, dark mode support, and UI refinements

### DIFF
--- a/src/libslic3r/MixedFilament.cpp
+++ b/src/libslic3r/MixedFilament.cpp
@@ -223,7 +223,7 @@ static float clamp_surface_offset(float v)
     return std::clamp(v, -2.f, 2.f);
 }
 
-static float canonical_signed_bias_value(float component_a_surface_offset, float component_b_surface_offset)
+float MixedFilamentManager::canonical_signed_bias_value(float component_a_surface_offset, float component_b_surface_offset)
 {
     const float offset_a = clamp_surface_offset(component_a_surface_offset);
     const float offset_b = clamp_surface_offset(component_b_surface_offset);
@@ -235,7 +235,7 @@ static float canonical_signed_bias_value(float component_a_surface_offset, float
     return 0.f;
 }
 
-static std::string format_surface_offset_token(float value)
+std::string MixedFilamentManager::format_surface_offset_token(float value)
 {
     std::ostringstream ss;
     ss << std::fixed << std::setprecision(4) << clamp_surface_offset(value);
@@ -268,7 +268,7 @@ static void compute_gradient_heights(const MixedFilament &mf, float lower_bound,
     h_b = lo + pct_b * (hi - lo);
 }
 
-static void normalize_ratio_pair(int &a, int &b)
+void MixedFilamentManager::normalize_ratio_pair(int &a, int &b)
 {
     a = std::max(0, a);
     b = std::max(0, b);
@@ -320,10 +320,10 @@ static void compute_gradient_ratios(MixedFilament &mf, int gradient_mode, float 
         }
     }
 
-    normalize_ratio_pair(mf.ratio_a, mf.ratio_b);
+    MixedFilamentManager::normalize_ratio_pair(mf.ratio_a, mf.ratio_b);
 }
 
-static int safe_mod(int x, int m)
+int MixedFilamentManager::safe_mod(int x, int m)
 {
     if (m <= 0)
         return 0;
@@ -353,12 +353,12 @@ static bool use_component_b_advanced_dither(int layer_index, int ratio_a, int ra
         return true;
 
     // Base ordered pattern: as evenly distributed as possible for ratio_b/cycle.
-    const int pos = safe_mod(layer_index, cycle);
+    const int pos = MixedFilamentManager::safe_mod(layer_index, cycle);
     const int cycle_idx = (layer_index - pos) / cycle;
 
     // Rotate each cycle to avoid visible long-period vertical striping.
-    const int phase = safe_mod(cycle_idx * dithering_phase_step(cycle), cycle);
-    const int p = safe_mod(pos + phase, cycle);
+    const int phase = MixedFilamentManager::safe_mod(cycle_idx * dithering_phase_step(cycle), cycle);
+    const int p = MixedFilamentManager::safe_mod(pos + phase, cycle);
 
     const int b_before = (p * ratio_b) / cycle;
     const int b_after  = ((p + 1) * ratio_b) / cycle;
@@ -1371,7 +1371,7 @@ static std::vector<double> build_local_z_preview_pass_heights(double nominal_lay
     return build_alternating(gradient_h_a, gradient_h_b);
 }
 
-static double mixed_filament_reference_nozzle_mm(unsigned int               component_a,
+double MixedFilamentManager::mixed_filament_reference_nozzle_mm(unsigned int               component_a,
                                                  unsigned int               component_b,
                                                  const std::vector<double> &nozzle_diameters)
 {
@@ -1487,7 +1487,7 @@ std::pair<int, int> mixed_filament_apparent_pair_percentages(const MixedFilament
     if (!mixed_filament_supports_bias_apparent_color(mf, preview_settings, bias_mode_enabled))
         return { 100 - base_b, base_b };
 
-    const double reference_nozzle_mm = mixed_filament_reference_nozzle_mm(mf.component_a, mf.component_b, nozzle_diameters);
+    const double reference_nozzle_mm = MixedFilamentManager::mixed_filament_reference_nozzle_mm(mf.component_a, mf.component_b, nozzle_diameters);
     const int apparent_b = MixedFilamentManager::apparent_mix_b_percent(base_b,
                                                                         mf.component_a_surface_offset,
                                                                         mf.component_b_surface_offset,
@@ -2111,7 +2111,7 @@ unsigned int MixedFilamentManager::resolve(unsigned int filament_id,
         if (!flattened_pattern.empty()) {
             const std::vector<std::string> tokens = split_pattern_group_to_tokens(flattened_pattern, num_physical);
             if (!tokens.empty()) {
-                const int pos = safe_mod(layer_index, int(tokens.size()));
+                const int pos = MixedFilamentManager::safe_mod(layer_index, int(tokens.size()));
                 const unsigned int resolved = physical_filament_from_token(tokens[size_t(pos)], mf, num_physical);
                 if (resolved >= 1 && resolved <= num_physical)
                     return resolved;
@@ -2128,7 +2128,7 @@ unsigned int MixedFilamentManager::resolve(unsigned int filament_id,
         const std::vector<unsigned int> gradient_sequence = build_weighted_gradient_sequence(
             gradient_ids, gradient_weights.empty() ? std::vector<int>(gradient_ids.size(), 1) : gradient_weights);
         if (!gradient_sequence.empty()) {
-            const size_t pos = size_t(safe_mod(layer_index, int(gradient_sequence.size())));
+            const size_t pos = size_t(MixedFilamentManager::safe_mod(layer_index, int(gradient_sequence.size())));
             return gradient_sequence[pos];
         }
     }
@@ -2183,7 +2183,7 @@ unsigned int MixedFilamentManager::resolve_perimeter(unsigned int filament_id,
             if (!group.empty()) {
                 const std::vector<std::string> tokens = split_pattern_group_to_tokens(group, num_physical);
                 if (!tokens.empty()) {
-                    const int pos = safe_mod(layer_index, int(tokens.size()));
+                    const int pos = MixedFilamentManager::safe_mod(layer_index, int(tokens.size()));
                     const unsigned int resolved = physical_filament_from_token(tokens[size_t(pos)], mf, num_physical);
                     if (resolved >= 1 && resolved <= num_physical)
                         return resolved;

--- a/src/libslic3r/MixedFilament.hpp
+++ b/src/libslic3r/MixedFilament.hpp
@@ -316,6 +316,13 @@ public:
                                       float component_b_surface_offset,
                                       float reference_width_mm = 0.4f);
 
+    // Exposed for unit testing — pure logic helpers.
+    static int         safe_mod(int x, int m);
+    static void        normalize_ratio_pair(int &a, int &b);
+    static float       canonical_signed_bias_value(float component_a_surface_offset, float component_b_surface_offset);
+    static std::string format_surface_offset_token(float value);
+    static double      mixed_filament_reference_nozzle_mm(unsigned int component_a, unsigned int component_b, const std::vector<double> &nozzle_diameters);
+
     // ---- Accessors ------------------------------------------------------
 
     const std::vector<MixedFilament> &mixed_filaments() const { return m_mixed; }

--- a/src/libslic3r/PresetBundle.hpp
+++ b/src/libslic3r/PresetBundle.hpp
@@ -319,11 +319,15 @@ public:
         for (size_t i = 0; i <= total_filaments; ++i) {
             if (i == from_id + 1) {
                 // Source physical filament maps to target mixed filament
-                // The target's new virtual ID after deletion: new_num_physical + target_mixed_idx
+                // The target's new virtual ID after deletion: new_num_physical + adjusted_mixed_idx
                 size_t target_old_virtual_id = to_id;  // 0-based
                 size_t target_old_mixed_idx = target_old_virtual_id - num_physical;
                 size_t new_num_physical = num_physical - 1;
-                size_t target_new_virtual_id = new_num_physical + target_old_mixed_idx;
+                // Subtract deleted mixed filaments that appear before the target
+                size_t deleted_before_target = 0;
+                for (size_t vid : deleted_mixed_indices)
+                    if (vid < target_old_virtual_id) ++deleted_before_target;
+                size_t target_new_virtual_id = new_num_physical + target_old_mixed_idx - deleted_before_target;
                 m_last_filament_id_remap[i] = (unsigned int)(target_new_virtual_id + 1);  // Convert to 1-based
             } else if (i > from_id + 1 && i <= num_physical) {
                 // Subsequent physical filaments shift down by 1
@@ -338,9 +342,13 @@ public:
                     // This mixed filament will be deleted, map to 0 (invalid)
                     m_last_filament_id_remap[i] = 0;
                 } else {
-                    // This mixed filament will be kept, calculate its new virtual ID
+                    // This mixed filament will be kept, calculate its new virtual ID.
+                    // Subtract deleted mixed filaments that appear before this one.
                     size_t new_num_physical = num_physical - 1;
-                    size_t new_virtual_id = new_num_physical + old_mixed_idx;
+                    size_t deleted_before = 0;
+                    for (size_t vid : deleted_mixed_indices)
+                        if (vid < old_virtual_id) ++deleted_before;
+                    size_t new_virtual_id = new_num_physical + old_mixed_idx - deleted_before;
                     m_last_filament_id_remap[i] = (unsigned int)(new_virtual_id + 1);  // Convert to 1-based
                 }
             } else {

--- a/src/libslic3r/libslic3r.h
+++ b/src/libslic3r/libslic3r.h
@@ -65,7 +65,7 @@ static constexpr double LARGE_BED_THRESHOLD = 2147;
 static constexpr size_t MAXIMUM_EXTRUDER_NUMBER = 64;
 
 // Combined upper limit for physical + mixed filaments.
-static constexpr size_t MAXIMUM_FILAMENT_NUMBER = 32;
+static constexpr size_t MAXIMUM_FILAMENT_NUMBER = 64;
 
 // Orca: maximum line width is 5 times the nozzle diameter
 static constexpr float MAX_LINE_WIDTH_MULTIPLIER = 5;

--- a/src/slic3r/GUI/MixedFilamentBadge.cpp
+++ b/src/slic3r/GUI/MixedFilamentBadge.cpp
@@ -34,20 +34,17 @@ MixedFilamentBadge::MixedFilamentBadge(wxWindow* parent, wxWindowID id, int virt
                                        const MixedFilament& mf,
                                        const MixedFilamentDisplayContext& display_context,
                                        bool show_number, int badge_size)
-    : wxButton(parent, id, wxString::Format("%d", virtual_id),
-               wxDefaultPosition, wxSize(badge_size, badge_size),
-               wxBU_EXACTFIT | wxBORDER_NONE)
+    : wxPanel(parent, id, wxDefaultPosition, wxSize(badge_size, badge_size), wxBORDER_NONE)
     , m_show_number(show_number)
+    , m_label(wxString::Format("%d", virtual_id))
 {
     SetBackgroundStyle(wxBG_STYLE_PAINT);
     SetSize(parent->FromDIP(wxSize(badge_size, badge_size)));
     SetMinSize(parent->FromDIP(wxSize(badge_size, badge_size)));
     SetMaxSize(parent->FromDIP(wxSize(badge_size, badge_size)));
     Bind(wxEVT_PAINT, &MixedFilamentBadge::on_paint, this);
-    // Prevent wxButton from entering pressed/focused state that overrides custom paint
-    Bind(wxEVT_SET_FOCUS, [](wxFocusEvent&) {});
-    Bind(wxEVT_KILL_FOCUS, [](wxFocusEvent&) {});
-    SetCanFocus(false);
+    Bind(wxEVT_LEFT_UP, &MixedFilamentBadge::on_left_up, this);
+    SetCursor(wxCursor(wxCURSOR_ARROW));
 
     SetFont(badge_size >= 20 ? Label::Body_12 : Label::Body_8);
 
@@ -123,7 +120,7 @@ void MixedFilamentBadge::on_paint(wxPaintEvent&)
 
     // Draw text — compute color using same luminance rule as constructor
     if (m_show_number) {
-        wxString label = GetLabel();
+        wxString label = m_label;
         wxFont font = GetFont();
         dc.SetFont(font);
 
@@ -137,11 +134,15 @@ void MixedFilamentBadge::on_paint(wxPaintEvent&)
         }
         dc.SetTextForeground(text_lum < 0.51 ? *wxWHITE : *wxBLACK);
 
-        wxSize text_size = dc.GetTextExtent(label);
-        int x = (rect.GetWidth() - text_size.GetWidth()) / 2;
-        int y = (rect.GetHeight() - text_size.GetHeight()) / 2;
-        dc.DrawText(label, rect.GetLeft() + x, rect.GetTop() + y);
+        dc.DrawLabel(label, rect, wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL);
     }
+}
+
+void MixedFilamentBadge::on_left_up(wxMouseEvent&)
+{
+    wxCommandEvent evt(wxEVT_BUTTON, GetId());
+    evt.SetEventObject(this);
+    ProcessWindowEvent(evt);
 }
 
 // ---------------------------------------------------------------------------
@@ -226,8 +227,7 @@ wxBitmap* get_color_block_bitmap_cached(const ColorBlockParams& params)
         dc.DrawRectangle(0, 0, params.width, params.height);
     }
 
-    wxSize txt_sz = dc.GetTextExtent(params.label);
-    dc.DrawText(params.label, (params.width - txt_sz.x) / 2, (params.height - txt_sz.y) / 2);
+    dc.DrawLabel(params.label, wxRect(0, 0, params.width, params.height), wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL);
     dc.SelectObject(wxNullBitmap);
 
     return cache.insert(key, bmp);

--- a/src/slic3r/GUI/MixedFilamentBadge.hpp
+++ b/src/slic3r/GUI/MixedFilamentBadge.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <wx/button.h>
+#include <wx/panel.h>
 #include <wx/dcclient.h>
 #include <wx/bitmap.h>
 
@@ -33,7 +33,7 @@ wxColour interpolate_color(const std::vector<wxColour>& colors, double pos);
 // Key format:  "solid:#RRGGBB:hH:wW:label"  or  "grad:#RRGGBB:#RRGGBBBT:hH:wW:label"
 wxBitmap* get_color_block_bitmap_cached(const ColorBlockParams& params);
 
-class MixedFilamentBadge : public wxButton
+class MixedFilamentBadge : public wxPanel
 {
 public:
     MixedFilamentBadge(wxWindow* parent, wxWindowID id, int virtual_id,
@@ -45,9 +45,11 @@ private:
     wxColour m_solid_color;
     bool m_is_gradient = false;
     bool m_show_number = true;
+    wxString m_label;
     std::vector<wxColour> m_gradient_colors;
 
     void on_paint(wxPaintEvent&);
+    void on_left_up(wxMouseEvent&);
 };
 
 // Create a menu/dropdown bitmap for a mixed filament.

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -42,9 +42,9 @@ public:
         : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize)
         , m_value(value), m_min(minVal), m_max(maxVal)
     {
-        SetInitialSize(wxSize(FromDIP(100), FromDIP(22)));
+        SetInitialSize(wxSize(FromDIP(110), FromDIP(22)));
         SetBackgroundStyle(wxBG_STYLE_PAINT);
-        SetBackgroundColour(wxColour("#FFFFFF"));
+        SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         Bind(wxEVT_PAINT, &MatchRangeSlider::on_paint, this);
         Bind(wxEVT_LEFT_DOWN, &MatchRangeSlider::on_left_down, this);
         Bind(wxEVT_LEFT_UP, &MatchRangeSlider::on_left_up, this);
@@ -76,7 +76,7 @@ private:
         wxAutoBufferedPaintDC dc(this);
         wxSize sz = GetClientSize();
         // Erase entire background to prevent ghosting
-        dc.SetBrush(wxBrush(wxColour("#FFFFFF")));
+        dc.SetBrush(wxBrush(StateColor::darkModeColorFor(wxColour("#FFFFFF"))));
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.DrawRectangle(0, 0, sz.x, sz.y);
 
@@ -86,21 +86,21 @@ private:
         int track_x = FromDIP(5);
         int track_w = std::max(4, sz.x - thumb_d);
 
-        dc.SetBrush(wxBrush(wxColour("#EBEBEB")));
-        dc.DrawRoundedRectangle(track_x, track_y, track_w, track_h, FromDIP(8));
+        dc.SetBrush(wxBrush(StateColor::darkModeColorFor(wxColour("#EBEBEB"))));
+        dc.DrawRoundedRectangle(track_x, track_y, track_w, track_h, FromDIP(2));
 
         float frac = (float)(m_value - m_min) / (float)std::max(1, m_max - m_min);
         int active_w = std::max(0, (int)(track_w * frac));
         if (active_w > 0) {
-            dc.SetBrush(wxBrush(wxColour("#009688")));
-            dc.DrawRoundedRectangle(track_x, track_y, active_w, track_h, FromDIP(8));
+            dc.SetBrush(wxBrush(StateColor::darkModeColorFor(wxColour("#009688"))));
+            dc.DrawRoundedRectangle(track_x, track_y, active_w, track_h, FromDIP(2));
         }
 
         int thumb_x = track_x + active_w - thumb_d / 2;
         thumb_x = std::clamp(thumb_x, track_x - thumb_d/2, track_x + track_w - thumb_d/2);
         int thumb_y = (sz.y - thumb_d) / 2;
-        dc.SetBrush(wxBrush(wxColour("#FFFFFF")));
-        dc.SetPen(wxPen(wxColour("#009688"), FromDIP(1)));
+        dc.SetBrush(wxBrush(StateColor::darkModeColorFor(wxColour("#FFFFFF"))));
+        dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour("#009688")), FromDIP(1)));
         dc.DrawEllipse(thumb_x, thumb_y, thumb_d, thumb_d);
     }
 
@@ -243,18 +243,17 @@ int MixedFilamentDialog::max_filaments_for_mode(int mode) const
 void MixedFilamentDialog::build_ui()
 {
     m_mode_btn_selected = m_current_mode;
-    SetBackgroundColour(wxColour("#F8F7F7"));
+    SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#F8F7F7")));
 
     auto* top_sizer = new wxBoxSizer(wxVERTICAL);
     const int M = FromDIP(8);
-    const int H_GAP = FromDIP(20);
     const int V_GAP = FromDIP(16);
 
     // ---- Segmented mode buttons (Figma: white 380×60 panel, inner #F8F7F7 segment bg, tabs 80×28, 4px gap) ----
     {
         // Outer white panel (#FFFFFF bg, bottom border #F0F0F0, px=20 py=12)
         auto* mode_outer = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
-        mode_outer->SetBackgroundColour(wxColour("#FFFFFF"));
+        mode_outer->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         auto* mode_outer_sizer = new wxBoxSizer(wxVERTICAL);
 
         // Inner segment container (#F8F7F7 bg, 36px height, 4px radius)
@@ -271,7 +270,7 @@ void MixedFilamentDialog::build_ui()
         auto seg_bg  = StateColor();
         auto seg_fg  = StateColor(std::pair(wxColour("#4A4A4A"), (int)StateColor::Normal));
         auto sel_bg  = StateColor(std::pair(wxColour("#009688"), (int)StateColor::Normal));
-        auto sel_fg  = StateColor(std::pair(wxColour("#FFFFFF"), (int)StateColor::Normal));
+        auto sel_fg  = StateColor(std::pair(wxColour("#FEFEFE"), (int)StateColor::Normal));
 
         for (int i = 0; i < 4; ++i) {
             auto* btn = new Button(m_mode_btn_container, mode_names[i]);
@@ -311,7 +310,7 @@ void MixedFilamentDialog::build_ui()
 
         // Bottom divider (Figma: #F0F0F0, 1px)
         auto* mode_divider = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxSize(-1, 1));
-        mode_divider->SetBackgroundColour(wxColour("#F0F0F0"));
+        mode_divider->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#F0F0F0")));
 
         top_sizer->Add(mode_outer, 0, wxEXPAND);
         top_sizer->Add(mode_divider, 0, wxEXPAND);
@@ -323,7 +322,7 @@ void MixedFilamentDialog::build_ui()
     {
         m_error_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition,
                                      wxDefaultSize, wxBORDER_NONE | wxTAB_TRAVERSAL);
-        m_error_panel->SetBackgroundColour(wxColour("#FDE8E8"));
+        m_error_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FDE8E8")));
         m_error_panel->Hide();
         auto* err_sizer = new wxBoxSizer(wxHORIZONTAL);
         ScalableBitmap error_bmp(m_error_panel, "error_icon_red_exclamation", 14);
@@ -331,7 +330,7 @@ void MixedFilamentDialog::build_ui()
         err_sizer->Add(error_icon, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(12));
         err_sizer->AddSpacer(FromDIP(4));
         m_error_text = new wxStaticText(m_error_panel, wxID_ANY, wxEmptyString);
-        m_error_text->SetForegroundColour(wxColour("#D32F2F"));
+        m_error_text->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#D32F2F")));
         m_error_text->Wrap(FromDIP(360));
         err_sizer->Add(m_error_text, 1, wxALL, FromDIP(8));
         m_error_panel->SetSizer(err_sizer);
@@ -342,7 +341,7 @@ void MixedFilamentDialog::build_ui()
     {
         m_warning_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition,
                                        wxDefaultSize, wxBORDER_NONE | wxTAB_TRAVERSAL);
-        m_warning_panel->SetBackgroundColour(wxColour("#FFF3EB"));
+        m_warning_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFF3EB")));
         m_warning_panel->Hide();
         auto* warn_sizer = new wxBoxSizer(wxHORIZONTAL);
         ScalableBitmap warn_bmp(m_warning_panel, "icon_warning_triangle", 14);
@@ -350,7 +349,7 @@ void MixedFilamentDialog::build_ui()
         warn_sizer->Add(warn_icon, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(12));
         warn_sizer->AddSpacer(FromDIP(4));
         m_warning_text = new wxStaticText(m_warning_panel, wxID_ANY, wxEmptyString);
-        m_warning_text->SetForegroundColour(wxColour("#FF842D"));
+        m_warning_text->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#FF842D")));
         m_warning_text->Wrap(FromDIP(360));
         warn_sizer->Add(m_warning_text, 1, wxALL, FromDIP(8));
         m_warning_panel->SetSizer(warn_sizer);
@@ -360,7 +359,7 @@ void MixedFilamentDialog::build_ui()
     m_scrolled_content = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition,
                                                wxSize(FromDIP(380), FromDIP(400)),
                                                wxVSCROLL | wxBORDER_NONE);
-    m_scrolled_content->SetBackgroundColour(wxColour("#F8F7F7"));
+    m_scrolled_content->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#F8F7F7")));
     m_scrolled_content->SetScrollRate(0, FromDIP(8));
     // Prevent wxScrolledWindow from auto-scrolling to focused children.
     // Without this, clicking a partially-visible widget first scrolls it
@@ -369,6 +368,7 @@ void MixedFilamentDialog::build_ui()
         // Do not evt.Skip() — that would invoke the default handler which scrolls.
     });
     auto* scroll_sizer = new wxBoxSizer(wxVERTICAL);
+    scroll_sizer->AddSpacer(FromDIP(16));
 
     // ======== Card 1: Match Input (match mode: filament badges + target color) ========
     {
@@ -376,6 +376,7 @@ void MixedFilamentDialog::build_ui()
                                            wxDefaultSize, wxBORDER_NONE);
         m_match_input_card->SetCornerRadius(FromDIP(4));
         m_match_input_card->SetMinSize(wxSize(FromDIP(325), -1));
+        m_match_input_card->SetMaxSize(wxSize(FromDIP(325), -1));
         m_match_input_card->SetBackgroundColor(
             StateColor(std::pair(wxColour("#FFFFFF"), (int)StateColor::Normal)));
         m_match_input_card->SetBorderWidth(FromDIP(1));
@@ -383,14 +384,15 @@ void MixedFilamentDialog::build_ui()
         auto* card1_sizer = new wxBoxSizer(wxVERTICAL);
 
         auto* filament_label = new wxStaticText(m_match_input_card, wxID_ANY, _L("Filaments:"));
-        filament_label->SetFont(Label::Head_14);
-        filament_label->SetBackgroundColour(wxColour("#FFFFFF"));
+        filament_label->SetFont(Label::Body_14);
+        filament_label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        filament_label->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         card1_sizer->Add(filament_label, 0, wxLEFT | wxRIGHT | wxTOP, FromDIP(16));
         card1_sizer->AddSpacer(FromDIP(12));
 
         m_match_badges_panel = new wxPanel(m_match_input_card, wxID_ANY, wxDefaultPosition,
                                            wxDefaultSize, wxBORDER_NONE);
-        m_match_badges_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+        m_match_badges_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_match_badges_sizer = new wxWrapSizer(wxHORIZONTAL);
         MixedFilamentDisplayContext ctx;
         ctx.num_physical = m_filament_colours.size();
@@ -402,16 +404,16 @@ void MixedFilamentDialog::build_ui()
             auto* badge = new MixedFilamentBadge(m_match_badges_panel, wxID_ANY, fid + 1,
                                                   mf, ctx, true, 20);
             badge->SetCanFocus(false);
-            m_match_badges_sizer->Add(badge, 0, wxRIGHT | wxBOTTOM, FromDIP(8));
+            m_match_badges_sizer->Add(badge, 0, wxRIGHT | wxBOTTOM, FromDIP(12));
         }
         m_match_badges_panel->SetSizer(m_match_badges_sizer);
         card1_sizer->Add(m_match_badges_panel, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(16));
-        card1_sizer->AddSpacer(FromDIP(12));
 
         // Target Color label
         auto* target_label = new wxStaticText(m_match_input_card, wxID_ANY, _L("Target Color:"));
-        target_label->SetFont(Label::Head_14);
-        target_label->SetBackgroundColour(wxColour("#FFFFFF"));
+        target_label->SetFont(Label::Body_14);
+        target_label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        target_label->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         card1_sizer->Add(target_label, 0, wxLEFT | wxRIGHT, FromDIP(16));
         card1_sizer->AddSpacer(FromDIP(12));
 
@@ -450,7 +452,7 @@ void MixedFilamentDialog::build_ui()
         auto* hex_wrapper = new wxPanel(m_match_input_card, wxID_ANY, wxDefaultPosition,
                                          wxSize(FromDIP(109), FromDIP(24)));
         m_match_hex_wrapper = hex_wrapper;
-        hex_wrapper->SetBackgroundColour(wxColour("#FFFFFF"));
+        hex_wrapper->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         hex_wrapper->SetMinSize(wxSize(FromDIP(109), FromDIP(24)));
         hex_wrapper->SetBackgroundStyle(wxBG_STYLE_PAINT);
         hex_wrapper->Bind(wxEVT_PAINT, [this](wxPaintEvent& evt) {
@@ -458,26 +460,26 @@ void MixedFilamentDialog::build_ui()
             if (!w) return;
             wxPaintDC dc(w);
             wxSize sz = w->GetClientSize();
-            dc.SetBrush(wxBrush(wxColour("#FFFFFF")));
+            dc.SetBrush(wxBrush(StateColor::darkModeColorFor(wxColour("#FFFFFF"))));
             dc.SetPen(*wxTRANSPARENT_PEN);
             dc.DrawRectangle(0, 0, sz.x, sz.y);
             dc.SetBrush(*wxTRANSPARENT_BRUSH);
-            dc.SetPen(wxPen(m_match_hex_error ? wxColour("#FF0000") : wxColour("#009688"), 1));
+            dc.SetPen(wxPen(m_match_hex_error ? StateColor::darkModeColorFor(wxColour("#FF0000")) : StateColor::darkModeColorFor(wxColour("#009688")), 1));
             dc.DrawRectangle(0, 0, sz.x, sz.y);
         });
         auto* hex_sizer = new wxBoxSizer(wxHORIZONTAL);
 
         auto* hex_label = new wxStaticText(hex_wrapper, wxID_ANY, "Hex:");
         hex_label->SetFont(Label::Body_12);
-        hex_label->SetForegroundColour(wxColour("#8F8F8F"));
-        hex_label->SetBackgroundColour(wxColour("#FFFFFF"));
+        hex_label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#8F8F8F")));
+        hex_label->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         hex_sizer->Add(hex_label, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(9));
         hex_sizer->AddSpacer(FromDIP(4));
 
         auto* hash_label = new wxStaticText(hex_wrapper, wxID_ANY, "#");
         hash_label->SetFont(Label::Body_12);
-        hash_label->SetForegroundColour(wxColour("#8F8F8F"));
-        hash_label->SetBackgroundColour(wxColour("#FFFFFF"));
+        hash_label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#8F8F8F")));
+        hash_label->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         hex_sizer->Add(hash_label, 0, wxALIGN_CENTER_VERTICAL);
         hex_sizer->AddSpacer(FromDIP(2));
 
@@ -486,8 +488,8 @@ void MixedFilamentDialog::build_ui()
                                            wxDefaultPosition, wxSize(FromDIP(52), -1),
                                            wxTE_PROCESS_ENTER | wxBORDER_NONE);
         m_match_hex_input->SetFont(Label::Body_12);
-        m_match_hex_input->SetForegroundColour(wxColour("#242424"));
-        m_match_hex_input->SetBackgroundColour(wxColour("#FFFFFF"));
+        m_match_hex_input->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        m_match_hex_input->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_match_hex_input->SetMaxLength(6);
         // Prevent wxEVT_TEXT_ENTER from propagating to dialog default button
         m_match_hex_input->Bind(wxEVT_TEXT_ENTER, [this](wxCommandEvent&) {
@@ -524,9 +526,8 @@ void MixedFilamentDialog::build_ui()
         card1_sizer->Add(target_row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
 
         m_match_input_card->SetSizer(card1_sizer);
-        scroll_sizer->Add(m_match_input_card, 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
+        scroll_sizer->Add(m_match_input_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     }
-
     // ======== Card A: Filament Selection ========
     {
         m_filament_card = new StaticBox(m_scrolled_content, wxID_ANY, wxDefaultPosition,
@@ -543,8 +544,9 @@ void MixedFilamentDialog::build_ui()
         // Title row with add/remove/swap buttons
         auto* card_title_row = new wxBoxSizer(wxHORIZONTAL);
         m_filament_card_title = new wxStaticText(m_filament_card, wxID_ANY, _L("Filament Selection"));
-        m_filament_card_title->SetFont(Label::Head_14);
-        m_filament_card_title->SetBackgroundColour(wxColour("#FFFFFF"));
+        m_filament_card_title->SetFont(Label::Body_14);
+        m_filament_card_title->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        m_filament_card_title->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         card_title_row->Add(m_filament_card_title, 0, wxALIGN_CENTER_VERTICAL);
 
         card_title_row->AddStretchSpacer();
@@ -563,7 +565,7 @@ void MixedFilamentDialog::build_ui()
             update_preview();
             update_compatibility_warning();
         });
-        card_title_row->Add(m_btn_swap_gradient_dir, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+        card_title_row->Add(m_btn_swap_gradient_dir, 0, wxALIGN_CENTER_VERTICAL);
 
         // Remove filament button
         m_btn_remove_filament = new ScalableButton(m_filament_card, wxID_ANY, "icon_minus");
@@ -602,14 +604,14 @@ void MixedFilamentDialog::build_ui()
 
         // Filament rows panel
         m_filament_rows_panel = new wxPanel(m_filament_card);
-        m_filament_rows_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+        m_filament_rows_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_filament_rows_sizer = new wxBoxSizer(wxVERTICAL);
         m_filament_rows_panel->SetSizer(m_filament_rows_sizer);
         m_filament_card_sizer->Add(m_filament_rows_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
 
         m_filament_card->SetSizer(m_filament_card_sizer);
         m_filament_card->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent& evt) { this->SetFocus(); evt.Skip(); });
-        scroll_sizer->Add(m_filament_card, 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT | wxBOTTOM, H_GAP);
+        scroll_sizer->Add(m_filament_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     }
 
     // ======== Card B: Mix Ratio (Ratio mode) ========
@@ -618,6 +620,7 @@ void MixedFilamentDialog::build_ui()
                                       wxDefaultSize, wxBORDER_NONE);
         m_ratio_card->SetCornerRadius(FromDIP(4));
         m_ratio_card->SetMinSize(wxSize(FromDIP(325), -1));
+        m_ratio_card->SetMaxSize(wxSize(FromDIP(325), -1));
         m_ratio_card->SetBackgroundColor(
             StateColor(std::pair(wxColour("#FFFFFF"), (int)StateColor::Normal)));
         m_ratio_card->SetBorderWidth(FromDIP(1));
@@ -626,9 +629,10 @@ void MixedFilamentDialog::build_ui()
 
         // Title
         auto* ratio_title = new wxStaticText(m_ratio_card, wxID_ANY, _L("Mix Ratio"));
-        ratio_title->SetFont(Label::Head_14);
-        ratio_title->SetBackgroundColour(wxColour("#FFFFFF"));
-        m_ratio_card_sizer->Add(ratio_title, 0, wxALL, FromDIP(16));
+        ratio_title->SetFont(Label::Body_14);
+        ratio_title->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        ratio_title->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        m_ratio_card_sizer->Add(ratio_title, 0, wxTOP | wxLEFT | wxRIGHT, FromDIP(16));
 
         // Compute initial values
         int initial_val = m_result.mix_b_percent;
@@ -640,17 +644,19 @@ void MixedFilamentDialog::build_ui()
             : col_a;
 
         // ---- Gradient bar (2-color) ----
+        m_ratio_gradient_spacer = m_ratio_card_sizer->AddSpacer(FromDIP(16));
         m_gradient_selector = new MixedGradientSelector(m_ratio_card, col_a, col_b, initial_val);
         m_ratio_card_sizer->Add(m_gradient_selector, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(16));
 
         // ---- Tri picker (3-color) ----
+        m_ratio_tri_spacer = m_ratio_card_sizer->AddSpacer(FromDIP(12));
         build_tri_picker(m_ratio_card);
-        m_ratio_card_sizer->Add(m_tri_picker, 0, wxALIGN_LEFT | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
+        m_ratio_card_sizer->Add(m_tri_picker, 0, wxALIGN_LEFT | wxLEFT | wxRIGHT, FromDIP(16));
 
         // ---- Legend panel (dynamic swatches + percentage labels) ----
         m_ratio_card_sizer->AddSpacer(FromDIP(6));
         m_legend_panel = new wxPanel(m_ratio_card, wxID_ANY, wxDefaultPosition, wxDefaultSize);
-        m_legend_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+        m_legend_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_legend_sizer = new wxBoxSizer(wxHORIZONTAL);
         m_legend_panel->SetSizer(m_legend_sizer);
         m_ratio_card_sizer->Add(m_legend_panel, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(16));
@@ -659,7 +665,7 @@ void MixedFilamentDialog::build_ui()
         {
             m_ratio_card_sizer->AddSpacer(FromDIP(6));
             auto* divider = new wxPanel(m_ratio_card, wxID_ANY, wxDefaultPosition, wxSize(-1, 1));
-            divider->SetBackgroundColour(wxColour("#F3F4F6"));
+            divider->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#F3F4F6")));
             m_ratio_card_sizer->Add(divider, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(16));
             m_ratio_card_sizer->AddSpacer(FromDIP(6));
         }
@@ -667,7 +673,7 @@ void MixedFilamentDialog::build_ui()
         // ---- Strip preview panel ----
         m_strip_panel = new wxPanel(m_ratio_card, wxID_ANY, wxDefaultPosition, wxDefaultSize);
         m_strip_panel->SetMinSize(wxSize(FromDIP(140), FromDIP(128)));
-        m_strip_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+        m_strip_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_strip_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
         m_strip_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
             wxAutoBufferedPaintDC dc(m_strip_panel);
@@ -682,8 +688,8 @@ void MixedFilamentDialog::build_ui()
             auto* left_col = new wxBoxSizer(wxVERTICAL);
             auto* preview_lbl = new wxStaticText(m_ratio_card, wxID_ANY, _L("Preview"));
             preview_lbl->SetFont(Label::Body_12);
-            preview_lbl->SetForegroundColour(wxColour("#8F8F8F"));
-            preview_lbl->SetBackgroundColour(wxColour("#FFFFFF"));
+            preview_lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#8F8F8F")));
+            preview_lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             left_col->Add(preview_lbl, 0, wxALIGN_LEFT | wxBOTTOM, FromDIP(4));
             left_col->Add(m_strip_panel, 1, wxEXPAND);
             dual_preview_row->Add(left_col, 1, wxEXPAND | wxRIGHT, FromDIP(8));
@@ -692,12 +698,12 @@ void MixedFilamentDialog::build_ui()
             auto* right_col = new wxBoxSizer(wxVERTICAL);
             auto* blend_lbl = new wxStaticText(m_ratio_card, wxID_ANY, _L("Blended Color"));
             blend_lbl->SetFont(Label::Body_12);
-            blend_lbl->SetForegroundColour(wxColour("#8F8F8F"));
-            blend_lbl->SetBackgroundColour(wxColour("#FFFFFF"));
+            blend_lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#8F8F8F")));
+            blend_lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             right_col->Add(blend_lbl, 0, wxALIGN_LEFT | wxBOTTOM, FromDIP(4));
             m_preview_blend_panel = new wxPanel(m_ratio_card, wxID_ANY, wxDefaultPosition, wxDefaultSize);
             m_preview_blend_panel->SetMinSize(wxSize(FromDIP(140), FromDIP(128)));
-            m_preview_blend_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+            m_preview_blend_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             m_preview_blend_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
             m_preview_blend_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
                 wxAutoBufferedPaintDC dc(m_preview_blend_panel);
@@ -705,7 +711,7 @@ void MixedFilamentDialog::build_ui()
                 dc.Clear();
                 wxSize sz = m_preview_blend_panel->GetClientSize();
                 dc.SetBrush(*wxTRANSPARENT_BRUSH);
-                dc.SetPen(wxPen(wxColour(180, 180, 180), 1));
+                dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour(180, 180, 180)), 1));
                 dc.DrawRectangle(0, 0, sz.x, sz.y);
             });
             right_col->Add(m_preview_blend_panel, 1, wxEXPAND);
@@ -716,7 +722,7 @@ void MixedFilamentDialog::build_ui()
 
         m_ratio_card->SetSizer(m_ratio_card_sizer);
         m_ratio_card->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent& evt) { this->SetFocus(); evt.Skip(); });
-        scroll_sizer->Add(m_ratio_card, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, H_GAP);
+        scroll_sizer->Add(m_ratio_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     }
 
     // ======== Match Mix Ratio Card (match mode's own card) ========
@@ -725,6 +731,7 @@ void MixedFilamentDialog::build_ui()
                                            wxDefaultSize, wxBORDER_NONE);
         m_match_ratio_card->SetCornerRadius(FromDIP(4));
         m_match_ratio_card->SetMinSize(wxSize(FromDIP(325), -1));
+        m_match_ratio_card->SetMaxSize(wxSize(FromDIP(325), -1));
         m_match_ratio_card->SetBackgroundColor(
             StateColor(std::pair(wxColour("#FFFFFF"), (int)StateColor::Normal)));
         m_match_ratio_card->SetBorderWidth(FromDIP(1));
@@ -733,8 +740,9 @@ void MixedFilamentDialog::build_ui()
 
         // Title: 混合比例 (Figma: 14px Medium)
         auto* match_title = new wxStaticText(m_match_ratio_card, wxID_ANY, _L("Mix Ratio"));
-        match_title->SetFont(Label::Head_14);
-        match_title->SetBackgroundColour(wxColour("#FFFFFF"));
+        match_title->SetFont(Label::Body_14);
+        match_title->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        match_title->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_match_ratio_card_sizer->Add(match_title, 0, wxLEFT | wxRIGHT | wxTOP, FromDIP(16));
 
         wxColour def_ca = (!m_filament_colours.empty())
@@ -743,15 +751,17 @@ void MixedFilamentDialog::build_ui()
             ? parse_mixed_color(m_filament_colours[1]) : def_ca;
         m_match_gradient_selector = new MixedGradientSelector(m_match_ratio_card, def_ca, def_cb, 50);
         m_match_gradient_selector->set_min_max(m_match_min_pct, 100 - m_match_min_pct);
+        m_match_gradient_spacer = m_match_ratio_card_sizer->AddSpacer(FromDIP(16));
         m_match_ratio_card_sizer->Add(m_match_gradient_selector, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(16));
 
+        m_match_tri_spacer = m_match_ratio_card_sizer->AddSpacer(FromDIP(12));
         build_match_tri_picker(m_match_ratio_card);
         m_match_ratio_card_sizer->Add(m_match_tri_picker, 0, wxALIGN_LEFT | wxLEFT | wxRIGHT, FromDIP(16));
 
         // Legend panel (gap-[6px] below tri-picker per Figma)
         m_match_ratio_card_sizer->AddSpacer(FromDIP(6));
         m_match_legend_panel = new wxPanel(m_match_ratio_card, wxID_ANY, wxDefaultPosition, wxDefaultSize);
-        m_match_legend_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+        m_match_legend_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_match_legend_sizer = new wxBoxSizer(wxHORIZONTAL);
         m_match_legend_panel->SetSizer(m_match_legend_sizer);
         m_match_ratio_card_sizer->Add(m_match_legend_panel, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(16));
@@ -759,20 +769,20 @@ void MixedFilamentDialog::build_ui()
         // Range slider row: 最低混色比例
         {
             m_match_range_row = new wxPanel(m_match_ratio_card, wxID_ANY, wxDefaultPosition, wxDefaultSize);
-            m_match_range_row->SetBackgroundColour(wxColour("#FFFFFF"));
+            m_match_range_row->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             auto* range_sizer = new wxBoxSizer(wxHORIZONTAL);
             auto* range_label = new wxStaticText(m_match_range_row, wxID_ANY, _L("Min mix ratio"));
-            range_label->SetFont(Label::Body_12);
-            range_label->SetForegroundColour(wxColour("#8F8F8F"));
-            range_label->SetBackgroundColour(wxColour("#FFFFFF"));
+            range_label->SetFont(Label::Body_14);
+            range_label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+            range_label->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             range_sizer->Add(range_label, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));
             m_match_range_slider = new MatchRangeSlider(m_match_range_row, m_match_min_pct, 0, 50);
             range_sizer->Add(m_match_range_slider, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
             m_match_range_value = new wxStaticText(m_match_range_row, wxID_ANY,
                                                     wxString::Format("%d%%", m_match_min_pct));
             m_match_range_value->SetFont(Label::Body_12);
-            m_match_range_value->SetForegroundColour(wxColour("#8F8F8F"));
-            m_match_range_value->SetBackgroundColour(wxColour("#FFFFFF"));
+            m_match_range_value->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+            m_match_range_value->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             range_sizer->Add(m_match_range_value, 0, wxALIGN_CENTER_VERTICAL);
             range_sizer->AddStretchSpacer();
             m_match_range_slider->Bind(wxEVT_SLIDER, [this](wxCommandEvent&) {
@@ -788,9 +798,9 @@ void MixedFilamentDialog::build_ui()
 
         // Divider
         {
-            m_match_ratio_card_sizer->AddSpacer(FromDIP(6));
+            m_match_ratio_card_sizer->AddSpacer(FromDIP(16));
             auto* divider = new wxPanel(m_match_ratio_card, wxID_ANY, wxDefaultPosition, wxSize(-1, 1));
-            divider->SetBackgroundColour(wxColour("#F3F4F6"));
+            divider->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#F3F4F6")));
             m_match_ratio_card_sizer->Add(divider, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(16));
             m_match_ratio_card_sizer->AddSpacer(FromDIP(6));
         }
@@ -798,7 +808,7 @@ void MixedFilamentDialog::build_ui()
         // Preview section
         m_match_strip_panel = new wxPanel(m_match_ratio_card, wxID_ANY, wxDefaultPosition, wxDefaultSize);
         m_match_strip_panel->SetMinSize(wxSize(FromDIP(140), FromDIP(128)));
-        m_match_strip_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+        m_match_strip_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_match_strip_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
         m_match_strip_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
             wxAutoBufferedPaintDC dc(m_match_strip_panel);
@@ -810,8 +820,8 @@ void MixedFilamentDialog::build_ui()
             auto* left_col = new wxBoxSizer(wxVERTICAL);
             auto* preview_lbl = new wxStaticText(m_match_ratio_card, wxID_ANY, _L("Preview"));
             preview_lbl->SetFont(Label::Body_12);
-            preview_lbl->SetForegroundColour(wxColour("#8F8F8F"));
-            preview_lbl->SetBackgroundColour(wxColour("#FFFFFF"));
+            preview_lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#8F8F8F")));
+            preview_lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             left_col->Add(preview_lbl, 0, wxALIGN_LEFT | wxBOTTOM, FromDIP(4));
             left_col->Add(m_match_strip_panel, 0, wxEXPAND);
             dual_preview_row->Add(left_col, 0, wxEXPAND | wxRIGHT, FromDIP(8));
@@ -819,12 +829,12 @@ void MixedFilamentDialog::build_ui()
             auto* right_col = new wxBoxSizer(wxVERTICAL);
             auto* blend_lbl = new wxStaticText(m_match_ratio_card, wxID_ANY, _L("Blended Color"));
             blend_lbl->SetFont(Label::Body_12);
-            blend_lbl->SetForegroundColour(wxColour("#8F8F8F"));
-            blend_lbl->SetBackgroundColour(wxColour("#FFFFFF"));
+            blend_lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#8F8F8F")));
+            blend_lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             right_col->Add(blend_lbl, 0, wxALIGN_LEFT | wxBOTTOM, FromDIP(4));
             m_match_blend_panel = new wxPanel(m_match_ratio_card, wxID_ANY, wxDefaultPosition, wxDefaultSize);
             m_match_blend_panel->SetMinSize(wxSize(FromDIP(140), FromDIP(128)));
-            m_match_blend_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+            m_match_blend_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             m_match_blend_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
             m_match_blend_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
                 wxAutoBufferedPaintDC dc(m_match_blend_panel);
@@ -832,7 +842,7 @@ void MixedFilamentDialog::build_ui()
                 dc.Clear();
                 wxSize sz = m_match_blend_panel->GetClientSize();
                 dc.SetBrush(*wxTRANSPARENT_BRUSH);
-                dc.SetPen(wxPen(wxColour(180, 180, 180), 1));
+                dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour(180, 180, 180)), 1));
                 dc.DrawRectangle(0, 0, sz.x, sz.y);
             });
             right_col->Add(m_match_blend_panel, 0, wxEXPAND);
@@ -853,7 +863,7 @@ void MixedFilamentDialog::build_ui()
         });
 
         m_match_ratio_card->SetSizer(m_match_ratio_card_sizer);
-        scroll_sizer->Add(m_match_ratio_card, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, H_GAP);
+        scroll_sizer->Add(m_match_ratio_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     }
 
     // ======== Gradient Effect Card: 混色效果 (shown in gradient mode) ========
@@ -862,24 +872,27 @@ void MixedFilamentDialog::build_ui()
                                                 wxDefaultSize, wxBORDER_NONE);
         m_gradient_effect_card->SetCornerRadius(FromDIP(4));
         m_gradient_effect_card->SetMinSize(wxSize(FromDIP(325), -1));
+        m_gradient_effect_card->SetMaxSize(wxSize(FromDIP(325), -1));
         m_gradient_effect_card->SetBackgroundColor(
             StateColor(std::pair(wxColour("#FFFFFF"), (int)StateColor::Normal)));
         m_gradient_effect_card->SetBorderWidth(FromDIP(1));
         m_gradient_effect_card->SetBorderColorNormal(wxColour("#F0F0F0"));
         m_gradient_effect_card_sizer = new wxBoxSizer(wxVERTICAL);
 
-        // Title: 混色效果 (Figma: 14px Medium, left-aligned, 16px top/left/right padding)
+        // Mix Effect title (same font as Blended Color)
         auto* effect_title = new wxStaticText(m_gradient_effect_card, wxID_ANY, _L("Mix Effect"));
-        effect_title->SetFont(Label::Head_14);
-        effect_title->SetBackgroundColour(wxColour("#FFFFFF"));
+        effect_title->SetFont(Label::Body_12);
+        effect_title->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        effect_title->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_gradient_effect_card_sizer->Add(effect_title, 0, wxTOP | wxLEFT | wxRIGHT, FromDIP(16));
+        m_gradient_effect_card_sizer->AddSpacer(FromDIP(8));
 
-        // Gradient preview panel (Figma: 140×140px, left-aligned, 8px below title)
+        // Gradient preview panel
         m_preview_panel = new wxPanel(m_gradient_effect_card, wxID_ANY, wxDefaultPosition,
                                       wxSize(FromDIP(PREVIEW_SIZE), FromDIP(PREVIEW_SIZE)));
         m_preview_panel->SetMinSize(wxSize(FromDIP(PREVIEW_SIZE), FromDIP(PREVIEW_SIZE)));
         m_preview_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
-        m_preview_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+        m_preview_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_preview_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
             wxAutoBufferedPaintDC dc(m_preview_panel);
             if (m_current_mode == MODE_GRADIENT && m_filament_rows.size() >= 2) {
@@ -911,14 +924,14 @@ void MixedFilamentDialog::build_ui()
             }
             wxSize sz = m_preview_panel->GetClientSize();
             dc.SetBrush(*wxTRANSPARENT_BRUSH);
-            dc.SetPen(wxPen(wxColour(180, 180, 180), 1));
+            dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour(180, 180, 180)), 1));
             dc.DrawRectangle(0, 0, sz.x, sz.y);
         });
-        m_gradient_effect_card_sizer->Add(m_preview_panel, 0, wxALIGN_LEFT | wxLEFT | wxBOTTOM, FromDIP(16));
+        m_gradient_effect_card_sizer->Add(m_preview_panel, 0, wxALIGN_LEFT | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
 
         m_gradient_effect_card->SetSizer(m_gradient_effect_card_sizer);
         m_gradient_effect_card->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent& evt) { this->SetFocus(); evt.Skip(); });
-        scroll_sizer->Add(m_gradient_effect_card, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, H_GAP);
+        scroll_sizer->Add(m_gradient_effect_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     }
 
     // ---- Match mode panel ----
@@ -926,7 +939,7 @@ void MixedFilamentDialog::build_ui()
         m_match_panel_sizer = new wxBoxSizer(wxVERTICAL);
         wxColour initial = (m_current_mode == MODE_MATCH && !m_result.display_color.empty())
             ? parse_mixed_color(m_result.display_color)
-            : wxColour("#26A69A");
+            : StateColor::darkModeColorFor(wxColour("#26A69A"));
         m_match_panel = new MixedColorMatchPanel(m_scrolled_content, m_filament_colours, initial);
         m_match_panel_sizer->Add(m_match_panel, 0, wxEXPAND | wxALL, M);
         scroll_sizer->Add(m_match_panel_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
@@ -938,6 +951,7 @@ void MixedFilamentDialog::build_ui()
                                       wxDefaultSize, wxBORDER_NONE);
         m_cycle_card->SetCornerRadius(FromDIP(4));
         m_cycle_card->SetMinSize(wxSize(FromDIP(325), -1));
+        m_cycle_card->SetMaxSize(wxSize(FromDIP(325), -1));
         m_cycle_card->SetBackgroundColor(
             StateColor(std::pair(wxColour("#FFFFFF"), (int)StateColor::Normal)));
         m_cycle_card->SetBorderWidth(FromDIP(1));
@@ -946,8 +960,9 @@ void MixedFilamentDialog::build_ui()
 
         // Title
         auto* cycle_title = new wxStaticText(m_cycle_card, wxID_ANY, _L("Pattern"));
-        cycle_title->SetFont(Label::Head_14);
-        cycle_title->SetBackgroundColour(wxColour("#FFFFFF"));
+        cycle_title->SetFont(Label::Body_14);
+        cycle_title->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        cycle_title->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_cycle_card_sizer->Add(cycle_title, 0, wxALL, FromDIP(16));
 
         // Filament quick buttons (20×20 badges, wrapping)
@@ -977,7 +992,8 @@ void MixedFilamentDialog::build_ui()
                 btn_row->Add(badge, 0, wxRIGHT | wxBOTTOM, FromDIP(8));
                 m_pattern_quick_buttons.push_back(badge);
             }
-            m_cycle_card_sizer->Add(btn_row, 0, wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
+            m_cycle_card_sizer->Add(btn_row, 0, wxLEFT | wxRIGHT, FromDIP(16));
+            m_cycle_card_sizer->AddSpacer(FromDIP(12));
         }
 
         // Pattern input (Figma: 293×30, #F0F0F0 1px border)
@@ -995,12 +1011,14 @@ void MixedFilamentDialog::build_ui()
             auto* wrapper_sizer = new wxBoxSizer(wxHORIZONTAL);
             m_pattern_ctrl = new wxTextCtrl(input_wrapper, wxID_ANY,
                                             from_u8(init_pattern.empty() ? "12" : init_pattern),
-                                            wxDefaultPosition, wxSize(FromDIP(293), FromDIP(30)),
+                                            wxDefaultPosition, wxDefaultSize,
                                             wxTE_PROCESS_ENTER | wxBORDER_NONE);
             m_pattern_ctrl->SetFont(Label::Body_14);
-            m_pattern_ctrl->SetBackgroundColour(wxColour("#FFFFFF"));
+            m_pattern_ctrl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+            m_pattern_ctrl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
             m_pattern_ctrl->SetMargins(FromDIP(8), FromDIP(8));
-            wrapper_sizer->Add(m_pattern_ctrl, 1, wxEXPAND | wxALL, FromDIP(1));
+            input_wrapper->SetMinSize(wxSize(FromDIP(293), FromDIP(30)));
+            wrapper_sizer->Add(m_pattern_ctrl, 1, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, FromDIP(1));
             input_wrapper->SetSizer(wrapper_sizer);
             m_pattern_ctrl->SetToolTip(_L("Allowed Input: Only digits, square brackets ([ and ]), and commas (,)."));
             m_pattern_ctrl->SetMaxLength(512);
@@ -1018,7 +1036,7 @@ void MixedFilamentDialog::build_ui()
         // Divider
         {
             auto* divider = new wxPanel(m_cycle_card, wxID_ANY, wxDefaultPosition, wxSize(-1, 1));
-            divider->SetBackgroundColour(wxColour("#F3F4F6"));
+            divider->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#F3F4F6")));
             m_cycle_card_sizer->Add(divider, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP | wxBOTTOM, M);
         }
 
@@ -1030,13 +1048,13 @@ void MixedFilamentDialog::build_ui()
             auto* left_col = new wxBoxSizer(wxVERTICAL);
             auto* preview_lbl = new wxStaticText(m_cycle_card, wxID_ANY, _L("Preview"));
             preview_lbl->SetFont(Label::Body_12);
-            preview_lbl->SetForegroundColour(wxColour("#8F8F8F"));
-            preview_lbl->SetBackgroundColour(wxColour("#FFFFFF"));
+            preview_lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#8F8F8F")));
+            preview_lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             left_col->Add(preview_lbl, 0, wxALIGN_LEFT | wxBOTTOM, FromDIP(4));
 
             m_cycle_strip_panel = new wxPanel(m_cycle_card, wxID_ANY, wxDefaultPosition, wxDefaultSize);
             m_cycle_strip_panel->SetMinSize(wxSize(FromDIP(140), FromDIP(140)));
-            m_cycle_strip_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+            m_cycle_strip_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             m_cycle_strip_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
             m_cycle_strip_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
                 wxAutoBufferedPaintDC dc(m_cycle_strip_panel);
@@ -1049,13 +1067,13 @@ void MixedFilamentDialog::build_ui()
             auto* right_col = new wxBoxSizer(wxVERTICAL);
             auto* blend_lbl = new wxStaticText(m_cycle_card, wxID_ANY, _L("Blended Color"));
             blend_lbl->SetFont(Label::Body_12);
-            blend_lbl->SetForegroundColour(wxColour("#8F8F8F"));
-            blend_lbl->SetBackgroundColour(wxColour("#FFFFFF"));
+            blend_lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#8F8F8F")));
+            blend_lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             right_col->Add(blend_lbl, 0, wxALIGN_LEFT | wxBOTTOM, FromDIP(4));
 
             m_cycle_blend_panel = new wxPanel(m_cycle_card, wxID_ANY, wxDefaultPosition, wxDefaultSize);
             m_cycle_blend_panel->SetMinSize(wxSize(FromDIP(140), FromDIP(140)));
-            m_cycle_blend_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+            m_cycle_blend_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
             m_cycle_blend_panel->SetBackgroundStyle(wxBG_STYLE_PAINT);
             m_cycle_blend_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
                 wxAutoBufferedPaintDC dc(m_cycle_blend_panel);
@@ -1063,7 +1081,7 @@ void MixedFilamentDialog::build_ui()
                 dc.Clear();
                 wxSize sz = m_cycle_blend_panel->GetClientSize();
                 dc.SetBrush(*wxTRANSPARENT_BRUSH);
-                dc.SetPen(wxPen(wxColour(180, 180, 180), 1));
+                dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour(180, 180, 180)), 1));
                 dc.DrawRectangle(0, 0, sz.x, sz.y);
             });
             right_col->Add(m_cycle_blend_panel, 1, wxEXPAND);
@@ -1074,14 +1092,14 @@ void MixedFilamentDialog::build_ui()
 
         // Legend panel (dynamic swatches + percentage labels)
         m_cycle_legend_panel = new wxPanel(m_cycle_card, wxID_ANY, wxDefaultPosition, wxDefaultSize);
-        m_cycle_legend_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+        m_cycle_legend_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_cycle_legend_sizer = new wxFlexGridSizer(5, FromDIP(12), FromDIP(6));
         m_cycle_legend_panel->SetSizer(m_cycle_legend_sizer);
         m_cycle_card_sizer->Add(m_cycle_legend_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
 
         m_cycle_card->SetSizer(m_cycle_card_sizer);
         m_cycle_card->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent& evt) { this->SetFocus(); evt.Skip(); });
-        scroll_sizer->Add(m_cycle_card, 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
+        scroll_sizer->Add(m_cycle_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     }
 
     // ======== Card C: Recommended Swatches ========
@@ -1090,6 +1108,7 @@ void MixedFilamentDialog::build_ui()
                                        wxDefaultSize, wxBORDER_NONE);
         m_swatch_card->SetCornerRadius(FromDIP(4));
         m_swatch_card->SetMinSize(wxSize(FromDIP(325), -1));
+        m_swatch_card->SetMaxSize(wxSize(FromDIP(325), -1));
         m_swatch_card->SetBackgroundColor(
             StateColor(std::pair(wxColour("#FFFFFF"), (int)StateColor::Normal)));
         m_swatch_card->SetBorderWidth(FromDIP(1));
@@ -1097,19 +1116,20 @@ void MixedFilamentDialog::build_ui()
         m_swatch_card_sizer = new wxBoxSizer(wxVERTICAL);
 
         auto* swatch_title = new wxStaticText(m_swatch_card, wxID_ANY, _L("Recommended"));
-        swatch_title->SetFont(Label::Head_14);
-        swatch_title->SetBackgroundColour(wxColour("#FFFFFF"));
+        swatch_title->SetFont(Label::Body_14);
+        swatch_title->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        swatch_title->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_swatch_card_sizer->Add(swatch_title, 0, wxALL, FromDIP(16));
 
         m_swatch_grid_panel = new wxPanel(m_swatch_card, wxID_ANY, wxDefaultPosition,
                                           wxDefaultSize);
-        m_swatch_grid_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+        m_swatch_grid_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         build_swatch_grid();
         m_swatch_card_sizer->Add(m_swatch_grid_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
 
         m_swatch_card->SetSizer(m_swatch_card_sizer);
         m_swatch_card->Bind(wxEVT_LEFT_DOWN, [this](wxMouseEvent& evt) { this->SetFocus(); evt.Skip(); });
-        scroll_sizer->Add(m_swatch_card, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, H_GAP);
+        scroll_sizer->Add(m_swatch_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     }
 
     m_scrolled_content->SetSizer(scroll_sizer);
@@ -1118,13 +1138,13 @@ void MixedFilamentDialog::build_ui()
     // ---- Bottom button panel: white bg + #F0F0F0 top border, padding 13/12/20 ----
     {
         auto* btn_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
-        btn_panel->SetBackgroundColour(wxColour("#FFFFFF"));
+        btn_panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
 
         auto* panel_sizer = new wxBoxSizer(wxVERTICAL);
 
         // #F0F0F0 top border (1px)
         auto* top_line = new wxPanel(btn_panel, wxID_ANY, wxDefaultPosition, wxSize(-1, 1));
-        top_line->SetBackgroundColour(wxColour("#F0F0F0"));
+        top_line->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#F0F0F0")));
         panel_sizer->Add(top_line, 0, wxEXPAND);
 
         // 13px top padding - 1px line = 12px remaining top padding
@@ -1149,7 +1169,7 @@ void MixedFilamentDialog::build_ui()
             std::pair(wxColour("#019687"), (int)StateColor::Normal)));
         m_btn_confirm->SetTextColor(StateColor(
             std::pair(wxColour("#6B6A6A"), (int)StateColor::Disabled),
-            std::pair(wxColour("#FFFFFF"), (int)StateColor::Normal)));
+            std::pair(wxColour("#FEFEFE"), (int)StateColor::Normal)));
 
         btn_sizer->Add(m_btn_cancel,  1, wxRIGHT, FromDIP(8));
         btn_sizer->Add(m_btn_confirm, 1);
@@ -1163,8 +1183,8 @@ void MixedFilamentDialog::build_ui()
     }
 
     SetSizer(top_sizer);
-    SetMinClientSize(wxSize(FromDIP(380), FromDIP(626)));
-    SetMaxClientSize(wxSize(FromDIP(380), FromDIP(626)));
+    SetMinClientSize(wxSize(FromDIP(380), FromDIP(666)));
+    SetMaxClientSize(wxSize(FromDIP(380), FromDIP(666)));
 
     // Initialize match state before rebuild (avoids gradient/tri flicker)
     on_mode_changed(m_current_mode);
@@ -1504,7 +1524,8 @@ void MixedFilamentDialog::rebuild_legend()
 
         auto* lbl = new wxStaticText(m_legend_panel, wxID_ANY, wxString::Format("%d%%", weights[i]));
         lbl->SetFont(Label::Body_12);
-        lbl->SetBackgroundColour(wxColour("#FFFFFF"));
+        lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         pair->Add(lbl, 0, wxALIGN_CENTER_VERTICAL);
         m_legend_labels.push_back(lbl);
 
@@ -1550,7 +1571,8 @@ void MixedFilamentDialog::rebuild_match_legend()
         int pct = (i < weights.size()) ? weights[i] : 0;
         auto* lbl = new wxStaticText(m_match_legend_panel, wxID_ANY, wxString::Format("%d%%", pct));
         lbl->SetFont(Label::Body_12);
-        lbl->SetBackgroundColour(wxColour("#FFFFFF"));
+        lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         pair->Add(lbl, 0, wxALIGN_CENTER_VERTICAL);
         m_match_legend_labels.push_back(lbl);
         m_match_legend_sizer->Add(pair, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));
@@ -1652,6 +1674,8 @@ void MixedFilamentDialog::rebuild_filament_rows()
         auto* row_lbl = new wxStaticText(m_filament_rows_panel, wxID_ANY,
                                          wxString::Format(_L("Filament %d"), i + 1),
                                          wxDefaultPosition, wxSize(FromDIP(48), -1));
+        row_lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+        row_lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         row->Add(row_lbl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));
 
         // Note: sw (color swatch panel) is kept for internal state tracking but hidden
@@ -1706,7 +1730,7 @@ void MixedFilamentDialog::rebuild_filament_rows()
 
         row->Add(cb, 1, wxEXPAND);
 
-        m_filament_rows_sizer->Add(row, 0, wxEXPAND | wxBOTTOM, FromDIP(12));
+        m_filament_rows_sizer->Add(row, 0, wxEXPAND | (i < count - 1 ? wxBOTTOM : 0), FromDIP(12));
     }
 
     m_filament_rows_panel->Layout();
@@ -1780,8 +1804,8 @@ void MixedFilamentDialog::build_tri_picker(wxWindow* parent)
         const int img_h = sz.GetHeight();
         wxImage img(img_w, img_h);
         
-        // Fill with background color
-        const wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+        // Fill with background color matching card
+        const wxColour bg = StateColor::darkModeColorFor(wxColour("#FFFFFF"));
         img.SetRGB(wxRect(0, 0, img_w, img_h), bg.Red(), bg.Green(), bg.Blue());
         unsigned char* data = img.GetData();
 
@@ -1795,7 +1819,7 @@ void MixedFilamentDialog::build_tri_picker(wxWindow* parent)
                 constexpr double EPSILON = 0.001;
                 if (w0 < -EPSILON || w1 < -EPSILON || w2 < -EPSILON) continue;
                 if (px < 0 || px >= img_w || py < 0 || py >= img_h) continue;
-                
+
                 const int idx = (py * img_w + px) * 3;
                 data[idx]     = (unsigned char)std::clamp((int)(c0.Red()   * w0 + c1.Red()   * w1 + c2.Red()   * w2), 0, 255);
                 data[idx + 1] = (unsigned char)std::clamp((int)(c0.Green() * w0 + c1.Green() * w1 + c2.Green() * w2), 0, 255);
@@ -1828,7 +1852,7 @@ void MixedFilamentDialog::build_tri_picker(wxWindow* parent)
         double hx = m_tri_wx*v0.x + m_tri_wy*v1.x + m_tri_wz*v2.x;
         double hy = m_tri_wx*v0.y + m_tri_wy*v1.y + m_tri_wz*v2.y;
         dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.SetPen(wxPen(wxColour("#FFFFFF"), 1));
+        dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour("#FFFFFF")), 1));
         dc.DrawCircle((int)hx, (int)hy, FromDIP(5));
 
     });
@@ -1843,15 +1867,16 @@ void MixedFilamentDialog::build_tri_picker(wxWindow* parent)
         if (!m_tri_dragging) return;
         TriPt clamped = tri_clamp_pt(p, v0, v1, v2);
         tri_bary(clamped, v0, v1, v2, m_tri_wx, m_tri_wy, m_tri_wz);
-        // Clamp each weight to be at least 10% and at most 90%
+        // Clamp each weight to be at least 10% and at most 90%, iterate to renormalize
         constexpr double MIN_WEIGHT = 0.10;
         constexpr double MAX_WEIGHT = 0.90;
-        m_tri_wx = std::clamp(m_tri_wx, MIN_WEIGHT, MAX_WEIGHT);
-        m_tri_wy = std::clamp(m_tri_wy, MIN_WEIGHT, MAX_WEIGHT);
-        m_tri_wz = std::clamp(m_tri_wz, MIN_WEIGHT, MAX_WEIGHT);
-        // Renormalize after clamping
-        double sum = m_tri_wx + m_tri_wy + m_tri_wz;
-        if (sum > 0) { m_tri_wx /= sum; m_tri_wy /= sum; m_tri_wz /= sum; }
+        for (int i = 0; i < 4; ++i) {
+            m_tri_wx = std::clamp(m_tri_wx, MIN_WEIGHT, MAX_WEIGHT);
+            m_tri_wy = std::clamp(m_tri_wy, MIN_WEIGHT, MAX_WEIGHT);
+            m_tri_wz = std::clamp(m_tri_wz, MIN_WEIGHT, MAX_WEIGHT);
+            double sum = m_tri_wx + m_tri_wy + m_tri_wz;
+            if (sum > 0) { m_tri_wx /= sum; m_tri_wy /= sum; m_tri_wz /= sum; }
+        }
         update_preview();
         m_tri_picker->Refresh();
     };
@@ -1910,7 +1935,7 @@ void MixedFilamentDialog::build_match_tri_picker(wxWindow* parent)
 
         const int img_w = sz.GetWidth(), img_h = sz.GetHeight();
         wxImage img(img_w, img_h);
-        const wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+        const wxColour bg = StateColor::darkModeColorFor(wxColour("#FFFFFF"));
         img.SetRGB(wxRect(0, 0, img_w, img_h), bg.Red(), bg.Green(), bg.Blue());
         unsigned char* data = img.GetData();
 
@@ -1951,7 +1976,7 @@ void MixedFilamentDialog::build_match_tri_picker(wxWindow* parent)
         double hx = m_match_tri_wx*v0.x + m_match_tri_wy*v1.x + m_match_tri_wz*v2.x;
         double hy = m_match_tri_wx*v0.y + m_match_tri_wy*v1.y + m_match_tri_wz*v2.y;
         dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.SetPen(wxPen(wxColour("#FFFFFF"), 1));
+        dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour("#FFFFFF")), 1));
         dc.DrawCircle((int)hx, (int)hy, FromDIP(5));
     });
 
@@ -2013,8 +2038,10 @@ void MixedFilamentDialog::update_ratio_or_tri_visibility()
         m_ratio_card->Show(show_ratio_card);
     }
     // Show/hide gradient bar vs tri-picker within card
-    if (m_gradient_selector) m_gradient_selector->Show(show_slider);
-    if (m_tri_picker)        m_tri_picker->Show(show_tri);
+    if (m_ratio_gradient_spacer) m_ratio_gradient_spacer->Show(show_slider);
+    if (m_gradient_selector)     m_gradient_selector->Show(show_slider);
+    if (m_ratio_tri_spacer)      m_ratio_tri_spacer->Show(show_tri);
+    if (m_tri_picker)            m_tri_picker->Show(show_tri);
     // Gradient effect card (shown in gradient mode)
     if (m_gradient_effect_card)
         m_gradient_effect_card->Show(is_gradient_mode && !is_match_mode);
@@ -2025,7 +2052,9 @@ void MixedFilamentDialog::update_ratio_or_tri_visibility()
         int n_tri = (int)m_match_tri_indices.size();
         bool match_show_slider = (n_tri == 2);
         bool match_show_tri    = (n_tri >= 3);
+        if (m_match_gradient_spacer)   m_match_gradient_spacer->Show(match_show_slider);
         if (m_match_gradient_selector) m_match_gradient_selector->Show(match_show_slider);
+        if (m_match_tri_spacer)        m_match_tri_spacer->Show(match_show_tri);
         if (m_match_tri_picker)        m_match_tri_picker->Show(match_show_tri);
     }
 
@@ -2556,7 +2585,7 @@ void MixedFilamentDialog::draw_strip(wxDC& dc, wxPanel* panel)
     }
 
     dc.SetBrush(*wxTRANSPARENT_BRUSH);
-    dc.SetPen(wxPen(wxColour(180, 180, 180), 1));
+    dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour(180, 180, 180)), 1));
     dc.DrawRectangle(0, 0, sz.x, sz.y);
 }
 
@@ -2973,10 +3002,40 @@ void MixedFilamentDialog::rebuild_cycle_legend()
                 for (unsigned int eid : sequence) counts[eid]++;
 
                 const int total = (int)sequence.size();
-                for (const auto& [eid, cnt] : counts) {
+
+                // Compute floor percentages first, then distribute remainder via largest remainders
+                // to guarantee sum=100. This matches summarize_cycle_pattern_text in Plater.
+                std::vector<std::pair<unsigned int, int>> sorted_cnts(counts.begin(), counts.end());
+                std::sort(sorted_cnts.begin(), sorted_cnts.end(),
+                          [](const auto& a, const auto& b) { return a.first < b.first; });
+
+                std::vector<int> pcts(sorted_cnts.size());
+                int sum_pct = 0;
+                for (size_t i = 0; i < sorted_cnts.size(); ++i) {
+                    pcts[i] = int((static_cast<long long>(sorted_cnts[i].second) * 100) / total);
+                    sum_pct += pcts[i];
+                }
+
+                if (sum_pct < 100) {
+                    std::vector<std::pair<size_t, int>> rem;
+                    rem.reserve(sorted_cnts.size());
+                    for (size_t i = 0; i < sorted_cnts.size(); ++i)
+                        rem.emplace_back(i, int((static_cast<long long>(sorted_cnts[i].second) * 100) % total));
+                    std::sort(rem.begin(), rem.end(), [](const auto& a, const auto& b) {
+                        if (a.second != b.second) return a.second > b.second;
+                        return a.first < b.first;
+                    });
+                    for (int extra = 100 - sum_pct; extra > 0; --extra) {
+                        pcts[rem.front().first]++;
+                        rem.erase(rem.begin());
+                    }
+                }
+
+                for (size_t i = 0; i < sorted_cnts.size(); ++i) {
+                    unsigned int eid = sorted_cnts[i].first;
+                    int pct         = pcts[i];
                     int idx = (int)eid - 1;
                     if (idx < 0 || idx >= num_physical) continue;
-                    int pct = (cnt * 100 + total / 2) / total;
 
                         // Badge + label pair
                         auto* pair = new wxBoxSizer(wxHORIZONTAL);
@@ -2992,7 +3051,8 @@ void MixedFilamentDialog::rebuild_cycle_legend()
 
                         auto* lbl = new wxStaticText(m_cycle_legend_panel, wxID_ANY, wxString::Format("%d%%", pct));
                         lbl->SetFont(Label::Body_12);
-                        lbl->SetBackgroundColour(wxColour("#FFFFFF"));
+                        lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
+                        lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
                         pair->Add(lbl, 0, wxALIGN_CENTER_VERTICAL);
                         m_cycle_legend_labels.push_back(lbl);
 

--- a/src/slic3r/GUI/MixedFilamentDialog.hpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.hpp
@@ -77,6 +77,8 @@ private:
     wxBoxSizer*             m_legend_sizer         = nullptr;
     std::vector<wxStaticText*> m_legend_labels;
     wxPanel*                m_tri_picker          = nullptr;
+    wxSizerItem*            m_ratio_gradient_spacer = nullptr;
+    wxSizerItem*            m_ratio_tri_spacer      = nullptr;
     wxPanel*                m_strip_panel         = nullptr;
     wxPanel*                m_cycle_strip_panel   = nullptr;
     wxPanel*                m_swatch_grid_panel   = nullptr;
@@ -115,6 +117,8 @@ private:
     wxBoxSizer*             m_match_ratio_card_sizer = nullptr;
     MixedGradientSelector*  m_match_gradient_selector = nullptr;
     wxPanel*                m_match_tri_picker       = nullptr;
+    wxSizerItem*            m_match_gradient_spacer   = nullptr;
+    wxSizerItem*            m_match_tri_spacer        = nullptr;
     wxPanel*                m_match_legend_panel     = nullptr;
     wxBoxSizer*             m_match_legend_sizer     = nullptr;
     std::vector<wxStaticText*> m_match_legend_labels;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1165,7 +1165,7 @@ public:
         root->Add(m_presets_host, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
 
         m_error_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
-        m_error_label->SetForegroundColour(wxColour(196, 67, 63));
+        m_error_label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#D32F2F")));
         root->Add(m_error_label, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(12));
 
         if (wxSizer* button_sizer = CreateStdDialogButtonSizer(wxOK | wxCANCEL))
@@ -3161,6 +3161,19 @@ void Sidebar::on_filaments_change(size_t num_filaments)
         update_ui_from_settings();
         update_dynamic_filament_list();
         update_mixed_filament_panel(sync_manager);
+
+        // Recalc scrolled filament window height (max 3 rows, matches color mix)
+        if (p->m_scrolled_filaments && p->m_panel_scrolled_filament_content) {
+            p->m_panel_scrolled_filament_content->Layout();
+            const wxSize content_best = p->m_panel_scrolled_filament_content->GetBestSize();
+            const int row_count = ((int)num_filaments + 1) / 2; // 2-column grid
+            const int desired_h = row_count > 3
+                ? (content_best.GetHeight() * 3) / std::max(1, row_count)
+                : content_best.GetHeight();
+            p->m_scrolled_filaments->SetMinSize({-1, desired_h});
+            p->m_scrolled_filaments->SetMaxSize({-1, desired_h});
+        }
+        Layout();
         return;
     }
 
@@ -5588,7 +5601,7 @@ void Sidebar::init_color_mix_panel(wxWindow* parent, wxSizer* sizer)
 
     auto* h_title = new wxBoxSizer(wxHORIZONTAL);
     auto* white_left_c = new wxPanel(p->m_panel_color_mix_title, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(SidebarProps::ContentMargin()), -1));
-    white_left_c->SetBackgroundColour(*wxWHITE);
+    white_left_c->SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
     h_title->Add(white_left_c, 0, wxEXPAND | wxTOP | wxBOTTOM, 0);
     h_title->Add(p->m_color_mix_icon, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(SidebarProps::TitlebarMargin()));
     h_title->AddSpacer(FromDIP(SidebarProps::ElementSpacing()));
@@ -5597,7 +5610,7 @@ void Sidebar::init_color_mix_panel(wxWindow* parent, wxSizer* sizer)
     h_title->Add(p->m_btn_del_color_mix, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
     h_title->Add(p->m_btn_add_color_mix, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
     auto* white_right_c = new wxPanel(p->m_panel_color_mix_title, wxID_ANY, wxDefaultPosition, wxSize(FromDIP(SidebarProps::ContentMargin()), -1));
-    white_right_c->SetBackgroundColour(*wxWHITE);
+    white_right_c->SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
     h_title->Add(white_right_c, 0, wxEXPAND | wxTOP | wxBOTTOM, 0);
     p->m_panel_color_mix_title->SetSizer(h_title);
     p->m_panel_color_mix_title->Layout();
@@ -5605,11 +5618,11 @@ void Sidebar::init_color_mix_panel(wxWindow* parent, wxSizer* sizer)
     // Scrolled window for content with max height of 3 rows
     p->m_scrolled_color_mix = new wxScrolledWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxVSCROLL);
     p->m_scrolled_color_mix->SetScrollRate(0, 5);
-    p->m_scrolled_color_mix->SetBackgroundColour(*wxWHITE);
+    p->m_scrolled_color_mix->SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
 
     // Content panel — match physical filament content panel (sizer set dynamically in update)
     p->m_panel_color_mix_content = new wxPanel(p->m_scrolled_color_mix, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-    p->m_panel_color_mix_content->SetBackgroundColour(*wxWHITE);
+    p->m_panel_color_mix_content->SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
 
     // Add content panel to scrolled window
     auto* scrolled_sizer = new wxBoxSizer(wxVERTICAL);
@@ -5823,7 +5836,7 @@ void Sidebar::update_color_mix_panel()
         
         // Create a panel with border for the text
         auto* name_panel = new wxPanel(p->m_panel_color_mix_content, wxID_ANY);
-        name_panel->SetBackgroundColour(*wxWHITE);
+        name_panel->SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
 
         auto* name_sizer = new wxBoxSizer(wxHORIZONTAL);
 
@@ -5836,8 +5849,8 @@ void Sidebar::update_color_mix_panel()
         }
 
         auto* name_btn = new wxStaticText(name_panel, wxID_ANY, lbl, wxDefaultPosition, wxDefaultSize, 0);
-        name_btn->SetBackgroundColour(*wxWHITE);
-        name_btn->SetForegroundColour(wxColour(50, 50, 50));
+        name_btn->SetBackgroundColour(StateColor::darkModeColorFor(*wxWHITE));
+        name_btn->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#262E30")));
         name_btn->SetCursor(wxCursor(wxCURSOR_HAND));
         name_btn->SetMinSize(wxSize(0, -1)); // allow sizer to shrink below text width
 
@@ -5869,7 +5882,7 @@ void Sidebar::update_color_mix_panel()
             wxRect rect = panel->GetClientRect();
 
             // Draw border matching combo (#dbdbdb, 1px)
-            dc.SetPen(wxPen(wxColour(0xdb, 0xdb, 0xdb), 1));
+            dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour(0xdb, 0xdb, 0xdb)), 1));
             dc.SetBrush(*wxTRANSPARENT_BRUSH);
             dc.DrawRectangle(rect);
         });
@@ -5899,6 +5912,7 @@ void Sidebar::update_color_mix_panel()
             mfs2[i].gradient_start             = r.gradient_start;
             mfs2[i].gradient_end               = r.gradient_end;
             mfs2[i].display_color               = r.display_color;
+            mfs2[i].custom                      = true;
             if (auto* opt = wxGetApp().preset_bundle->project_config.option<ConfigOptionString>("mixed_filament_definitions"))
                 opt->value = mgr.serialize_custom_entries();
             wxGetApp().plater()->post_slice_state_change_update();
@@ -5945,6 +5959,7 @@ void Sidebar::update_color_mix_panel()
                 mfs2[i].gradient_enabled           = r.gradient_enabled;
                 mfs2[i].gradient_start             = r.gradient_start;
                 mfs2[i].gradient_end               = r.gradient_end;
+                mfs2[i].custom                      = true;
                 if (auto* opt = wxGetApp().preset_bundle->project_config.option<ConfigOptionString>("mixed_filament_definitions"))
                     opt->value = mgr.serialize_custom_entries();
                 wxGetApp().plater()->post_slice_state_change_update();
@@ -7625,12 +7640,12 @@ void Sidebar::delete_filament(size_t filament_id, int replace_filament_id)
     else if (is_physical_to_mixed_merge && target_depends_on_source) {
         BOOST_LOG_TRIVIAL(info) << "Physical to mixed merge: target depends on source, will delete physical and reset to default";
     }
-    
+
     // Delete the physical filament (this also removes mixed filaments that depend on it)
     pb.update_num_filaments(filament_id);
     size_t new_num_physical = pb.filament_presets.size();
 
-    size_t total_after_delete = new_num_physical;
+    size_t total_after_delete = pb.mixed_filaments.total_filaments(new_num_physical);
     wxGetApp().plater()->get_partplate_list().on_filament_deleted(total_after_delete, filament_id);
 
     int final_replace_id;
@@ -14089,6 +14104,9 @@ void Plater::priv::apply_color_mode()
     m_aui_mgr.GetArtProvider()->SetColour(wxAUI_DOCKART_INACTIVE_CAPTION_TEXT_COLOUR, *wxWHITE);
     m_aui_mgr.GetArtProvider()->SetColour(wxAUI_DOCKART_SASH_COLOUR, sash_color);
     m_aui_mgr.GetArtProvider()->SetColour(wxAUI_DOCKART_BORDER_COLOUR, is_dark ? *wxBLACK : wxColour(165, 165, 165));
+
+    if (sidebar)
+        sidebar->update_color_mix_panel();
 }
 
 static void get_position(wxWindowBase* child, wxWindowBase* until_parent, int& x, int& y) {
@@ -19808,10 +19826,13 @@ void Plater::on_filaments_delete(size_t num_filaments, size_t filament_id, int r
     if (preset_bundle != nullptr)
         id_remap = preset_bundle->consume_last_filament_id_remap();
 
-    // Build state map for remap if available
+    // Build state map for remap if available.
+    // When replace_filament_id >= 0 the caller handles paint transfer via
+    // update_extruder_count_when_delete_filament — skip the generic remap
+    // (which maps deleted→0) so paint is moved to the target, not lost.
     EnforcerBlockerStateMap state_map;
     bool should_remap_states = false;
-    if (!id_remap.empty()) {
+    if (!id_remap.empty() && replace_filament_id < 0) {
         should_remap_states = true;
         for (size_t i = 0; i < state_map.size(); ++i)
             state_map[i] = EnforcerBlockerType(i);

--- a/src/slic3r/GUI/Widgets/StateColor.cpp
+++ b/src/slic3r/GUI/Widgets/StateColor.cpp
@@ -46,6 +46,24 @@ static std::map<wxColour, wxColour> gDarkColors{
     // ORCA
     {"#BFE1DE", "#223C3C"}, // rgb(191, 225, 222)  Dropdown checked item background color > ORCA color with %25 opacity
     {"#E5F0EE", "#283232"}, // rgb(229, 240, 238)  Combo / Dropdown focused background color > ORCA color with %10 opacity
+    // MixedFilamentDialog dark mode
+    {"#F8F7F7", "#2A2A2E"}, // rgb(248, 247, 247)  Dialog / scrolled content background
+    {"#F0F0F0", "#3F3F46"}, // rgb(240, 240, 240)  Card borders, dividers
+    {"#F3F4F6", "#3A3A3F"}, // rgb(243, 244, 246)  Internal card dividers
+    {"#242424", "#E4E4E7"}, // rgb(36, 36, 36)    Primary text (hex input, cancel btn)
+    {"#4A4A4A", "#A1A1AA"}, // rgb(74, 74, 74)    Secondary text (segmented btns)
+    {"#8F8F8F", "#8A8A95"}, // rgb(143, 143, 143) Label text (Hex:, Preview, percentages)
+    {"#EBEBEB", "#45454B"}, // rgb(235, 235, 235)  Slider track background
+    {"#FDE8E8", "#4D2020"}, // rgb(253, 232, 232)  Error banner background
+    {"#D32F2F", "#EF5350"}, // rgb(211, 47, 47)    Error text
+    {"#FFF3EB", "#452A1A"}, // rgb(255, 243, 235)  Warning banner background
+    {"#FF842D", "#FF9F43"}, // rgb(255, 132, 45)   Warning text
+    {"#B4B4B4", "#73737D"}, // rgb(180, 180, 180)  Preview/strip border
+    {"#D1D5DC", "#52525B"}, // rgb(209, 213, 220)  Cancel button border
+    {"#FF0000", "#FF5252"}, // rgb(255, 0, 0)      Hex input error border
+    {"#019687", "#00675B"}, // rgb(1, 150, 135)    Confirm button bg (near #009688)
+    {"#26A69A", "#00675B"}, // rgb(38, 166, 154)   Default target/match color
+    {"#FEFEFE", "#FEFEFE"}, // rgb(254, 254, 254)   Near-white text (segment btn selected, confirm btn)
 };
 
 std::tuple<double, double, double> StateColor::GetLAB(const wxColour& color) {

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -64,6 +64,13 @@ struct MixedAutoGenerateGuard
     bool previous = true;
 };
 
+// Enable auto_generate by default for all tests (matches production behavior where
+// AppConfig sets this to true during GUI startup).
+static const int _auto_generate_enabler = []() {
+    MixedFilamentManager::set_auto_generate_enabled(true);
+    return 0;
+}();
+
 } // namespace
 
 TEST_CASE("Mixed filament remap follows stable row ids when same-pair rows reorder", "[MixedFilament]")
@@ -186,11 +193,13 @@ TEST_CASE("Mixed filament component surface offsets round-trip and bias the seco
     loaded.load_custom_entries(serialized, colors);
     REQUIRE(loaded.mixed_filaments().size() == 1);
 
+    using Catch::Matchers::WithinAbs;
+
     const MixedFilament &loaded_row = loaded.mixed_filaments().front();
-    CHECK(loaded_row.component_a_surface_offset == Approx(0.02f));
-    CHECK(loaded_row.component_b_surface_offset == Approx(-0.01f));
-    CHECK(loaded.component_surface_offset(3, 2, 0) == Approx(0.01f));
-    CHECK(loaded.component_surface_offset(3, 2, 1) == Approx(0.0f));
+    CHECK_THAT(double(loaded_row.component_a_surface_offset), WithinAbs(0.02, 0.0001));
+    CHECK_THAT(double(loaded_row.component_b_surface_offset), WithinAbs(-0.01, 0.0001));
+    CHECK_THAT(double(loaded.component_surface_offset(3, 2, 0)), WithinAbs(0.01, 0.0001));
+    CHECK_THAT(double(loaded.component_surface_offset(3, 2, 1)), WithinAbs(0.0, 0.0001));
 }
 
 TEST_CASE("Mixed filament apparent mix percent follows the signed bias target", "[MixedFilament]")
@@ -248,25 +257,26 @@ TEST_CASE("Mixed filament component surface offsets follow the signed bias targe
     row.ratio_a = 1;
     row.ratio_b = 1;
 
+    using Catch::Matchers::WithinAbs;
     {
         const auto [offset_a, offset_b] = MixedFilamentManager::surface_offset_pair_from_signed_bias(0.05f, 0.4f);
         row.component_a_surface_offset = offset_a;
         row.component_b_surface_offset = offset_b;
 
-        CHECK(mgr.component_surface_offset(3, 2, 0) == Approx(0.0f));
-        CHECK(mgr.component_surface_offset(3, 2, 1) == Approx(0.05f));
-        CHECK(mgr.component_surface_offset(3, 2, 2) == Approx(0.0f));
-        CHECK(mgr.component_surface_offset(3, 2, 3) == Approx(0.05f));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 0)), WithinAbs(0.0, 0.0001));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 1)), WithinAbs(0.05, 0.0001));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 2)), WithinAbs(0.0, 0.0001));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 3)), WithinAbs(0.05, 0.0001));
     }
 
     {
         row.component_a_surface_offset = 0.05f;
         row.component_b_surface_offset = 0.0f;
 
-        CHECK(mgr.component_surface_offset(3, 2, 0) == Approx(0.05f));
-        CHECK(mgr.component_surface_offset(3, 2, 1) == Approx(0.0f));
-        CHECK(mgr.component_surface_offset(3, 2, 2) == Approx(0.05f));
-        CHECK(mgr.component_surface_offset(3, 2, 3) == Approx(0.0f));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 0)), WithinAbs(0.05, 0.0001));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 1)), WithinAbs(0.0, 0.0001));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 2)), WithinAbs(0.05, 0.0001));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 3)), WithinAbs(0.0, 0.0001));
     }
 
     {
@@ -274,10 +284,10 @@ TEST_CASE("Mixed filament component surface offsets follow the signed bias targe
         row.component_a_surface_offset = offset_a;
         row.component_b_surface_offset = offset_b;
 
-        CHECK(mgr.component_surface_offset(3, 2, 0) == Approx(0.05f));
-        CHECK(mgr.component_surface_offset(3, 2, 1) == Approx(0.0f));
-        CHECK(mgr.component_surface_offset(3, 2, 2) == Approx(0.05f));
-        CHECK(mgr.component_surface_offset(3, 2, 3) == Approx(0.0f));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 0)), WithinAbs(0.05, 0.0001));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 1)), WithinAbs(0.0, 0.0001));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 2)), WithinAbs(0.05, 0.0001));
+        CHECK_THAT(double(mgr.component_surface_offset(3, 2, 3)), WithinAbs(0.0, 0.0001));
     }
 }
 
@@ -479,17 +489,18 @@ TEST_CASE("Mixed filament painted-region resolver preserves virtual channels for
     mgr.add_custom_filament(1, 2, 50, colors);
     REQUIRE(mgr.mixed_filaments().size() == 1);
 
+    using Catch::Matchers::WithinAbs;
     MixedFilament &row = mgr.mixed_filaments().front();
     row.manual_pattern = MixedFilamentManager::normalize_manual_pattern("12,21");
     CHECK(mgr.effective_painted_region_filament_id(3, 2, 0) == 3);
     row.component_a_surface_offset = 0.02f;
     row.component_b_surface_offset = -0.02f;
-    CHECK(mgr.component_surface_offset(3, 2, 0) == Approx(0.0f));
+    CHECK_THAT(double(mgr.component_surface_offset(3, 2, 0)), WithinAbs(0.0, 0.0001));
 
     row.manual_pattern.clear();
     row.distribution_mode = int(MixedFilament::SameLayerPointillisme);
     CHECK(mgr.effective_painted_region_filament_id(3, 2, 0) == 3);
-    CHECK(mgr.component_surface_offset(3, 2, 0) == Approx(0.0f));
+    CHECK_THAT(double(mgr.component_surface_offset(3, 2, 0)), WithinAbs(0.0, 0.0001));
 }
 
 TEST_CASE("ExtrusionPath copies preserve inset index", "[MixedFilament]")
@@ -527,4 +538,1058 @@ TEST_CASE("Extrusion loop and multipath entities preserve inset index", "[MixedF
 
     ExtrusionLoop loop_copy(loop_from_path);
     CHECK(loop_copy.inset_idx == 2);
+}
+
+// ============================================================================
+// [MixedFilament][Utility]
+// ============================================================================
+
+TEST_CASE("Mixed filament safe_mod handles negative wrapping and edge cases", "[MixedFilament][Utility]")
+{
+    CHECK(MixedFilamentManager::safe_mod(5, 3) == 2);
+    CHECK(MixedFilamentManager::safe_mod(-1, 5) == 4);
+    CHECK(MixedFilamentManager::safe_mod(5, 1) == 0);
+    CHECK(MixedFilamentManager::safe_mod(0, 5) == 0);
+    CHECK(MixedFilamentManager::safe_mod(7, 5) == 2);
+}
+
+TEST_CASE("Mixed filament normalize_ratio_pair clamps and normalizes", "[MixedFilament][Utility]")
+{
+    int a = 0, b = 0;
+    MixedFilamentManager::normalize_ratio_pair(a, b);
+    CHECK(a == 1);
+    CHECK(b == 0);
+
+    a = 0; b = 3;
+    MixedFilamentManager::normalize_ratio_pair(a, b);
+    CHECK(a == 0);
+    CHECK(b == 3);
+
+    a = -1; b = -2;
+    MixedFilamentManager::normalize_ratio_pair(a, b);
+    // negatives clamped to 0, then (0,0) → (1,0)
+    CHECK(a == 1);
+    CHECK(b == 0);
+}
+
+TEST_CASE("Mixed filament fill_continuous_layer_range fills gaps", "[MixedFilament][Utility]")
+{
+    const std::vector<int> empty;
+    CHECK(fill_continuous_layer_range(empty).empty());
+
+    const std::vector<int> single = {3};
+    const auto filled_single = fill_continuous_layer_range(single);
+    REQUIRE(filled_single.size() == 1);
+    CHECK(filled_single[0] == 3);
+
+    const std::vector<int> sparse = {1, 5};
+    const auto filled_sparse = fill_continuous_layer_range(sparse);
+    REQUIRE(filled_sparse.size() == 5);
+    CHECK(filled_sparse[0] == 1);
+    CHECK(filled_sparse[4] == 5);
+
+    const std::vector<int> cont = {1, 2, 3};
+    const auto filled_cont = fill_continuous_layer_range(cont);
+    REQUIRE(filled_cont.size() == 3);
+    CHECK(filled_cont[0] == 1);
+    CHECK(filled_cont[2] == 3);
+}
+
+TEST_CASE("Mixed filament canonical_signed_bias_value extracts signed bias", "[MixedFilament][Utility]")
+{
+    using Catch::Matchers::WithinAbs;
+    CHECK_THAT(double(MixedFilamentManager::canonical_signed_bias_value(0.f, 0.f)), WithinAbs(0.0, 0.0001));
+    CHECK_THAT(double(MixedFilamentManager::canonical_signed_bias_value(0.f, 0.05f)), WithinAbs(0.05, 0.0001));
+    CHECK_THAT(double(MixedFilamentManager::canonical_signed_bias_value(0.05f, 0.f)), WithinAbs(-0.05, 0.0001));
+    CHECK_THAT(double(MixedFilamentManager::canonical_signed_bias_value(-0.05f, 0.f)), WithinAbs(0.05, 0.0001));
+}
+
+TEST_CASE("Mixed filament format_surface_offset_token formats and strips", "[MixedFilament][Utility]")
+{
+    CHECK(MixedFilamentManager::format_surface_offset_token(0.f) == "0");
+    CHECK(MixedFilamentManager::format_surface_offset_token(0.02f) == "0.02");
+    CHECK(MixedFilamentManager::format_surface_offset_token(-0.01f) == "-0.01");
+    CHECK(MixedFilamentManager::format_surface_offset_token(2.f) == "2");
+    CHECK(MixedFilamentManager::format_surface_offset_token(-0.f) == "0");
+    CHECK(MixedFilamentManager::format_surface_offset_token(0.1234f) == "0.1234");
+}
+
+TEST_CASE("Mixed filament max surface offset clamps correctly", "[MixedFilament][Utility]")
+{
+    using Catch::Matchers::WithinRel;
+    CHECK_THAT(double(MixedFilamentManager::max_component_surface_offset_mm(0.4f)), WithinRel(0.35, 0.001));
+    CHECK_THAT(double(MixedFilamentManager::max_component_surface_offset_mm(0.001f)), WithinRel(0.05, 0.001));
+    CHECK_THAT(double(MixedFilamentManager::max_component_surface_offset_mm(2.f)), WithinRel(0.35, 0.001));
+    CHECK_THAT(double(MixedFilamentManager::max_pair_bias_mm(0.4f)), WithinRel(0.35, 0.001));
+}
+
+// ============================================================================
+// [MixedFilament][Pattern]
+// ============================================================================
+
+TEST_CASE("Mixed filament manual pattern bracket notation acceptance", "[MixedFilament][Pattern]")
+{
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[10]") == "[10]");
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[1]") == "1");
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[99]") == "[99]");
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[11]") == "[11]");
+    CHECK(MixedFilamentManager::normalize_manual_pattern("1[10],[11]2") == "1[10],[11]2");
+}
+
+TEST_CASE("Mixed filament manual pattern bracket overflow rejection", "[MixedFilament][Pattern]")
+{
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[100]").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[123]").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[9999]").empty());
+}
+
+TEST_CASE("Mixed filament manual pattern zero and leading-zero rejection", "[MixedFilament][Pattern]")
+{
+    CHECK(MixedFilamentManager::normalize_manual_pattern("0").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[0]").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[01]").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[00]").empty());
+}
+
+TEST_CASE("Mixed filament manual pattern malformed bracket rejection", "[MixedFilament][Pattern]")
+{
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("]").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[]").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[1").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("1]").empty());
+}
+
+TEST_CASE("Mixed filament manual pattern empty group rejection", "[MixedFilament][Pattern]")
+{
+    CHECK(MixedFilamentManager::normalize_manual_pattern("1,").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern(",1").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("1,,2").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern(",").empty());
+}
+
+TEST_CASE("Mixed filament manual pattern invalid character rejection", "[MixedFilament][Pattern]")
+{
+    CHECK(MixedFilamentManager::normalize_manual_pattern("a").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("(1)").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern(" ").empty());
+    CHECK(MixedFilamentManager::normalize_manual_pattern("[1a]").empty());
+}
+
+TEST_CASE("Mixed filament mix_percent_from_manual_pattern with bracket tokens", "[MixedFilament][Pattern]")
+{
+    CHECK(MixedFilamentManager::mix_percent_from_manual_pattern("1112") == 25);
+    CHECK(MixedFilamentManager::mix_percent_from_manual_pattern("22[2]1") == 75);
+    CHECK(MixedFilamentManager::mix_percent_from_manual_pattern("[10][10]1[10]2") == 20);
+}
+
+TEST_CASE("Mixed filament physical_filament_from_token maps tokens correctly", "[MixedFilament][Pattern]")
+{
+    MixedFilament mf;
+    mf.component_a = 3;
+    mf.component_b = 4;
+    const size_t num_physical = 10;
+
+    CHECK(MixedFilamentManager::physical_filament_from_token("1", mf, num_physical) == 3);
+    CHECK(MixedFilamentManager::physical_filament_from_token("2", mf, num_physical) == 4);
+    CHECK(MixedFilamentManager::physical_filament_from_token("10", mf, num_physical) == 10);
+    CHECK(MixedFilamentManager::physical_filament_from_token("999", mf, num_physical) == 0);
+    CHECK(MixedFilamentManager::physical_filament_from_token("abc", mf, num_physical) == 0);
+    CHECK(MixedFilamentManager::physical_filament_from_token("0", mf, num_physical) == 0);
+}
+
+// ============================================================================
+// [MixedFilament][Color]
+// ============================================================================
+
+TEST_CASE("Mixed filament blend_color_multi blends N colors", "[MixedFilament][Color]")
+{
+    const std::vector<std::pair<std::string, int>> empty;
+    CHECK(MixedFilamentManager::blend_color_multi(empty) == "#000000");
+
+    const std::vector<std::pair<std::string, int>> single = {{"#FF0000", 100}};
+    CHECK(MixedFilamentManager::blend_color_multi(single) == "#FF0000");
+
+    const std::vector<std::pair<std::string, int>> all_zero = {{"#FF0000", 0}, {"#00FF00", 0}};
+    CHECK(MixedFilamentManager::blend_color_multi(all_zero) == "#000000");
+
+    const std::vector<std::pair<std::string, int>> three = {{"#FF0000", 40}, {"#00FF00", 30}, {"#0000FF", 30}};
+    const std::string result = MixedFilamentManager::blend_color_multi(three);
+    CHECK(!result.empty());
+    CHECK(result[0] == '#');
+}
+
+TEST_CASE("Mixed filament blend_color handles ratio edge cases", "[MixedFilament][Color]")
+{
+    const std::string blended = MixedFilamentManager::blend_color("#FF0000", "#00FF00", 1, 1);
+    CHECK(!blended.empty());
+    CHECK(blended[0] == '#');
+
+    const std::string zero_both = MixedFilamentManager::blend_color("#FF0000", "#00FF00", 0, 0);
+    CHECK(!zero_both.empty());
+    CHECK(zero_both[0] == '#');
+
+    const std::string pure_b = MixedFilamentManager::blend_color("#FF0000", "#00FF00", 0, 1);
+    CHECK(pure_b == "#00FF00");
+
+    const std::string pure_a = MixedFilamentManager::blend_color("#FF0000", "#00FF00", 1, 0);
+    CHECK(pure_a == "#FF0000");
+}
+
+// ============================================================================
+// [MixedFilament][Lifecycle]
+// ============================================================================
+
+TEST_CASE("Mixed filament add_custom_filament guards and auto-swap", "[MixedFilament][Lifecycle]")
+{
+    // n<2 → no-op
+    MixedFilamentManager mgr_small;
+    const std::vector<std::string> one_color = {"#FF0000"};
+    mgr_small.add_custom_filament(1, 2, 50, one_color);
+    CHECK(mgr_small.mixed_filaments().empty());
+
+    // Normal addition
+    MixedFilamentManager mgr;
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00", "#0000FF"};
+    mgr.add_custom_filament(1, 2, 50, colors);
+    REQUIRE(mgr.mixed_filaments().size() == 1);
+    const auto &entry = mgr.mixed_filaments().front();
+    CHECK(entry.custom);
+    CHECK(entry.enabled);
+    CHECK_FALSE(entry.deleted);
+    CHECK(entry.mix_b_percent == 50);
+
+    // a==b → auto-swap
+    MixedFilamentManager mgr_swap;
+    mgr_swap.add_custom_filament(1, 1, 30, colors);
+    REQUIRE(mgr_swap.mixed_filaments().size() == 1);
+    CHECK(mgr_swap.mixed_filaments().front().component_a == 1);
+    CHECK(mgr_swap.mixed_filaments().front().component_b == 2);
+}
+
+TEST_CASE("Mixed filament auto_generate preserves state and respects disable", "[MixedFilament][Lifecycle]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00", "#0000FF"};
+
+    MixedFilamentManager::set_auto_generate_enabled(true);
+    MixedFilamentManager mgr;
+    mgr.auto_generate(colors);
+    REQUIRE(mgr.mixed_filaments().size() >= 3);
+
+    // Disable one auto row, then re-generate
+    mgr.mixed_filaments()[0].enabled = false;
+    mgr.auto_generate(colors);
+    CHECK_FALSE(mgr.mixed_filaments()[0].enabled);
+
+    // Custom rows survive auto_generate
+    mgr.add_custom_filament(1, 3, 50, colors);
+    size_t custom_count_before = 0;
+    for (const auto &mf : mgr.mixed_filaments())
+        if (mf.custom) ++custom_count_before;
+    mgr.auto_generate(colors);
+    size_t custom_count_after = 0;
+    for (const auto &mf : mgr.mixed_filaments())
+        if (mf.custom) ++custom_count_after;
+    CHECK(custom_count_after == custom_count_before);
+
+    // Disabled auto-generate: only custom rows remain
+    {
+        MixedAutoGenerateGuard guard_disabled(false);
+        mgr.auto_generate(colors);
+        for (const auto &mf : mgr.mixed_filaments())
+            CHECK(mf.custom);
+    }
+}
+
+TEST_CASE("Mixed filament enabled_count and cleanup operations", "[MixedFilament][Lifecycle]")
+{
+    MixedFilamentManager mgr;
+    CHECK(mgr.enabled_count() == 0);
+
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    mgr.add_custom_filament(1, 2, 50, colors);
+    CHECK(mgr.enabled_count() == 1);
+
+    mgr.mixed_filaments()[0].enabled = false;
+    CHECK(mgr.enabled_count() == 0);
+
+    mgr.mixed_filaments()[0].enabled = true;
+    mgr.mixed_filaments()[0].deleted = true;
+    CHECK(mgr.enabled_count() == 0);
+
+    // cleanup removes deleted
+    mgr.cleanup_deleted_entries();
+    CHECK(mgr.mixed_filaments().empty());
+}
+
+TEST_CASE("Mixed filament clear_custom_entries removes only custom", "[MixedFilament][Lifecycle]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00", "#0000FF"};
+    MixedFilamentManager::set_auto_generate_enabled(true);
+    MixedFilamentManager mgr;
+    mgr.auto_generate(colors);
+    size_t auto_count = mgr.mixed_filaments().size();
+
+    mgr.add_custom_filament(1, 2, 50, colors);
+    mgr.add_custom_filament(1, 3, 50, colors);
+    CHECK(mgr.mixed_filaments().size() == auto_count + 2);
+
+    mgr.clear_custom_entries();
+    CHECK(mgr.mixed_filaments().size() == auto_count);
+    for (const auto &mf : mgr.mixed_filaments())
+        CHECK_FALSE(mf.custom);
+}
+
+TEST_CASE("Mixed filament mixed_filaments_using_physical finds dependents", "[MixedFilament][Lifecycle]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00", "#0000FF"};
+    MixedFilamentManager::set_auto_generate_enabled(true);
+    MixedFilamentManager mgr;
+    mgr.auto_generate(colors);
+
+    // Physical 1 used in auto pairs with 2 and 3
+    auto deps = mgr.mixed_filaments_using_physical(1);
+    CHECK(deps.size() >= 2);
+
+    // Physical 2 used in auto pairs
+    deps = mgr.mixed_filaments_using_physical(2);
+    CHECK(deps.size() >= 2);
+
+    // Deleted entries skipped
+    mgr.mixed_filaments()[0].deleted = true;
+    mgr.mixed_filaments()[0].enabled = false;
+    deps = mgr.mixed_filaments_using_physical(1);
+    for (size_t idx : deps)
+        CHECK(idx != 0);
+}
+
+TEST_CASE("Mixed filament remove_physical_filament removes and shifts", "[MixedFilament][Lifecycle]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00", "#0000FF", "#FFFF00"};
+    MixedFilamentManager::set_auto_generate_enabled(true);
+    MixedFilamentManager mgr;
+    mgr.auto_generate(colors);
+    mgr.add_custom_filament(2, 3, 50, colors);
+
+    // Verify initial state has entries for filament 1
+    size_t count_before = mgr.mixed_filaments().size();
+    CHECK(count_before > 0);
+
+    mgr.remove_physical_filament(1);
+
+    // After removal, total count decreased (entries using old filament 1 removed)
+    size_t count_after = mgr.mixed_filaments().size();
+    CHECK(count_after < count_before);
+
+    // Higher IDs shifted: old filament 2 → 1, 3 → 2, 4 → 3
+    for (const auto &mf : mgr.mixed_filaments()) {
+        CHECK(mf.component_a > 0);
+        CHECK(mf.component_b > 0);
+    }
+}
+
+TEST_CASE("Mixed filament mixed_index_from_filament_id maps correctly", "[MixedFilament][Lifecycle]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    const size_t num_physical = 2;
+    CHECK(mgr.mixed_index_from_filament_id(1, num_physical) == -1);
+    CHECK(mgr.mixed_index_from_filament_id(2, num_physical) == -1);
+    CHECK(mgr.mixed_index_from_filament_id(3, num_physical) >= 0);
+
+    // Deleted/disabled entry skipped
+    mgr.mixed_filaments()[0].enabled = false;
+    mgr.mixed_filaments()[0].deleted = true;
+    CHECK(mgr.mixed_index_from_filament_id(3, num_physical) == -1);
+}
+
+TEST_CASE("Mixed filament stable_id allocation and normalize", "[MixedFilament][Lifecycle]")
+{
+    MixedFilamentManager mgr;
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    const auto &entry = mgr.mixed_filaments().front();
+    CHECK(entry.stable_id >= 1);
+}
+
+TEST_CASE("Mixed filament accessors total_filaments display_colors is_mixed", "[MixedFilament][Lifecycle]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    CHECK(mgr.total_filaments(2) == 3);
+
+    CHECK(mgr.is_mixed(1, 2) == false);
+    CHECK(mgr.is_mixed(3, 2) == true);
+
+    auto display = mgr.display_colors();
+    CHECK(display.size() == 1);
+}
+
+// ============================================================================
+// [MixedFilament][Serialization]
+// ============================================================================
+
+TEST_CASE("Mixed filament full 17-field serialization round-trip", "[MixedFilament][Serialization]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00", "#0000FF"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    auto &mf = mgr.mixed_filaments().front();
+    mf.gradient_component_ids = "123";
+    mf.gradient_component_weights = "40/30/30";
+    mf.gradient_enabled = true;
+    mf.gradient_start = 0.85f;
+    mf.gradient_end = 0.15f;
+    mf.manual_pattern = "12,21";
+    mf.distribution_mode = int(MixedFilament::LayerCycle);
+    mf.local_z_max_sublayers = 4;
+    mf.component_a_surface_offset = 0.02f;
+    mf.component_b_surface_offset = -0.01f;
+    mf.deleted = false;
+    mf.origin_auto = false;
+
+    const std::string serialized = mgr.serialize_custom_entries();
+
+    MixedFilamentManager loaded;
+    loaded.add_custom_filament(1, 3, 50, colors); // add an auto pairing trigger row
+    loaded.load_custom_entries(serialized, colors);
+    REQUIRE(loaded.mixed_filaments().size() >= 1);
+
+    // Find the loaded custom entry
+    const MixedFilament *loaded_mf = nullptr;
+    for (const auto &row : loaded.mixed_filaments()) {
+        if (row.custom && row.component_a == 1 && row.component_b == 2) {
+            loaded_mf = &row;
+            break;
+        }
+    }
+    REQUIRE(loaded_mf != nullptr);
+    CHECK(loaded_mf->gradient_enabled == true);
+    CHECK(loaded_mf->distribution_mode == int(MixedFilament::LayerCycle));
+    CHECK(loaded_mf->local_z_max_sublayers == 4);
+    CHECK(loaded_mf->manual_pattern == "12,21");
+}
+
+TEST_CASE("Mixed filament legacy 4-token format parsing", "[MixedFilament][Serialization]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    MixedFilamentManager mgr;
+    mgr.load_custom_entries("1,2,1,50", colors);
+
+    REQUIRE(mgr.mixed_filaments().size() == 1);
+    const auto &entry = mgr.mixed_filaments().front();
+    CHECK(entry.component_a == 1);
+    CHECK(entry.component_b == 2);
+    CHECK(entry.enabled);
+    CHECK(entry.mix_b_percent == 50);
+    CHECK(entry.custom);
+}
+
+TEST_CASE("Mixed filament legacy pointillism flag", "[MixedFilament][Serialization]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    MixedFilamentManager::set_auto_generate_enabled(true);
+    MixedFilamentManager mgr;
+    // Add an auto row first so the serialized custom row is recognizable
+    mgr.auto_generate(colors);
+    mgr.load_custom_entries("1,2,1,1,50,1", colors);
+    // The row is custom (tokens.size() > 4 with custom=1)
+    bool found_custom = false;
+    for (const auto &mf : mgr.mixed_filaments())
+        if (mf.custom) found_custom = true;
+    CHECK(found_custom);
+}
+
+TEST_CASE("Mixed filament deleted entry serialization round-trip", "[MixedFilament][Serialization]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+    mgr.mixed_filaments().front().deleted = true;
+    mgr.mixed_filaments().front().enabled = false;
+
+    const std::string serialized = mgr.serialize_custom_entries();
+    CHECK(serialized.find("d1") != std::string::npos);
+
+    MixedFilamentManager loaded;
+    loaded.load_custom_entries(serialized, colors);
+    REQUIRE(loaded.mixed_filaments().size() >= 1);
+    CHECK(loaded.mixed_filaments().front().deleted);
+    CHECK_FALSE(loaded.mixed_filaments().front().enabled);
+}
+
+TEST_CASE("Mixed filament duplicate stable_id dedup on load", "[MixedFilament][Serialization]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00", "#0000FF"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+    mgr.add_custom_filament(1, 3, 50, colors);
+    // Force same stable_id
+    mgr.mixed_filaments()[0].stable_id = 100;
+    mgr.mixed_filaments()[1].stable_id = 100;
+
+    const std::string serialized = mgr.serialize_custom_entries();
+
+    MixedFilamentManager loaded;
+    loaded.load_custom_entries(serialized, colors);
+    REQUIRE(loaded.mixed_filaments().size() >= 2);
+    // The two entries should have different stable_ids after dedup
+    CHECK(loaded.mixed_filaments()[0].stable_id != loaded.mixed_filaments()[1].stable_id);
+}
+
+// ============================================================================
+// [MixedFilament][Gradient]
+// ============================================================================
+
+TEST_CASE("Mixed filament is_simple_gradient all branches", "[MixedFilament][Gradient]")
+{
+    MixedFilament mf;
+    mf.gradient_enabled = true;
+    mf.component_a = 1;
+    mf.component_b = 2;
+    mf.manual_pattern.clear();
+    mf.gradient_component_ids = "1";
+
+    CHECK(is_simple_gradient(mf));
+
+    mf.gradient_enabled = false;
+    CHECK_FALSE(is_simple_gradient(mf));
+
+    mf.gradient_enabled = true;
+    mf.component_a = 1;
+    mf.component_b = 1;
+    CHECK_FALSE(is_simple_gradient(mf));
+
+    mf.component_b = 2;
+    mf.manual_pattern = "12";
+    CHECK_FALSE(is_simple_gradient(mf));
+
+    mf.manual_pattern.clear();
+    mf.gradient_component_ids = "123";
+    CHECK_FALSE(is_simple_gradient(mf));
+}
+
+TEST_CASE("Mixed filament gradient serialization round-trip with r1 token", "[MixedFilament][Gradient]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    auto &mf = mgr.mixed_filaments().front();
+    mf.gradient_component_ids = "12";
+    mf.gradient_component_weights = "60/40";
+    mf.gradient_enabled = true;
+    mf.gradient_start = 0.85f;
+    mf.gradient_end = 0.15f;
+
+    const std::string serialized = mgr.serialize_custom_entries();
+    CHECK(serialized.find("r1/0.8500/0.1500") != std::string::npos);
+
+    MixedFilamentManager loaded;
+    loaded.load_custom_entries(serialized, colors);
+    REQUIRE(loaded.mixed_filaments().size() >= 1);
+    const auto &loaded_mf = loaded.mixed_filaments().front();
+    CHECK(loaded_mf.gradient_enabled);
+    CHECK(loaded_mf.gradient_component_ids == "12");
+    CHECK(loaded_mf.gradient_component_weights == "60/40");
+}
+
+TEST_CASE("Mixed filament gradient auto-disables when range too small", "[MixedFilament][Gradient]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    auto &mf = mgr.mixed_filaments().front();
+    mf.gradient_enabled = true;
+    mf.gradient_start = 0.80f;
+    mf.gradient_end = 0.82f;
+
+    const std::string serialized = mgr.serialize_custom_entries();
+
+    MixedFilamentManager loaded;
+    loaded.load_custom_entries(serialized, colors);
+    REQUIRE(loaded.mixed_filaments().size() >= 1);
+    CHECK_FALSE(loaded.mixed_filaments().front().gradient_enabled);
+}
+
+TEST_CASE("Mixed filament apply_gradient_settings modes", "[MixedFilament][Gradient]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00", "#0000FF"};
+    MixedFilamentManager::set_auto_generate_enabled(true);
+    MixedFilamentManager mgr;
+    mgr.auto_generate(colors);
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    // Mode 0: layer-cycle
+    mgr.apply_gradient_settings(0, 0.04f, 0.16f, false);
+    for (const auto &mf : mgr.mixed_filaments()) {
+        if (!mf.custom) {
+            CHECK(mf.ratio_a == 1);
+            CHECK(mf.ratio_b == 1);
+        }
+    }
+
+    // Mode 1: height-weighted
+    mgr.apply_gradient_settings(1, 0.04f, 0.16f, false);
+    for (const auto &mf : mgr.mixed_filaments()) {
+        CHECK(mf.ratio_a >= 0);
+        CHECK(mf.ratio_b >= 0);
+    }
+}
+
+TEST_CASE("Mixed filament gradient multi-color resolve", "[MixedFilament][Gradient]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00", "#0000FF"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    auto &mf = mgr.mixed_filaments().front();
+    mf.gradient_component_ids = "123";
+    mf.gradient_component_weights = "50/30/20";
+    mf.distribution_mode = int(MixedFilament::LayerCycle);
+
+    const size_t num_physical = 3;
+    const unsigned int mixed_id = 4;
+    // Should resolve to different physical IDs at different layers
+    unsigned int r0 = mgr.resolve(mixed_id, num_physical, 0);
+    unsigned int r1 = mgr.resolve(mixed_id, num_physical, 1);
+    unsigned int r2 = mgr.resolve(mixed_id, num_physical, 2);
+    CHECK(r0 >= 1);
+    CHECK(r0 <= num_physical);
+    CHECK(r1 >= 1);
+    CHECK(r1 <= num_physical);
+    CHECK(r2 >= 1);
+    CHECK(r2 <= num_physical);
+}
+
+// ============================================================================
+// [MixedFilament][Resolve]
+// ============================================================================
+
+TEST_CASE("Mixed filament resolve passthrough and simple cadence", "[MixedFilament][Resolve]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    const size_t num_physical = 2;
+    // Physical filament passthrough
+    CHECK(mgr.resolve(1, num_physical, 0) == 1);
+    CHECK(mgr.resolve(2, num_physical, 0) == 2);
+
+    // Simple cadence: ratio_a=1, ratio_b=1
+    const unsigned int mixed_id = 3;
+    unsigned int r0 = mgr.resolve(mixed_id, num_physical, 0);
+    unsigned int r1 = mgr.resolve(mixed_id, num_physical, 1);
+    CHECK(r0 != r1);
+}
+
+TEST_CASE("Mixed filament resolve height-weighted mode", "[MixedFilament][Resolve]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    const size_t num_physical = 2;
+    const unsigned int mixed_id = 3;
+    unsigned int result = mgr.resolve(mixed_id, num_physical, 0, 0.5f, 0.2f, true);
+    CHECK(result >= 1);
+    CHECK(result <= num_physical);
+}
+
+TEST_CASE("Mixed filament resolve advanced dithering", "[MixedFilament][Resolve]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    MixedFilamentManager mgr;
+    mgr.apply_gradient_settings(0, 0.04f, 0.16f, true);
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    const size_t num_physical = 2;
+    const unsigned int mixed_id = 3;
+    unsigned int result = mgr.resolve(mixed_id, num_physical, 0);
+    CHECK(result >= 1);
+    CHECK(result <= num_physical);
+}
+
+TEST_CASE("Mixed filament resolve_perimeter and ordered_perimeter_extruders", "[MixedFilament][Resolve]")
+{
+    const std::vector<std::string> colors = {"#00FFFF", "#FF00FF"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    auto &mf = mgr.mixed_filaments().front();
+    mf.manual_pattern = MixedFilamentManager::normalize_manual_pattern("12,21");
+    const size_t num_physical = 2;
+    const unsigned int mixed_id = 3;
+
+    CHECK(mgr.resolve_perimeter(mixed_id, num_physical, 0, 0) == 1);
+    CHECK(mgr.resolve_perimeter(mixed_id, num_physical, 0, 1) == 2);
+
+    auto ordered = mgr.ordered_perimeter_extruders(mixed_id, num_physical, 0);
+    CHECK_FALSE(ordered.empty());
+}
+
+TEST_CASE("Mixed filament effective_painted_region_filament_id", "[MixedFilament][Resolve]")
+{
+    const std::vector<std::string> colors = {"#00FFFF", "#FF00FF"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    const size_t num_physical = 2;
+    const unsigned int mixed_id = 3;
+
+    // Simple mode collapses to physical
+    unsigned int eff = mgr.effective_painted_region_filament_id(mixed_id, num_physical, 0);
+    CHECK(eff >= 1);
+    CHECK(eff <= num_physical);
+
+    // Pointillisme keeps virtual
+    mgr.mixed_filaments().front().distribution_mode = int(MixedFilament::SameLayerPointillisme);
+    CHECK(mgr.effective_painted_region_filament_id(mixed_id, num_physical, 0) == mixed_id);
+
+    // Grouped pattern keeps virtual
+    mgr.mixed_filaments().front().distribution_mode = int(MixedFilament::LayerCycle);
+    mgr.mixed_filaments().front().manual_pattern = "12,21";
+    CHECK(mgr.effective_painted_region_filament_id(mixed_id, num_physical, 0) == mixed_id);
+}
+
+TEST_CASE("Mixed filament component_surface_offset bias routing", "[MixedFilament][Resolve]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#FFFF00"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    auto &mf = mgr.mixed_filaments().front();
+    mf.ratio_a = 1;
+    mf.ratio_b = 1;
+    mf.distribution_mode = int(MixedFilament::Simple);
+
+    const size_t num_physical = 2;
+    const unsigned int mixed_id = 3;
+
+    // Pointillisme → 0
+    mf.distribution_mode = int(MixedFilament::SameLayerPointillisme);
+    using Catch::Matchers::WithinAbs;
+    CHECK_THAT(double(mgr.component_surface_offset(mixed_id, num_physical, 0)), WithinAbs(0.0, 0.0001));
+
+    // Grouped → 0
+    mf.distribution_mode = int(MixedFilament::LayerCycle);
+    mf.manual_pattern = "12,21";
+    CHECK_THAT(double(mgr.component_surface_offset(mixed_id, num_physical, 0)), WithinAbs(0.0, 0.0001));
+
+    // Bias routing (simple mode)
+    mf.distribution_mode = int(MixedFilament::Simple);
+    mf.manual_pattern.clear();
+    mf.component_a_surface_offset = 0.f;
+    mf.component_b_surface_offset = 0.05f;
+    // At layer 1 (resolved to component_b), offset should be positive
+    float off = mgr.component_surface_offset(mixed_id, num_physical, 1);
+    CHECK(off >= -0.01f);
+}
+
+TEST_CASE("Mixed filament mixed_filament_from_id lookup", "[MixedFilament][Resolve]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    const size_t num_physical = 2;
+    CHECK(mgr.mixed_filament_from_id(1, num_physical) == nullptr);
+    CHECK(mgr.mixed_filament_from_id(3, num_physical) != nullptr);
+    CHECK(mgr.mixed_filament_from_id(999, num_physical) == nullptr);
+}
+
+// ============================================================================
+// [MixedFilament][Merge] — Physical filament merge / remap (PresetBundle level)
+// ============================================================================
+
+TEST_CASE("Mixed filament merge physical shifts IDs down and removes dependents", "[MixedFilament][Merge]")
+{
+    PresetBundle bundle;
+    bundle.filament_presets = {"PLA Red", "PLA Green", "PLA Blue", "PLA Yellow"};
+    bundle.project_config.option<ConfigOptionStrings>("filament_colour")->values = {
+        "#FF0000", "#00FF00", "#0000FF", "#FFFF00"
+    };
+    bundle.update_multi_material_filament_presets();
+
+    const size_t physical_before = 4;
+    auto &mgr = bundle.mixed_filaments;
+    REQUIRE(mgr.mixed_filaments().size() >= 6);
+
+    // Delete the last physical filament (truncation — the function handles this case).
+    // Erase filament at 0-based index 3 (physical #4), then call with to_delete=3.
+    bundle.filament_presets.pop_back();
+    bundle.project_config.option<ConfigOptionStrings>("filament_colour")->values.pop_back();
+    bundle.update_multi_material_filament_presets(3, physical_before);
+
+    const std::vector<unsigned int> remap = bundle.consume_last_filament_id_remap();
+    // After truncating physical 4: physical 1→1, 2→2, 3→3, 4→0 (deleted)
+    REQUIRE(remap.size() >= 5);
+    CHECK(remap[1] == 1);
+    CHECK(remap[2] == 2);
+    CHECK(remap[3] == 3);
+    CHECK(remap[4] == 0);
+}
+
+TEST_CASE("Mixed filament merge stable_id preserves surviving mixed rows", "[MixedFilament][Merge]")
+{
+    PresetBundle bundle;
+    bundle.filament_presets = {"PLA Red", "PLA Green", "PLA Blue"};
+    bundle.project_config.option<ConfigOptionStrings>("filament_colour")->values = {
+        "#FF0000", "#00FF00", "#0000FF"
+    };
+    bundle.update_multi_material_filament_presets();
+
+    const size_t physical_before = 3;
+    auto &mgr = bundle.mixed_filaments;
+
+    // Record stable_ids of mixed rows NOT depending on physical 3 (the last one)
+    std::vector<uint64_t> surviving_stable_ids;
+    for (const auto &mf : mgr.mixed_filaments()) {
+        if (mf.enabled && !mf.deleted && mf.component_a != 3 && mf.component_b != 3)
+            surviving_stable_ids.push_back(mf.stable_id);
+    }
+    REQUIRE_FALSE(surviving_stable_ids.empty());
+
+    // Delete the last filament (truncation from end — 0-based index 2)
+    bundle.filament_presets.pop_back();
+    bundle.project_config.option<ConfigOptionStrings>("filament_colour")->values.pop_back();
+    bundle.update_multi_material_filament_presets(2, physical_before);
+
+    const std::vector<unsigned int> remap = bundle.consume_last_filament_id_remap();
+    REQUIRE(remap.size() >= 4);
+    CHECK(remap[1] == 1);
+    CHECK(remap[2] == 2);
+    CHECK(remap[3] == 0);
+
+    // Surviving rows should not reference the deleted physical filament
+    for (const auto &mf : mgr.mixed_filaments()) {
+        if (mf.enabled && !mf.deleted) {
+            CHECK(mf.component_a != 3);
+            CHECK(mf.component_b != 3);
+        }
+    }
+}
+
+TEST_CASE("Mixed filament merge canonical_pair fallback when stable_id missing", "[MixedFilament][Merge]")
+{
+    PresetBundle bundle;
+    bundle.filament_presets = {"PLA Red", "PLA Green", "PLA Blue"};
+    bundle.project_config.option<ConfigOptionStrings>("filament_colour")->values = {
+        "#FF0000", "#00FF00", "#0000FF"
+    };
+    bundle.update_multi_material_filament_presets();
+
+    const size_t physical_before = 3;
+    auto &mgr = bundle.mixed_filaments;
+
+    const auto &colors = bundle.project_config.option<ConfigOptionStrings>("filament_colour")->values;
+    // Add a custom row that does NOT depend on the last physical filament (3)
+    mgr.add_custom_filament(1, 2, 50, colors);
+    REQUIRE(mgr.mixed_filaments().size() >= 4);
+
+    bool has_custom_pair_12 = false;
+    for (const auto &mf : mgr.mixed_filaments())
+        if (mf.custom && ((mf.component_a == 1 && mf.component_b == 2) ||
+                          (mf.component_a == 2 && mf.component_b == 1)))
+            has_custom_pair_12 = true;
+    CHECK(has_custom_pair_12);
+
+    // Delete the last filament (truncation — 0-based index 2 = physical 3)
+    bundle.filament_presets.pop_back();
+    bundle.project_config.option<ConfigOptionStrings>("filament_colour")->values.pop_back();
+    bundle.update_multi_material_filament_presets(2, physical_before);
+
+    const std::vector<unsigned int> remap = bundle.consume_last_filament_id_remap();
+    CHECK(remap.size() >= 6);
+
+    // Custom pair (1,2) should survive since it doesn't depend on deleted physical 3
+    bool has_surviving_custom_pair = false;
+    for (const auto &mf : mgr.mixed_filaments())
+        if (mf.custom && ((mf.component_a == 1 && mf.component_b == 2) ||
+                          (mf.component_a == 2 && mf.component_b == 1)))
+            has_surviving_custom_pair = true;
+    CHECK(has_surviving_custom_pair);
+}
+
+// ============================================================================
+// [MixedFilament][Display]
+// ============================================================================
+
+TEST_CASE("Mixed filament reference nozzle mm computation", "[MixedFilament][Display]")
+{
+    using Catch::Matchers::WithinRel;
+    const std::vector<double> nozzles = {0.4, 0.6, 0.2};
+
+    double ref = MixedFilamentManager::mixed_filament_reference_nozzle_mm(1, 2, nozzles);
+    CHECK_THAT(ref, WithinRel(0.5, 0.01));
+
+    double single = MixedFilamentManager::mixed_filament_reference_nozzle_mm(1, 0, nozzles);
+    CHECK_THAT(single, WithinRel(0.4, 0.01));
+
+    const std::vector<double> empty_nozzles;
+    double fallback = MixedFilamentManager::mixed_filament_reference_nozzle_mm(0, 0, empty_nozzles);
+    CHECK_THAT(fallback, WithinRel(0.4, 0.01));
+}
+
+TEST_CASE("Mixed filament supports_bias_apparent_color conditions", "[MixedFilament][Display]")
+{
+    MixedFilament mf;
+    mf.component_a = 1;
+    mf.component_b = 2;
+    mf.distribution_mode = int(MixedFilament::Simple);
+    mf.gradient_component_ids.clear();
+    mf.manual_pattern.clear();
+    mf.gradient_enabled = false;
+
+    MixedFilamentPreviewSettings preview;
+    preview.local_z_mode = false;
+
+    CHECK(mixed_filament_supports_bias_apparent_color(mf, preview, true));
+
+    CHECK_FALSE(mixed_filament_supports_bias_apparent_color(mf, preview, false));
+    preview.local_z_mode = true;
+    CHECK_FALSE(mixed_filament_supports_bias_apparent_color(mf, preview, true));
+    preview.local_z_mode = false;
+    mf.distribution_mode = int(MixedFilament::SameLayerPointillisme);
+    CHECK_FALSE(mixed_filament_supports_bias_apparent_color(mf, preview, true));
+    mf.distribution_mode = int(MixedFilament::Simple);
+    mf.manual_pattern = "12";
+    CHECK_FALSE(mixed_filament_supports_bias_apparent_color(mf, preview, true));
+    mf.manual_pattern.clear();
+    mf.gradient_component_ids = "123";
+    CHECK_FALSE(mixed_filament_supports_bias_apparent_color(mf, preview, true));
+}
+
+TEST_CASE("Mixed filament effective_local_z_preview_mix_b_percent", "[MixedFilament][Display]")
+{
+    MixedFilament mf;
+    mf.mix_b_percent = 50;
+    mf.distribution_mode = int(MixedFilament::Simple);
+    mf.manual_pattern.clear();
+    mf.gradient_component_ids.clear();
+
+    MixedFilamentPreviewSettings preview;
+    preview.local_z_mode = false;
+
+    CHECK(mixed_filament_effective_local_z_preview_mix_b_percent(mf, preview) == 50);
+
+    preview.local_z_mode = true;
+    preview.nominal_layer_height = 0.2;
+    preview.mixed_lower_bound = 0.04;
+    preview.mixed_upper_bound = 0.16;
+    preview.preferred_a_height = 0.0;
+    preview.preferred_b_height = 0.0;
+
+    int local_z_mix = mixed_filament_effective_local_z_preview_mix_b_percent(mf, preview);
+    CHECK(local_z_mix >= 0);
+    CHECK(local_z_mix <= 100);
+
+    // Manual pattern → passthrough
+    mf.manual_pattern = "12";
+    CHECK(mixed_filament_effective_local_z_preview_mix_b_percent(mf, preview) == 50);
+
+    // Pointillisme → passthrough
+    mf.manual_pattern.clear();
+    mf.distribution_mode = int(MixedFilament::SameLayerPointillisme);
+    CHECK(mixed_filament_effective_local_z_preview_mix_b_percent(mf, preview) == 50);
+}
+
+TEST_CASE("Mixed filament compute_mixed_filament_display_color fallback paths", "[MixedFilament][Display]")
+{
+    MixedFilament entry;
+    entry.component_a = 1;
+    entry.component_b = 2;
+    entry.mix_b_percent = 50;
+    entry.distribution_mode = int(MixedFilament::Simple);
+
+    MixedFilamentDisplayContext ctx;
+    ctx.num_physical = 0;
+    CHECK(compute_mixed_filament_display_color(entry, ctx) == "#26A69A");
+
+    ctx.num_physical = 2;
+    ctx.physical_colors = {"#FF0000", "#0000FF"};
+    ctx.preview_settings.nominal_layer_height = 0.2;
+    ctx.preview_settings.wall_loops = 1;
+    ctx.nozzle_diameters = {0.4, 0.4};
+    ctx.component_bias_enabled = false;
+
+    std::string color = compute_mixed_filament_display_color(entry, ctx);
+    CHECK(!color.empty());
+    CHECK(color[0] == '#');
+
+    // Out of range component → fallback
+    MixedFilament bad;
+    bad.component_a = 0;
+    bad.component_b = 2;
+    bad.mix_b_percent = 50;
+    bad.distribution_mode = int(MixedFilament::Simple);
+    CHECK(compute_mixed_filament_display_color(bad, ctx) == "#26A69A");
+}
+
+// ============================================================================
+// [MixedFilament][Display] — Remaining display helpers
+// ============================================================================
+
+TEST_CASE("Mixed filament set_display_context auto-corrects and refreshes", "[MixedFilament][Display]")
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00", "#0000FF"};
+    MixedFilamentManager mgr;
+    mgr.add_custom_filament(1, 2, 50, colors);
+
+    MixedFilamentDisplayContext ctx;
+    ctx.num_physical = 0;
+    ctx.physical_colors = colors;
+    ctx.preview_settings.wall_loops = 0;
+    ctx.preview_settings.nominal_layer_height = 0.2;
+    // nozzle_diameters left empty
+
+    mgr.set_display_context(ctx);
+
+    // After set_display_context, num_physical should be corrected to colors.size()
+    auto display = mgr.display_colors();
+    CHECK(display.size() >= 1);
+
+    // total_filaments should reflect correct num_physical
+    CHECK(mgr.total_filaments(3) == 3 + mgr.enabled_count());
+}
+
+TEST_CASE("Mixed filament apparent pair percentages bias on vs off", "[MixedFilament][Display]")
+{
+    MixedFilament mf;
+    mf.component_a = 1;
+    mf.component_b = 2;
+    mf.mix_b_percent = 50;
+    mf.distribution_mode = int(MixedFilament::Simple);
+    mf.component_a_surface_offset = 0.f;
+    mf.component_b_surface_offset = 0.05f;
+    mf.manual_pattern.clear();
+    mf.gradient_component_ids.clear();
+    mf.gradient_enabled = false;
+
+    MixedFilamentPreviewSettings preview;
+    preview.local_z_mode = false;
+    preview.nominal_layer_height = 0.2;
+    preview.mixed_lower_bound = 0.04;
+    preview.mixed_upper_bound = 0.16;
+
+    const std::vector<double> nozzles = {0.4, 0.6};
+
+    // Bias off: returns (100-base, base)
+    auto [pct_a_off, pct_b_off] = mixed_filament_apparent_pair_percentages(mf, preview, nozzles, false);
+    CHECK(pct_a_off == 50);
+    CHECK(pct_b_off == 50);
+
+    // Bias on: apparent percents shift due to surface offset
+    auto [pct_a_on, pct_b_on] = mixed_filament_apparent_pair_percentages(mf, preview, nozzles, true);
+    CHECK(pct_a_on + pct_b_on == 100);
+    // With positive B offset (0.05mm), B's apparent percent should decrease
+    CHECK(pct_b_on < pct_b_off);
 }


### PR DESCRIPTION

### Summary

This change adds ~1000 lines of unit tests for the mixed filament feature, completes dark mode color adaptation across related UI components, includes multiple UI refinements, and fixes a paint transfer bug during filament deletion.

### Changes

#### Tests
- Exposed `MixedFilamentManager` internal static functions as public methods (`safe_mod`, `normalize_ratio_pair`, `canonical_signed_bias_value`, `format_surface_offset_token`) for testability
- Added Utility tests: negative modulo wrapping, ratio normalization edge cases, continuous layer range fill, signed bias extraction, token formatting with trailing-zero stripping, max offset clamping
- Added Pattern tests: bracket notation acceptance (`[10]`, `[99]`) and overflow rejection (`[100]`, `[9999]`)
- Replaced `Approx` with `WithinAbs` / `WithinRel` matchers for deterministic floating-point assertions across CI environments
- Enabled `auto_generate` by default in test environment via static initializer to match production behavior

#### Dark Mode
- Replaced all hardcoded color literals with `StateColor::darkModeColorFor()` across `MixedFilamentDialog`, `Plater` sidebar, and `MixedFilamentBadge`
- Added new color entries in `StateColor`

#### UI Refinements
- Changed `MixedFilamentBadge` base class from `wxButton` to `wxPanel` with `on_left_up` mouse handler
- Card max-width constrained to 325px with centered horizontal layout
- Title font changed from `Head_14` to `Body_14`
- Slider track corner radius reduced from 8px to 2px
- Dynamic spacer management for ratio card gradient bar and triangle picker

#### Bug Fix
- Fixed paint transfer being incorrectly overwritten when `replace_filament_id >= 0` during filament deletion: skip the generic remap so paint moves to the replacement filament instead of being lost

### Scope
`MixedFilamentDialog` `Plater` `MixedFilamentBadge` `MixedFilamentManager` `StateColor` `PresetBundle` `tests`