### PR TITLE
fix: skip re-slicing on tab switch when cached result is still valid

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12655,7 +12655,8 @@ void Plater::priv::set_current_panel(wxPanel* panel, bool no_slice)
 
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": from set_current_panel, no_slice %1%, export_in_progress %2%, model_fits %3%, m_is_slicing %4%")%no_slice%export_in_progress%model_fits%m_is_slicing;
 
-            if (!no_slice && !this->model.objects.empty() && !export_in_progress && model_fits && current_has_print_instances)
+            if (!no_slice && !this->model.objects.empty() && !export_in_progress && model_fits && current_has_print_instances
+                && !current_plate->is_slice_result_valid())
             {
                 //if already running in background, not relice here
                 //BBS: add more judge for slicing


### PR DESCRIPTION
# Description
When switching from Prepare back to Preview tab with MMU-painted models
in same_layer_mode (match pattern), the do_reslice() lambda unconditionally
called reslice() even when is_slice_result_valid() was true. This caused
Print::apply() to re-run and, for same_layer_mode with painting extruders,
unconditionally invalidate all objects, triggering a full re-slice.

