### PR TITLE
fix: extend gradient_component_ids encoding to support filament IDs >= 10

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3738,21 +3738,7 @@ static std::vector<unsigned int> decode_manual_pattern_sequence_for_gcode(const 
 
 static std::vector<unsigned int> decode_gradient_component_ids_for_gcode(const MixedFilament& mf, size_t num_physical)
 {
-    std::vector<unsigned int> ids;
-    if (mf.gradient_component_ids.empty() || num_physical == 0)
-        return ids;
-    bool seen[10] = { false };
-    ids.reserve(mf.gradient_component_ids.size());
-    for (const char c : mf.gradient_component_ids) {
-        if (c < '1' || c > '9')
-            continue;
-        const unsigned int id = unsigned(c - '0');
-        if (id == 0 || id > num_physical || seen[id])
-            continue;
-        seen[id] = true;
-        ids.emplace_back(id);
-    }
-    return ids;
+    return MixedFilamentManager::decode_gradient_component_ids(mf.gradient_component_ids, num_physical);
 }
 
 static std::vector<int> decode_gradient_component_weights_for_gcode(const MixedFilament& mf, size_t expected_components)

--- a/src/libslic3r/MixedFilament.cpp
+++ b/src/libslic3r/MixedFilament.cpp
@@ -736,39 +736,77 @@ static int mix_percent_from_normalized_pattern(const std::string &pattern)
     return clamp_int(int(std::lround(100.0 * blend_b / double(groups.size()))), 0, 100);
 }
 
-static std::string normalize_gradient_component_ids(const std::string &components)
+std::string MixedFilamentManager::normalize_gradient_component_ids(const std::string &components)
 {
-    std::string normalized;
-    normalized.reserve(components.size());
-    bool seen[10] = { false };
-    for (const char c : components) {
-        if (c < '1' || c > '9')
-            continue;
-        const int idx = c - '0';
-        if (seen[idx])
-            continue;
-        seen[idx] = true;
-        normalized.push_back(c);
-    }
-    return normalized;
+    // Decode (no validation cap during normalization), then re-encode to canonical form.
+    auto ids = decode_gradient_component_ids(components, kMaxPhysicalFilaments);
+    return encode_gradient_component_ids(ids);
 }
 
-static std::vector<unsigned int> decode_gradient_component_ids(const std::string &components, size_t num_physical)
+std::string MixedFilamentManager::encode_gradient_component_ids(const std::vector<unsigned int> &ids)
+{
+    bool extended = false;
+    for (unsigned int id : ids)
+        if (id > 9) { extended = true; break; }
+
+    // Single extended ID: use leading '/' to disambiguate from legacy format
+    if (extended && ids.size() == 1)
+        return "/" + std::to_string(ids[0]);
+
+    std::string out;
+    for (size_t i = 0; i < ids.size(); ++i) {
+        if (i > 0 && extended) out.push_back('/');
+        if (extended)
+            out.append(std::to_string(ids[i]));
+        else
+            out.push_back(char('0' + ids[i]));
+    }
+    return out;
+}
+
+std::vector<unsigned int> MixedFilamentManager::decode_gradient_component_ids(const std::string &components,
+                                                                               size_t             num_physical)
 {
     std::vector<unsigned int> ids;
-    if (components.empty() || num_physical == 0)
+    if (components.empty())
         return ids;
 
-    bool seen[10] = { false };
+    const bool validate = (num_physical > 0);
+    std::unordered_set<unsigned int> seen;
     ids.reserve(components.size());
-    for (const char c : components) {
-        if (c < '1' || c > '9')
-            continue;
-        const unsigned int id = unsigned(c - '0');
-        if (id == 0 || id > num_physical || seen[id])
-            continue;
-        seen[id] = true;
-        ids.emplace_back(id);
+
+    // Extended format: /-separated decimal IDs
+    if (components.find('/') != std::string::npos) {
+        std::string token;
+        for (const char c : components) {
+            if (c == '/') {
+                if (!token.empty()) {
+                    const unsigned int id = unsigned(std::strtoul(token.c_str(), nullptr, 10));
+                    if (id >= 1 && (!validate || id <= num_physical) && seen.insert(id).second)
+                        ids.emplace_back(id);
+                    token.clear();
+                }
+            } else {
+                token.push_back(c);
+            }
+        }
+        if (!token.empty()) {
+            const unsigned int id = unsigned(std::strtoul(token.c_str(), nullptr, 10));
+            if (id >= 1 && (!validate || id <= num_physical) && seen.insert(id).second)
+                ids.emplace_back(id);
+        }
+    } else {
+        // Legacy format: concatenated single-digit chars
+        bool seen_legacy[10] = { false };
+        for (const char c : components) {
+            if (c < '1' || c > '9')
+                continue;
+            const unsigned int id = unsigned(c - '0');
+            if (id == 0 || (validate && id > num_physical) || seen_legacy[id])
+                continue;
+            seen_legacy[id] = true;
+            ids.emplace_back(id);
+        }
     }
     return ids;
 }
@@ -779,7 +817,7 @@ static int normalize_distribution_mode_without_pointillism(int distribution_mode
     if (clamped_mode != int(MixedFilament::SameLayerPointillisme))
         return clamped_mode;
 
-    const size_t gradient_count = decode_gradient_component_ids(gradient_component_ids, 9).size();
+    const size_t gradient_count = MixedFilamentManager::decode_gradient_component_ids(gradient_component_ids, 0).size();
     return gradient_count >= 3 ? int(MixedFilament::LayerCycle) : int(MixedFilament::Simple);
 }
 
@@ -1401,7 +1439,7 @@ int mixed_filament_effective_local_z_preview_mix_b_percent(const MixedFilament  
     if (!normalized_pattern.empty() || mf.distribution_mode == int(MixedFilament::SameLayerPointillisme))
         return std::clamp(mf.mix_b_percent, 0, 100);
 
-    const std::vector<unsigned int> gradient_ids = decode_gradient_component_ids(mf.gradient_component_ids, 9);
+    const std::vector<unsigned int> gradient_ids = MixedFilamentManager::decode_gradient_component_ids(mf.gradient_component_ids, 0);
     if (gradient_ids.size() >= 3)
         return std::clamp(mf.mix_b_percent, 0, 100);
 
@@ -1473,7 +1511,7 @@ bool mixed_filament_supports_bias_apparent_color(const MixedFilament            
         return false;
     if (!MixedFilamentManager::normalize_manual_pattern(mf.manual_pattern).empty())
         return false;
-    if (decode_gradient_component_ids(mf.gradient_component_ids, 9).size() >= 3)
+    if (MixedFilamentManager::decode_gradient_component_ids(mf.gradient_component_ids, 0).size() >= 3)
         return false;
     return mf.component_a >= 1 && mf.component_b >= 1 && mf.component_a != mf.component_b;
 }
@@ -1523,7 +1561,7 @@ std::string compute_mixed_filament_display_color(const MixedFilament &entry, con
     }
 
     if (entry.distribution_mode != int(MixedFilament::Simple)) {
-        const std::vector<unsigned int> gradient_ids = decode_gradient_component_ids(entry.gradient_component_ids, context.num_physical);
+        const std::vector<unsigned int> gradient_ids = MixedFilamentManager::decode_gradient_component_ids(entry.gradient_component_ids, context.num_physical);
         if (gradient_ids.size() >= 3) {
             const std::vector<int> gradient_weights =
                 decode_gradient_component_weights(entry.gradient_component_weights, gradient_ids.size());
@@ -1665,13 +1703,10 @@ void MixedFilamentManager::remove_physical_filament(unsigned int deleted_filamen
 
         // Check gradient components
         bool uses_deleted_in_gradient = false;
-        for (char c : mf.gradient_component_ids) {
-            if (c >= '1' && c <= '9') {
-                unsigned int comp_id = static_cast<unsigned int>(c - '0');
-                if (comp_id == deleted_filament_id) {
-                    uses_deleted_in_gradient = true;
-                    break;
-                }
+        for (unsigned int comp_id : decode_gradient_component_ids(mf.gradient_component_ids, 0)) {
+            if (comp_id == deleted_filament_id) {
+                uses_deleted_in_gradient = true;
+                break;
             }
         }
         if (uses_deleted_in_gradient)
@@ -1684,19 +1719,13 @@ void MixedFilamentManager::remove_physical_filament(unsigned int deleted_filamen
             --mf.component_b;
 
         // Adjust gradient component IDs
-        std::string adjusted_gradient_ids;
-        for (char c : mf.gradient_component_ids) {
-            if (c >= '1' && c <= '9') {
-                unsigned int comp_id = static_cast<unsigned int>(c - '0');
-                if (comp_id > deleted_filament_id)
-                    adjusted_gradient_ids += char('0' + comp_id - 1);
-                else
-                    adjusted_gradient_ids += c;
-            } else {
-                adjusted_gradient_ids += c;
-            }
+        {
+            auto decoded = decode_gradient_component_ids(mf.gradient_component_ids, 0);
+            for (unsigned int &id : decoded)
+                if (id > deleted_filament_id)
+                    --id;
+            mf.gradient_component_ids = encode_gradient_component_ids(decoded);
         }
-        mf.gradient_component_ids = adjusted_gradient_ids;
 
         filtered.emplace_back(std::move(mf));
     }
@@ -1859,7 +1888,7 @@ std::string MixedFilamentManager::serialize_custom_entries()
         disable_pointillism_mode(mf);
         mf.stable_id = normalize_stable_id(mf.stable_id);
         const std::string normalized_ids = normalize_gradient_component_ids(mf.gradient_component_ids);
-        const std::string normalized_weights = normalize_gradient_component_weights(mf.gradient_component_weights, normalized_ids.size());
+        const std::string normalized_weights = normalize_gradient_component_weights(mf.gradient_component_weights, decode_gradient_component_ids(normalized_ids, 0).size());
         ss << mf.component_a << ','
            << mf.component_b << ','
            << (mf.enabled ? 1 : 0) << ','
@@ -2002,7 +2031,7 @@ void MixedFilamentManager::load_custom_entries(const std::string &serialized, co
             mf.pointillism_all_filaments = pointillism_all_filaments;
             mf.gradient_component_ids = normalize_gradient_component_ids(gradient_component_ids);
             mf.gradient_component_weights =
-                normalize_gradient_component_weights(gradient_component_weights, mf.gradient_component_ids.size());
+                normalize_gradient_component_weights(gradient_component_weights, decode_gradient_component_ids(mf.gradient_component_ids, 0).size());
             mf.manual_pattern = normalize_manual_pattern(manual_pattern);
             mf.distribution_mode = clamp_int(distribution_mode, int(MixedFilament::LayerCycle), int(MixedFilament::Simple));
             mf.local_z_max_sublayers = std::max(0, local_z_max_sublayers);
@@ -2035,7 +2064,7 @@ void MixedFilamentManager::load_custom_entries(const std::string &serialized, co
         mf.pointillism_all_filaments = pointillism_all_filaments;
         mf.gradient_component_ids = normalize_gradient_component_ids(gradient_component_ids);
         mf.gradient_component_weights =
-            normalize_gradient_component_weights(gradient_component_weights, mf.gradient_component_ids.size());
+            normalize_gradient_component_weights(gradient_component_weights, decode_gradient_component_ids(mf.gradient_component_ids, 0).size());
         mf.manual_pattern = normalize_manual_pattern(manual_pattern);
         mf.distribution_mode = clamp_int(distribution_mode, int(MixedFilament::LayerCycle), int(MixedFilament::Simple));
         mf.local_z_max_sublayers = std::max(0, local_z_max_sublayers);
@@ -2347,13 +2376,10 @@ std::vector<size_t> MixedFilamentManager::mixed_filaments_using_physical(unsigne
         
         // Check gradient components
         if (!depends_on_physical) {
-            for (char c : mf.gradient_component_ids) {
-                if (c >= '1' && c <= '9') {
-                    unsigned int comp_id = static_cast<unsigned int>(c - '0');
-                    if (comp_id == physical_filament_1based) {
-                        depends_on_physical = true;
-                        break;
-                    }
+            for (unsigned int comp_id : decode_gradient_component_ids(mf.gradient_component_ids, 0)) {
+                if (comp_id == physical_filament_1based) {
+                    depends_on_physical = true;
+                    break;
                 }
             }
         }

--- a/src/libslic3r/MixedFilament.hpp
+++ b/src/libslic3r/MixedFilament.hpp
@@ -233,6 +233,27 @@ public:
     // Split a normalized pattern string by comma into group strings.
     static std::vector<std::string> split_pattern_groups(const std::string &pattern);
 
+    // ---- Gradient component ID encoding / decoding ------------------------
+
+    // Maximum number of physical filaments supported by the encoding.
+    static constexpr size_t kMaxPhysicalFilaments = 64;
+
+    // Encode filament IDs (1-based) to a compact string.
+    // Legacy format (all IDs ≤ 9):  concatenated single chars, e.g. "132".
+    // Extended format (any ID > 9): '/' separated decimals, e.g. "1/12/3".
+    // Single-ID extended uses leading '/' to disambiguate, e.g. "/12".
+    static std::string encode_gradient_component_ids(const std::vector<unsigned int> &ids);
+
+    // Decode a gradient_component_ids string to a vector of filament IDs (1-based).
+    // Handles both legacy and extended formats.  When num_physical > 0 each ID is
+    // validated to be ≤ num_physical.
+    static std::vector<unsigned int> decode_gradient_component_ids(const std::string &components,
+                                                                   size_t             num_physical = 0);
+
+    // Normalize a gradient_component_ids string to canonical form.
+    // Canonical form uses legacy encoding when all IDs ≤ 9, extended otherwise.
+    static std::string normalize_gradient_component_ids(const std::string &components);
+
     // ---- Queries --------------------------------------------------------
 
     // True when `filament_id` (1-based) refers to a mixed filament.
@@ -361,10 +382,30 @@ private:
 // that can be rendered as a vertical color ramp (no manual pattern, exactly 2 components).
 inline bool is_simple_gradient(const MixedFilament& mf)
 {
+    // Lightweight ID count without heap allocation.
+    // Canonical form: legacy "12" = two IDs, extended "1/12/3" = three IDs.
+    auto count_ids = [](const std::string& s) -> size_t {
+        if (s.empty()) return 0;
+        if (s.find('/') != std::string::npos) {
+            size_t n = 0;
+            bool in_token = false;
+            for (char c : s) {
+                if (c == '/') {
+                    if (in_token) ++n;
+                    in_token = false;
+                } else {
+                    in_token = true;
+                }
+            }
+            if (in_token) ++n;
+            return n;
+        }
+        return s.size();
+    };
     return mf.gradient_enabled
         && mf.component_a != mf.component_b
         && MixedFilamentManager::normalize_manual_pattern(mf.manual_pattern).empty()
-        && mf.gradient_component_ids.size() < 3;
+        && count_ids(mf.gradient_component_ids) < 3;
 }
 
 } // namespace Slic3r

--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -1160,11 +1160,8 @@ static void append_mixed_component_extruders(const MixedFilamentManager &mixed_m
     append_unique_painted_extruder(painting_extruders, mixed_row->component_a, num_physical_extruders);
     append_unique_painted_extruder(painting_extruders, mixed_row->component_b, num_physical_extruders);
 
-    for (char token : mixed_row->gradient_component_ids) {
-        if (token < '1' || token > '9')
-            continue;
-        append_unique_painted_extruder(painting_extruders, unsigned(token - '0'), num_physical_extruders);
-    }
+    for (unsigned int id : MixedFilamentManager::decode_gradient_component_ids(mixed_row->gradient_component_ids, num_physical_extruders))
+        append_unique_painted_extruder(painting_extruders, id, num_physical_extruders);
 
     {
         const std::string flattened = MixedFilamentManager::normalize_manual_pattern(mixed_row->manual_pattern);

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -9,9 +9,7 @@
 #include <limits>
 #include <numeric>
 #include <sstream>
-
 #include <tbb/parallel_for.h>
-
 #include "ClipperUtils.hpp"
 #include "ElephantFootCompensation.hpp"
 #include "I18N.hpp"
@@ -1591,22 +1589,7 @@ static std::vector<unsigned int> decode_manual_pattern_sequence(const MixedFilam
 
 static std::vector<unsigned int> decode_gradient_component_ids(const MixedFilament &mf, size_t num_physical)
 {
-    std::vector<unsigned int> ids;
-    if (mf.gradient_component_ids.empty() || num_physical == 0)
-        return ids;
-
-    bool seen[10] = { false };
-    ids.reserve(mf.gradient_component_ids.size());
-    for (const char c : mf.gradient_component_ids) {
-        if (c < '1' || c > '9')
-            continue;
-        const unsigned int id = unsigned(c - '0');
-        if (id == 0 || id > num_physical || seen[id])
-            continue;
-        seen[id] = true;
-        ids.emplace_back(id);
-    }
-    return ids;
+    return MixedFilamentManager::decode_gradient_component_ids(mf.gradient_component_ids, num_physical);
 }
 
 static std::vector<int> decode_gradient_component_weights(const MixedFilament &mf, size_t expected_components)

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -106,7 +106,7 @@ std::vector<int> expand_color_match_recipe_weights(const MixedColorMatchRecipeRe
         return weights;
 
     if (!recipe.gradient_component_ids.empty()) {
-        const std::vector<unsigned int> ids = decode_color_match_gradient_ids(recipe.gradient_component_ids);
+        const std::vector<unsigned int> ids = MixedFilamentManager::decode_gradient_component_ids(recipe.gradient_component_ids);
         const std::vector<int>          raw_weights =
             normalize_color_match_weights(decode_color_match_gradient_weights(recipe.gradient_component_weights, ids.size()), ids.size());
         if (ids.size() != raw_weights.size())
@@ -133,7 +133,7 @@ std::string summarize_color_match_recipe(const MixedColorMatchRecipeResult& reci
     std::vector<unsigned int> ids;
     std::vector<int>          weights;
     if (!recipe.gradient_component_ids.empty()) {
-        ids     = decode_color_match_gradient_ids(recipe.gradient_component_ids);
+        ids     = MixedFilamentManager::decode_gradient_component_ids(recipe.gradient_component_ids);
         weights = normalize_color_match_weights(decode_color_match_gradient_weights(recipe.gradient_component_weights, ids.size()),
                                                 ids.size());
     } else {
@@ -373,21 +373,9 @@ MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std:
     // Helper: encode filament IDs as gradient_component_ids string.
     // Legacy format (all IDs ≤ 9): concatenated single chars, e.g. "123".
     // Extended format (any ID > 9): '/' separated decimals, e.g. "1/12/3".
+    // Single-ID extended format uses leading '/' to disambiguate from legacy: "/12".
     auto encode_gradient_ids = [](const std::vector<unsigned int>& ids) -> std::string {
-        bool extended = false;
-        for (unsigned int id : ids)
-            if (id > 9) { extended = true; break; }
-        std::ostringstream ss;
-        for (size_t i = 0; i < ids.size(); ++i) {
-            if (i > 0) {
-                if (extended) ss << '/';
-            }
-            if (extended)
-                ss << ids[i];
-            else
-                ss << char('0' + ids[i]);
-        }
-        return ss.str();
+        return MixedFilamentManager::encode_gradient_component_ids(ids);
     };
 
     auto encode_gradient_weights = [](const std::vector<int>& weights) -> std::string {
@@ -666,42 +654,6 @@ wxColour compute_color_match_recipe_display_color(const MixedColorMatchRecipeRes
     return parse_mixed_color(compute_mixed_filament_display_color(entry, context));
 }
 
-std::vector<unsigned int> decode_color_match_gradient_ids(const std::string& value)
-{
-    std::vector<unsigned int> ids;
-    std::unordered_set<unsigned int> seen;
-    // Detect format: if contains '/' → extended (ID/ID/...), else legacy (concatenated chars)
-    if (value.find('/') != std::string::npos) {
-        std::string token;
-        for (const char ch : value) {
-            if (ch == '/') {
-                if (!token.empty()) {
-                    const unsigned int id = unsigned(std::strtoul(token.c_str(), nullptr, 10));
-                    if (id > 0 && seen.insert(id).second)
-                        ids.emplace_back(id);
-                    token.clear();
-                }
-            } else {
-                token.push_back(ch);
-            }
-        }
-        if (!token.empty()) {
-            const unsigned int id = unsigned(std::strtoul(token.c_str(), nullptr, 10));
-            if (id > 0 && seen.insert(id).second)
-                ids.emplace_back(id);
-        }
-    } else {
-        // Legacy format: concatenated single chars '1'-'9'
-        for (const char ch : value) {
-            if (ch < '1' || ch > '9') continue;
-            const unsigned int id = unsigned(ch - '0');
-            if (seen.insert(id).second)
-                ids.emplace_back(id);
-        }
-    }
-    return ids;
-}
-
 std::vector<int> decode_color_match_gradient_weights(const std::string& value, size_t expected_components)
 {
     std::vector<int> weights;
@@ -796,20 +748,7 @@ MixedColorMatchRecipeResult build_multi_color_match_candidate(const std::vector<
     candidate.mix_b_percent     = pair_weight_total > 0 ?
                                       std::clamp(int(std::lround(100.0 * double(ordered_weights[1]) / double(pair_weight_total))), 0, 100) :
                                       50;
-    {
-        bool extended = false;
-        for (unsigned int fid : ordered_ids)
-            if (fid > 9) { extended = true; break; }
-        std::ostringstream gid_ss;
-        for (size_t i = 0; i < ordered_ids.size(); ++i) {
-            if (i > 0 && extended) gid_ss << '/';
-            if (extended)
-                gid_ss << ordered_ids[i];
-            else
-                gid_ss << char('0' + ordered_ids[i]);
-        }
-        candidate.gradient_component_ids = gid_ss.str();
-    }
+    candidate.gradient_component_ids = MixedFilamentManager::encode_gradient_component_ids(ordered_ids);
     {
         std::ostringstream weights_ss;
         for (size_t weight_idx = 0; weight_idx < ordered_weights.size(); ++weight_idx) {
@@ -1183,7 +1122,7 @@ bool is_filament_compatible(const MixedFilament& mf)
         if (mf.component_a >= 1) fids.push_back(mf.component_a - 1);
         if (mf.component_b >= 1) fids.push_back(mf.component_b - 1);
         if (!mf.gradient_component_ids.empty()) {
-            for (unsigned int fid : decode_color_match_gradient_ids(mf.gradient_component_ids))
+            for (unsigned int fid : MixedFilamentManager::decode_gradient_component_ids(mf.gradient_component_ids))
                 if (fid >= 1) fids.push_back(fid - 1);
         }
     }

--- a/src/slic3r/GUI/MixedColorMatchHelpers.hpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.hpp
@@ -100,7 +100,6 @@ wxColour compute_color_match_recipe_display_color(
     const MixedColorMatchRecipeResult  &recipe,
     const MixedFilamentDisplayContext  &context);
 
-std::vector<unsigned int> decode_color_match_gradient_ids(const std::string& value);
 std::vector<int>          decode_color_match_gradient_weights(const std::string& value, size_t expected_components);
 MixedColorMatchRecipeResult build_pair_color_match_candidate(const std::vector<wxColour>& palette,
                                                              unsigned int                 component_a,

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -25,6 +25,7 @@
 #include <numeric>
 #include <utility>
 #include <set>
+#include <sstream>
 
 namespace Slic3r { namespace GUI {
 
@@ -1646,21 +1647,22 @@ void MixedFilamentDialog::rebuild_filament_rows()
     const int max_idx = std::max(0, (int)m_filament_colours.size() - 1);
     std::vector<int> sels;
 
+    // Decode gradient_component_ids (supports both legacy single-char and extended /-separated formats)
+    std::vector<unsigned int> decoded_ids = MixedFilamentManager::decode_gradient_component_ids(m_result.gradient_component_ids);
+
     // Detect "all-ids" format (match recipe): gradient_component_ids contains
     // component_a as its first entry, meaning all filaments are listed there.
-    const std::string &ids = m_result.gradient_component_ids;
-    const bool all_ids_format = !ids.empty() &&
-        (ids[0] - '0') == (int)m_result.component_a;
+    const bool all_ids_format = !decoded_ids.empty() &&
+        decoded_ids[0] == m_result.component_a;
 
     if (all_ids_format) {
-        for (char c : ids)
-            sels.push_back(std::clamp(int(c - '1'), 0, max_idx));
+        for (unsigned int id : decoded_ids)
+            sels.push_back(std::clamp(int(id - 1), 0, max_idx));
     } else {
         sels.push_back(std::clamp((int)m_result.component_a - 1, 0, max_idx));
         sels.push_back(std::clamp((int)m_result.component_b - 1, 0, max_idx));
-        for (char c : ids) {
-            int idx = c - '1';
-            sels.push_back(std::clamp(idx, 0, max_idx));
+        for (unsigned int id : decoded_ids) {
+            sels.push_back(std::clamp(int(id - 1), 0, max_idx));
         }
     }
 
@@ -2100,31 +2102,35 @@ void MixedFilamentDialog::resize_gradient_ids(int target_count)
 {
     int extra = target_count - 2;
     if (extra <= 0) { m_result.gradient_component_ids.clear(); return; }
-    std::string ids = m_result.gradient_component_ids;
-    
-    // Build set of already used filament indices
-    std::set<int> used;
-    used.insert((int)m_result.component_a - 1);
-    used.insert((int)m_result.component_b - 1);
-    for (char c : ids) {
-        used.insert(c - '1');
-    }
-    
+
+    // Decode existing gradient IDs
+    std::vector<unsigned int> ids = MixedFilamentManager::decode_gradient_component_ids(m_result.gradient_component_ids);
+
+    // Build set of already used filament IDs (1-based)
+    std::set<unsigned int> used;
+    used.insert(m_result.component_a);
+    used.insert(m_result.component_b);
+    for (unsigned int id : ids)
+        used.insert(id);
+
     // Find unused filaments for new slots
     while ((int)ids.size() < extra) {
-        int new_filament = 0;
+        unsigned int new_filament = 0;
         for (int j = 0; j < (int)m_filament_colours.size(); ++j) {
-            if (used.find(j) == used.end()) {
-                new_filament = j;
-                used.insert(j);
+            unsigned int fid = (unsigned int)(j + 1);
+            if (used.find(fid) == used.end()) {
+                new_filament = fid;
+                used.insert(fid);
                 break;
             }
         }
-        if (new_filament >= 0 && new_filament <= 8)
-            ids += char('1' + new_filament);
+        if (new_filament >= 1)
+            ids.push_back(new_filament);
+        else
+            break;  // No unused filament available, stop filling
     }
     ids.resize((size_t)extra);
-    m_result.gradient_component_ids = ids;
+    m_result.gradient_component_ids = MixedFilamentManager::encode_gradient_component_ids(ids);
 }
 
 void MixedFilamentDialog::sync_rows_to_result()
@@ -2134,13 +2140,13 @@ void MixedFilamentDialog::sync_rows_to_result()
     int b = (m_filament_rows.size() > 1) ? get_filament_index(1) : a;
     m_result.component_a = (unsigned int)(std::max(0, a) + 1);
     m_result.component_b = (unsigned int)(std::max(0, b) + 1);
-    std::string ids;
+    std::vector<unsigned int> extra_ids;
     for (int i = 2; i < (int)m_filament_rows.size(); ++i) {
         int s = get_filament_index(i);
-        if (s >= 0 && s <= 8)
-            ids += char('1' + s);
+        if (s >= 0)
+            extra_ids.push_back((unsigned int)(s + 1));
     }
-    m_result.gradient_component_ids = ids;
+    m_result.gradient_component_ids = MixedFilamentManager::encode_gradient_component_ids(extra_ids);
 }
 
 void MixedFilamentDialog::update_compatibility_warning()
@@ -2157,9 +2163,8 @@ void MixedFilamentDialog::update_compatibility_warning()
             if (recipe.component_a >= 1) fids.push_back(recipe.component_a - 1);
             if (recipe.component_b >= 1) fids.push_back(recipe.component_b - 1);
             if (!recipe.gradient_component_ids.empty()) {
-                for (char c : recipe.gradient_component_ids) {
-                    int idx = c - '1';
-                    if (idx >= 0 && idx <= 8) fids.push_back(static_cast<unsigned int>(idx));
+                for (unsigned int id : MixedFilamentManager::decode_gradient_component_ids(recipe.gradient_component_ids)) {
+                    if (id >= 1) fids.push_back(id - 1);
                 }
             }
         } else {
@@ -2181,9 +2186,8 @@ void MixedFilamentDialog::update_compatibility_warning()
         if (m_result.component_a >= 1) fids.push_back(m_result.component_a - 1);
         if (m_result.component_b >= 1) fids.push_back(m_result.component_b - 1);
         if (!m_result.gradient_component_ids.empty()) {
-            for (char c : m_result.gradient_component_ids) {
-                int idx = c - '1';
-                if (idx >= 0 && idx <= 8) fids.push_back(static_cast<unsigned int>(idx));
+            for (unsigned int id : MixedFilamentManager::decode_gradient_component_ids(m_result.gradient_component_ids)) {
+                if (id >= 1) fids.push_back(id - 1);
             }
         }
     }
@@ -2669,7 +2673,7 @@ void MixedFilamentDialog::build_swatch_grid()
             Candidate c;
             c.color   = preset.preview_color;
             c.tooltip = from_u8(summarize_color_match_recipe(preset));
-            auto decoded = decode_color_match_gradient_ids(preset.gradient_component_ids);
+            auto decoded = MixedFilamentManager::decode_gradient_component_ids(preset.gradient_component_ids);
             if (decoded.size() >= 2) {
                 c.rows[0] = (int)decoded[0] - 1; c.rows[1] = (int)decoded[1] - 1;
                 c.n_rows = 2; c.b_pct = preset.mix_b_percent;
@@ -2854,12 +2858,13 @@ void MixedFilamentDialog::on_mode_changed(int mode_index)
         m_match_tri_indices.clear();
         m_match_tri_weights.clear();
         // Restore saved data if editing, otherwise use default 2:1:1
-        if (!m_result.gradient_component_ids.empty() && m_result.gradient_component_ids.size() >= 3) {
+        auto saved_ids = MixedFilamentManager::decode_gradient_component_ids(m_result.gradient_component_ids);
+        if (saved_ids.size() >= 3) {
             // Restore from saved match data
-            for (char c : m_result.gradient_component_ids) {
-                int id = c - '1';
-                if (id >= 0 && id < num_physical)
-                    m_match_tri_indices.push_back(id);
+            for (unsigned int id : saved_ids) {
+                int idx = int(id - 1);
+                if (idx >= 0 && idx < num_physical)
+                    m_match_tri_indices.push_back(idx);
             }
             if (m_match_tri_indices.size() >= 3) {
                 auto w = decode_color_match_gradient_weights(m_result.gradient_component_weights, (int)m_match_tri_indices.size());
@@ -2870,12 +2875,12 @@ void MixedFilamentDialog::on_mode_changed(int mode_index)
                 }
                 m_match_tri_weights = {m_match_tri_wx, m_match_tri_wy, m_match_tri_wz};
             }
-        } else if (!m_result.gradient_component_ids.empty() && m_result.gradient_component_ids.size() == 2) {
+        } else if (saved_ids.size() == 2) {
             // 2-color saved match
-            for (char c : m_result.gradient_component_ids) {
-                int id = c - '1';
-                if (id >= 0 && id < num_physical)
-                    m_match_tri_indices.push_back(id);
+            for (unsigned int id : saved_ids) {
+                int idx = int(id - 1);
+                if (idx >= 0 && idx < num_physical)
+                    m_match_tri_indices.push_back(idx);
             }
             m_match_tri_weights = {(double)(100 - m_result.mix_b_percent) / 100.0, (double)m_result.mix_b_percent / 100.0};
             m_match_tri_wx = m_match_tri_weights[0]; m_match_tri_wy = m_match_tri_weights[1];
@@ -3161,16 +3166,16 @@ void MixedFilamentDialog::collect_result()
         if ((int)m_filament_rows.size() == 3) {
             m_result.distribution_mode = int(MixedFilament::LayerCycle);
             m_result.manual_pattern.clear();
-            // Store all 3 filament ids so gradient_component_ids.size() >= 3,
+            // Store all 3 filament ids (1-based) so gradient_component_ids has 3 entries,
             // which lets resolve() enter the weighted gradient branch.
             {
-                std::string all_ids;
+                std::vector<unsigned int> all_ids;
                 for (int i = 0; i < 3; ++i) {
                     int s = get_filament_index(i);
-                    if (s >= 0 && s <= 8)
-                        all_ids += char('1' + s);
+                    if (s >= 0)
+                        all_ids.push_back((unsigned int)(s + 1));
                 }
-                m_result.gradient_component_ids = all_ids;
+                m_result.gradient_component_ids = MixedFilamentManager::encode_gradient_component_ids(all_ids);
             }
             int r0 = (int)(m_tri_wx * 100 + 0.5);
             int r1 = (int)(m_tri_wy * 100 + 0.5);
@@ -3225,15 +3230,17 @@ void MixedFilamentDialog::collect_result()
                 int w2 = std::max(0, 100 - w0 - w1);
                 m_result.gradient_component_ids.clear();
                 std::string weights_str;
+                std::vector<unsigned int> match_ids;
                 // Only include filaments with actual weight > 0
-                if (w0 > 0) { m_result.gradient_component_ids.push_back(char('0' + m_match_tri_indices[0] + 1)); weights_str += std::to_string(w0); }
-                if (w1 > 0) { m_result.gradient_component_ids.push_back(char('0' + m_match_tri_indices[1] + 1)); if (!weights_str.empty()) weights_str += "/"; weights_str += std::to_string(w1); }
-                if (w2 > 0) { m_result.gradient_component_ids.push_back(char('0' + m_match_tri_indices[2] + 1)); if (!weights_str.empty()) weights_str += "/"; weights_str += std::to_string(w2); }
+                if (w0 > 0) { match_ids.push_back((unsigned int)(m_match_tri_indices[0] + 1)); weights_str += std::to_string(w0); }
+                if (w1 > 0) { match_ids.push_back((unsigned int)(m_match_tri_indices[1] + 1)); if (!weights_str.empty()) weights_str += "/"; weights_str += std::to_string(w1); }
+                if (w2 > 0) { match_ids.push_back((unsigned int)(m_match_tri_indices[2] + 1)); if (!weights_str.empty()) weights_str += "/"; weights_str += std::to_string(w2); }
+                m_result.gradient_component_ids = MixedFilamentManager::encode_gradient_component_ids(match_ids);
                 m_result.gradient_component_weights = weights_str;
-                if (m_result.gradient_component_ids.size() >= 3) {
+                if (match_ids.size() >= 3) {
                     m_result.distribution_mode = int(MixedFilament::LayerCycle);
                     m_result.mix_b_percent = 50;
-                } else if (m_result.gradient_component_ids.size() == 2) {
+                } else if (match_ids.size() == 2) {
                     m_result.distribution_mode = int(MixedFilament::Simple);
                     int total_w = 0;
                     if (w0 > 0) total_w += w0;
@@ -3245,8 +3252,7 @@ void MixedFilamentDialog::collect_result()
                 m_result.mix_b_percent = m_match_gradient_selector ? m_match_gradient_selector->value() : 50;
                 m_result.gradient_component_ids.clear();
                 // Store for constructor detection (Plater skips display for Simple mode)
-                m_result.gradient_component_ids.push_back(char('0' + m_result.component_a));
-                m_result.gradient_component_ids.push_back(char('0' + m_result.component_b));
+                m_result.gradient_component_ids = MixedFilamentManager::encode_gradient_component_ids({m_result.component_a, m_result.component_b});
                 m_result.gradient_component_weights.clear();
             }
         } else {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3673,34 +3673,12 @@ static std::vector<unsigned int> build_grouped_manual_pattern_preview_sequence(c
 
 std::vector<unsigned int> MixedFilamentConfigPanel::decode_gradient_ids(const std::string &s)
 {
-    std::vector<unsigned int> ids;
-    if (s.empty())
-        return ids;
-
-    bool seen[10] = { false };
-    for (const char c : s) {
-        if (c < '1' || c > '9')
-            continue;
-        const unsigned int id = unsigned(c - '0');
-        if (seen[id])
-            continue;
-        seen[id] = true;
-        ids.emplace_back(id);
-    }
-    return ids;
+    return MixedFilamentManager::decode_gradient_component_ids(s, 0);
 }
 
 std::string MixedFilamentConfigPanel::encode_gradient_ids(const std::vector<unsigned int> &ids)
 {
-    std::string out;
-    bool seen[10] = { false };
-    for (const unsigned int id : ids) {
-        if (id == 0 || id > 9 || seen[id])
-            continue;
-        seen[id] = true;
-        out.push_back(char('0' + id));
-    }
-    return out;
+    return MixedFilamentManager::encode_gradient_component_ids(ids);
 }
 
 std::vector<unsigned int> MixedFilamentConfigPanel::decode_manual_pattern_ids(const std::string &pattern,
@@ -5789,15 +5767,15 @@ void Sidebar::update_color_mix_panel()
                                              virtual_id, mf, display_context);
 
         const std::string normalized_pattern_cm = MixedFilamentManager::normalize_manual_pattern(mf.manual_pattern);
+        std::vector<unsigned int> gradient_ids = MixedFilamentManager::decode_gradient_component_ids(mf.gradient_component_ids, 0);
         const bool z_gradient_tile = mf.gradient_enabled && mf.component_a != mf.component_b
-                                  && normalized_pattern_cm.empty() && mf.gradient_component_ids.size() < 3;
-
+                                  && normalized_pattern_cm.empty() && gradient_ids.size() < 3;
         wxString lbl;
         if (!normalized_pattern_cm.empty())
             lbl = wxString(summarize_cycle_pattern_text(normalized_pattern_cm, mf, int(num_physical)));
-        else if (mf.gradient_component_ids.size() >= 3) {
+        else if (gradient_ids.size() >= 3) {
             // parse weights
-            const size_t n = mf.gradient_component_ids.size();
+            const size_t n = gradient_ids.size();
             std::vector<int> weights;
             {
                 std::string token;
@@ -5812,7 +5790,7 @@ void Sidebar::update_color_mix_panel()
             int sum = 0; for (int v : weights) sum += v;
             if (sum <= 0) { weights.assign(n, 0); weights[0] = 100; sum = 100; }
             for (size_t k = 0; k < n; ++k) {
-                const unsigned int fid = unsigned(mf.gradient_component_ids[k] - '0');
+                const unsigned int fid = gradient_ids[k];
                 const int pct = int(std::round(100.0 * weights[k] / sum));
                 if (k > 0) lbl += "+";
                 lbl += wxString::Format("F%u %d%%", fid, pct);
@@ -5828,8 +5806,8 @@ void Sidebar::update_color_mix_panel()
             const int pct_a = 100 - pct_b;
             lbl = wxString::Format("F%u %d%%+F%u %d%%", mf.component_a, pct_a, mf.component_b, pct_b);
             if (mf.distribution_mode != int(MixedFilament::Simple))
-                for (char c : mf.gradient_component_ids)
-                    lbl += wxString::Format("+F%d", int(c - '0'));
+                for (unsigned int fid : gradient_ids)
+                    lbl += wxString::Format("+F%u", fid);
         }
         
         bool has_error = !is_filament_compatible(mf);
@@ -6293,32 +6271,11 @@ void Sidebar::update_mixed_filament_panel(bool sync_manager)
         if (wxGetApp().mainframe)
             wxGetApp().mainframe->on_config_changed(print_cfg);
     };
-    auto decode_gradient_ids = [num_physical](const std::string &encoded) {
-        std::vector<unsigned int> ids;
-        if (encoded.empty() || num_physical == 0)
-            return ids;
-        bool seen[10] = { false };
-        for (const char c : encoded) {
-            if (c < '1' || c > '9')
-                continue;
-            const unsigned int id = unsigned(c - '0');
-            if (id == 0 || id > num_physical || seen[id])
-                continue;
-            seen[id] = true;
-            ids.emplace_back(id);
-        }
-        return ids;
+    auto decode_gradient_ids = [](const std::string &encoded) {
+        return MixedFilamentManager::decode_gradient_component_ids(encoded, 0);
     };
-    auto encode_gradient_ids = [num_physical](const std::vector<unsigned int> &ids) {
-        std::string encoded;
-        bool seen[10] = { false };
-        for (const unsigned int id : ids) {
-            if (id == 0 || id > num_physical || id > 9 || seen[id])
-                continue;
-            seen[id] = true;
-            encoded.push_back(char('0' + id));
-        }
-        return encoded;
+    auto encode_gradient_ids = [](const std::vector<unsigned int> &ids) {
+        return MixedFilamentManager::encode_gradient_component_ids(ids);
     };
     auto decode_gradient_weights = [](const std::string &encoded, size_t expected_count) {
         std::vector<int> out;
@@ -7334,16 +7291,15 @@ static bool mixed_filament_uses_physical(const MixedFilament* target_mf, unsigne
         return true;
     }
     
-    // Also check gradient components
-    for (char c : target_mf->gradient_component_ids) {
-        if (c >= '1' && c <= '9') {
-            unsigned int comp_id = static_cast<unsigned int>(c - '0');
-            if (comp_id == source_physical_1based) {
+    // Also check gradient components (delegates to centralized decode)
+    {
+        const std::vector<unsigned int> ids = MixedFilamentManager::decode_gradient_component_ids(target_mf->gradient_component_ids, 0);
+        for (unsigned int id : ids) {
+            if (id == source_physical_1based)
                 return true;
-            }
         }
     }
-    
+
     return false;
 }
 


### PR DESCRIPTION
# Description

Legacy format stores filament IDs as concatenated single characters ('1'-'9'),
which cannot represent IDs >= 10. This caused 3-color mixes to silently drop
the third color when any selected filament had an ID >= 10.

Add extended format with '/' separated decimal IDs (e.g. "1/12/3") and a
leading '/' for single-ID extended entries (e.g. "/12") to disambiguate from
legacy format.

Affected modules:
- MixedFilament.cpp/hpp: decode/encode/normalize for core slicing pipeline
- MixedFilamentDialog.cpp: encode/decode in add/edit dialog
- MixedColorMatchHelpers.cpp: encode/decode for match recipe generation
- Plater.cpp: encode/decode in config panel and mixed filament display
- GCode.cpp/PrintObjectSlice.cpp/PrintApply.cpp: decode in slicing pipeline