### PR TITLE
fix: resolve dithering_local_z_mode state inconsistencies across preset operations

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -905,7 +905,9 @@ static std::vector<std::string> s_Preset_print_options {
      "hole_to_polyhole", "hole_to_polyhole_threshold", "hole_to_polyhole_twisted", "mmu_segmented_region_max_width", "mmu_segmented_region_interlocking_depth",
      "small_area_infill_flow_compensation", "small_area_infill_flow_compensation_model",
      "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold", "scarf_joint_speed", "scarf_joint_flow_ratio", "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length", "seam_slope_steps", "seam_slope_inner_walls", "scarf_overhang_threshold",
-     "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width","calib_flowrate_topinfill_special_order",
+     "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width",
+     "dithering_local_z_mode",
+     "calib_flowrate_topinfill_special_order",
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6241,8 +6241,6 @@ void Sidebar::update_mixed_filament_panel(bool sync_manager)
         if (print_cfg) {
             if (ConfigOptionFloat *opt = print_cfg->option<ConfigOptionFloat>(key))
                 opt->value = value;
-            else
-                print_cfg->set_key_value(key, new ConfigOptionFloat(value));
         }
         if (ConfigOptionFloat *opt = preset_bundle->project_config.option<ConfigOptionFloat>(key))
             opt->value = value;
@@ -6253,8 +6251,6 @@ void Sidebar::update_mixed_filament_panel(bool sync_manager)
         if (print_cfg) {
             if (ConfigOptionString *opt = print_cfg->option<ConfigOptionString>(key))
                 opt->value = value;
-            else
-                print_cfg->set_key_value(key, new ConfigOptionString(value));
         }
         if (ConfigOptionString *opt = preset_bundle->project_config.option<ConfigOptionString>(key))
             opt->value = value;
@@ -6267,8 +6263,6 @@ void Sidebar::update_mixed_filament_panel(bool sync_manager)
                 opt->value = value;
             else if (ConfigOptionInt *opt = print_cfg->option<ConfigOptionInt>(key))
                 opt->value = value ? 1 : 0;
-            else
-                print_cfg->set_key_value(key, new ConfigOptionBool(value));
         }
         if (ConfigOptionBool *opt = preset_bundle->project_config.option<ConfigOptionBool>(key))
             opt->value = value;
@@ -6283,8 +6277,6 @@ void Sidebar::update_mixed_filament_panel(bool sync_manager)
                 opt->value = enabled;
             else if (ConfigOptionInt *opt = print_cfg->option<ConfigOptionInt>("mixed_filament_gradient_mode"))
                 opt->value = enabled ? 1 : 0;
-            else
-                print_cfg->set_key_value("mixed_filament_gradient_mode", new ConfigOptionBool(enabled));
         }
         if (ConfigOptionBool *opt = preset_bundle->project_config.option<ConfigOptionBool>("mixed_filament_gradient_mode"))
             opt->value = enabled;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1556,50 +1556,6 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
         update_wiping_button_visibility();
     }
 
-    if (opt_key == "dithering_local_z_mode") {
-        const bool local_z_enabled = boost::any_cast<bool>(value);
-        if (local_z_enabled &&
-            (!m_config->has("mixed_filament_region_collapse") ||
-             m_config->option("mixed_filament_region_collapse") == nullptr ||
-             m_config->opt_bool("mixed_filament_region_collapse"))) {
-            change_opt_value(*m_config, "mixed_filament_region_collapse", boost::any(false));
-            if (m_type == Preset::TYPE_PRINT) {
-                DynamicPrintConfig &project_cfg = wxGetApp().preset_bundle->project_config;
-                project_cfg.set_key_value("mixed_filament_region_collapse", new ConfigOptionBool(false));
-            }
-            if (Field *field = this->get_field("mixed_filament_region_collapse"))
-                field->set_value(boost::any(false), false);
-            update_dirty();
-        }
-        if (!local_z_enabled &&
-            m_config->has("dithering_local_z_whole_objects") &&
-            m_config->option("dithering_local_z_whole_objects") != nullptr &&
-            m_config->opt_bool("dithering_local_z_whole_objects")) {
-            change_opt_value(*m_config, "dithering_local_z_whole_objects", boost::any(false));
-            if (m_type == Preset::TYPE_PRINT) {
-                DynamicPrintConfig &project_cfg = wxGetApp().preset_bundle->project_config;
-                project_cfg.set_key_value("dithering_local_z_whole_objects", new ConfigOptionBool(false));
-            }
-            if (Field *field = this->get_field("dithering_local_z_whole_objects"))
-                field->set_value(boost::any(false), false);
-            update_dirty();
-        }
-        if (!local_z_enabled &&
-            m_config->has("dithering_local_z_direct_multicolor") &&
-            m_config->option("dithering_local_z_direct_multicolor") != nullptr &&
-            m_config->opt_bool("dithering_local_z_direct_multicolor")) {
-            change_opt_value(*m_config, "dithering_local_z_direct_multicolor", boost::any(false));
-            if (m_type == Preset::TYPE_PRINT) {
-                DynamicPrintConfig &project_cfg = wxGetApp().preset_bundle->project_config;
-                project_cfg.set_key_value("dithering_local_z_direct_multicolor", new ConfigOptionBool(false));
-            }
-            if (Field *field = this->get_field("dithering_local_z_direct_multicolor"))
-                field->set_value(boost::any(false), false);
-            update_dirty();
-        }
-    }
-
-
     if (opt_key == "single_extruder_multi_material"  ){
         const auto bSEMM = m_config->opt_bool("single_extruder_multi_material");
         wxGetApp().sidebar().show_SEMM_buttons(bSEMM);
@@ -5215,6 +5171,11 @@ void Tab::load_current_preset()
 
     // Reload preset pages with the new configuration values.
     reload_config();
+
+    // Refresh field decorations (orange/modified markers) after reload.
+    // Without this, stale decorations from a previous dirty state persist
+    // even after discard_current_changes() resets the config.
+    update_changed_ui();
 
     update_ui_items_related_on_parent_preset(m_presets->get_selected_preset_parent());
 

--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -1686,18 +1686,28 @@ void UnsavedChangesDialog::update_tree(Preset::Type type, PresetCollection* pres
         for (const std::string& opt_key : dirty_options) {
             const Search::Option& option = searcher.get_option(opt_key, type);
             if (option.opt_key() != opt_key) {
-                // When founded option isn't the correct one.
-                // It can be for dirty_options: "default_print_profile", "printer_model", "printer_settings_id",
-                // because of they don't exist in searcher
+                // Only show the fallback for user-facing option types
+                // (bool/float/int/enum). Internal keys like IDs and
+                // serialized blobs are coString — skip those silently.
+                const ConfigOption* o = old_config.option(opt_key);
+                if (!o) o = new_config.option(opt_key);
+                if (!o || o->type() == coString || o->type() == coStrings)
+                    continue;
+                wxString label = from_u8(opt_key);
+                if (old_config.def()) {
+                    const ConfigOptionDef* def = old_config.def()->get(opt_key);
+                    if (def && !def->label.empty())
+                        label = def->label;
+                }
+                PresetItem pi = {type, opt_key,
+                    _L("Other"), wxEmptyString,
+                    label,
+                    get_string_value(opt_key, old_config),
+                    get_string_value(opt_key, new_config)};
+                m_presetitems.push_back(pi);
                 continue;
             }
 
-            /*m_tree->Append(opt_key, type, option.category_local, option.group_local, option.label_local,
-                get_string_value(opt_key, old_config), get_string_value(opt_key, new_config), category_icon_map.at(option.category));*/
-
-
-            //PresetItem pi = {opt_key, type, 1983};
-            //m_presetitems.push_back()
             PresetItem pi = {type, opt_key, option.category_local, option.group_local, option.label_local, get_string_value(opt_key, old_config), get_string_value(opt_key, new_config)};
             m_presetitems.push_back(pi);
 


### PR DESCRIPTION
Description
Add dithering_local_z_mode to s_Preset_print_options so it is stored in the print preset config. This ensures the UI reads the correct value on 3MF import, and the existing preset->project_config sync in load_current_presets() handles discard/new-project flows.