### PR TITLE
Apply Subdivide Mix Layer refinement to infill

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5089,6 +5089,7 @@ LayerResult GCode::process_layer(const Print& print,
     const float      local_z_perimeter_mask_expand    = float(scale_(LOCAL_Z_PERIMETER_MASK_EXPAND_MM));
     const float      local_z_base_mask_expand         = float(scale_(LOCAL_Z_BASE_MASK_EXPAND_MM));
     const bool       local_z_whole_objects_enabled    = print.full_print_config().opt_bool("dithering_local_z_whole_objects");
+    const bool       local_z_infill_enabled           = print.full_print_config().opt_bool("dithering_local_z_infill");
 
     struct LocalZPassBucket {
         const SubLayerPlan*                                   plan { nullptr };
@@ -5481,8 +5482,10 @@ LayerResult GCode::process_layer(const Print& print,
                             continue;
 
                         const ExtrusionEntityCollection* filtered_extrusions = extrusions;
-                        if (entity_type == ObjectByExtruder::Island::Region::PERIMETERS &&
-                            local_z_ctx != nullptr && !local_z_ctx->mixed_masks_union.empty()) {
+                        const bool local_z_entity_enabled =
+                            entity_type == ObjectByExtruder::Island::Region::PERIMETERS ||
+                            (local_z_infill_enabled && entity_type == ObjectByExtruder::Island::Region::INFILL);
+                        if (local_z_entity_enabled && local_z_ctx != nullptr && !local_z_ctx->mixed_masks_union.empty()) {
                             for (LocalZPassBucket& pass_bucket : local_z_ctx->pass_buckets) {
                                 if (pass_bucket.plan == nullptr)
                                     continue;
@@ -5527,8 +5530,7 @@ LayerResult GCode::process_layer(const Print& print,
                                         if (last || entity_matches_surface(island_idx, *clipped_ptr)) {
                                             if (islands[island_idx].by_region.empty())
                                                 islands[island_idx].by_region.assign(print.num_print_regions(), ObjectByExtruder::Island::Region());
-                                            islands[island_idx].by_region[region.print_region_id()].append(
-                                                ObjectByExtruder::Island::Region::PERIMETERS, clipped_ptr, nullptr);
+                                            islands[island_idx].by_region[region.print_region_id()].append(entity_type, clipped_ptr, nullptr);
                                             break;
                                         }
                                     }
@@ -5805,9 +5807,9 @@ LayerResult GCode::process_layer(const Print& print,
     if (local_z_perimeter_phase_b_enabled) {
         BOOST_LOG_TRIVIAL(info) << "Local-Z phase-b prepared"
                                 << " print_z=" << print_z
-                                << " perimeter_passes=" << local_z_pass_refs.size();
+                                << " path_passes=" << local_z_pass_refs.size();
         if (local_z_pass_refs.empty()) {
-            BOOST_LOG_TRIVIAL(warning) << "Local-Z phase-b enabled but produced no perimeter passes"
+            BOOST_LOG_TRIVIAL(warning) << "Local-Z phase-b enabled but produced no path passes"
                                        << " print_z=" << print_z;
         }
     }
@@ -5825,8 +5827,8 @@ LayerResult GCode::process_layer(const Print& print,
         int  local_z_phase_b_active_extruder = (m_writer.extruder() != nullptr) ? int(m_writer.extruder()->id()) : -1;
         BOOST_LOG_TRIVIAL(info) << "Local-Z phase-b emitting"
                                 << " print_z=" << print_z
-                                << " perimeter_passes=" << local_z_pass_refs.size();
-        gcode += "; local-z phase-b perimeter passes begin\n";
+                                << " path_passes=" << local_z_pass_refs.size();
+        gcode += "; local-z phase-b path passes begin\n";
         auto emit_local_z_toolchange = [&](unsigned int extruder_id, double toolchange_print_z) {
             if (has_wipe_tower && m_wipe_tower) {
                 gcode += m_wipe_tower->tool_change(*this, int(extruder_id), false, true, print_z + m_config.z_offset.value);
@@ -5871,7 +5873,7 @@ LayerResult GCode::process_layer(const Print& print,
                                      << " extruder=" << local_extruder_id;
             if (std::abs(m_writer.get_position().z() - pass_z) > EPSILON) {
                 gcode += this->retract(false, false, LiftType::NormalLift);
-                gcode += m_writer.travel_to_z(pass_z, "Local-Z perimeter pass");
+                gcode += m_writer.travel_to_z(pass_z, "Local-Z path pass");
             }
             if (std::abs(m_writer.get_position().z() - pass_z) > EPSILON) {
                 BOOST_LOG_TRIVIAL(warning) << "Local-Z pass z restore"
@@ -5913,7 +5915,9 @@ LayerResult GCode::process_layer(const Print& print,
 
                 for (ObjectByExtruder::Island& island : instance_to_print.object_by_extruder.islands) {
                     gcode += this->extrude_perimeters(print, island.by_region, first_layer, false);
+                    gcode += this->extrude_infill(print, island.by_region, false);
                     gcode += this->extrude_perimeters(print, island.by_region, first_layer, true);
+                    gcode += this->extrude_infill(print, island.by_region, true);
                 }
                 m_config.reduce_crossing_wall.value = saved_reduce_crossing_wall;
             }
@@ -6192,7 +6196,7 @@ LayerResult GCode::process_layer(const Print& print,
             gcode += this->retract(false, false, LiftType::NormalLift);
             gcode += m_writer.travel_to_z(nominal_layer_z, "Local-Z return to nominal layer");
         }
-        gcode += "; local-z phase-b perimeter passes end\n";
+        gcode += "; local-z phase-b path passes end\n";
     }
 
     if (nominal_layer_start_extruder >= 0) {

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -907,6 +907,7 @@ static std::vector<std::string> s_Preset_print_options {
      "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold", "scarf_joint_speed", "scarf_joint_flow_ratio", "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length", "seam_slope_steps", "seam_slope_inner_walls", "scarf_overhang_threshold",
      "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width",
      "dithering_local_z_mode",
+     "dithering_local_z_infill",
      "calib_flowrate_topinfill_special_order",
 };
 

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -83,6 +83,7 @@ static std::vector<std::string> s_project_options {
     "dithering_z_step_size",
     "dithering_local_z_mode",
     "dithering_local_z_whole_objects",
+    "dithering_local_z_infill",
     "dithering_local_z_direct_multicolor",
     "dithering_step_painted_zones_only",
 };

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -96,8 +96,8 @@ static bool local_z_segments_exist(Polylines segments)
     return false;
 }
 
-static bool extrusion_collection_has_local_z_perimeter_segment(const ExtrusionEntityCollection &source,
-                                                               const ExPolygons               &include_masks)
+static bool extrusion_collection_has_local_z_segment(const ExtrusionEntityCollection &source,
+                                                     const ExPolygons               &include_masks)
 {
     if (source.entities.empty() || include_masks.empty())
         return false;
@@ -123,7 +123,7 @@ static bool extrusion_collection_has_local_z_perimeter_segment(const ExtrusionEn
     return false;
 }
 
-static bool layer_has_local_z_perimeters(const Layer &layer, const ExPolygons &pass_masks)
+static bool layer_has_local_z_extrusions(const Layer &layer, const ExPolygons &pass_masks, bool include_infill)
 {
     if (pass_masks.empty())
         return false;
@@ -133,7 +133,16 @@ static bool layer_has_local_z_perimeters(const Layer &layer, const ExPolygons &p
             const auto *extrusions = dynamic_cast<const ExtrusionEntityCollection*>(entity);
             if (extrusions == nullptr)
                 continue;
-            if (extrusion_collection_has_local_z_perimeter_segment(*extrusions, pass_masks))
+            if (extrusion_collection_has_local_z_segment(*extrusions, pass_masks))
+                return true;
+        }
+        if (!include_infill)
+            continue;
+        for (const ExtrusionEntity *entity : layer_region->fills.entities) {
+            const auto *extrusions = dynamic_cast<const ExtrusionEntityCollection*>(entity);
+            if (extrusions == nullptr)
+                continue;
+            if (extrusion_collection_has_local_z_segment(*extrusions, pass_masks))
                 return true;
         }
     }
@@ -168,6 +177,7 @@ static std::vector<LocalZWipeTowerToolchange> collect_local_z_wipe_tower_toolcha
 {
     std::vector<LocalZWipeTowerPassRef> pass_refs;
     const bool  local_z_whole_objects_enabled = print.full_print_config().opt_bool("dithering_local_z_whole_objects");
+    const bool  local_z_infill_enabled        = print.full_print_config().opt_bool("dithering_local_z_infill");
     const float local_z_perimeter_mask_expand = float(scale_(LOCAL_Z_PERIMETER_MASK_EXPAND_MM));
 
     for (size_t layer_to_print_idx = 0; layer_to_print_idx < layers.size(); ++layer_to_print_idx) {
@@ -249,7 +259,7 @@ static std::vector<LocalZWipeTowerToolchange> collect_local_z_wipe_tower_toolcha
                 const ExPolygons &pass_masks = compensated_masks_by_extruder[extruder_id];
                 if (pass_masks.empty())
                     continue;
-                if (layer_has_local_z_perimeters(*layer_to_print.object_layer, pass_masks))
+                if (layer_has_local_z_extrusions(*layer_to_print.object_layer, pass_masks, local_z_infill_enabled))
                     pass_ref.extruders.push_back(unsigned(extruder_id));
             }
 
@@ -767,6 +777,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             || opt_key == "wipe_tower_fillet_wall"
             || opt_key == "wipe_tower_filament"
             || opt_key == "wiping_volumes_extruders"
+            || opt_key == "dithering_local_z_infill"
             || opt_key == "enable_filament_ramming"
             || opt_key == "purge_in_prime_tower"
             || opt_key == "z_offset"

--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -1207,6 +1207,7 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
     new_full_config.option("dithering_z_step_size", true);
     new_full_config.option("dithering_local_z_mode", true);
     new_full_config.option("dithering_local_z_whole_objects", true);
+    new_full_config.option("dithering_local_z_infill", true);
     new_full_config.option("dithering_local_z_direct_multicolor", true);
     new_full_config.option("dithering_step_painted_zones_only", true);
     new_full_config.option("mixed_filament_gradient_mode", true);
@@ -1222,6 +1223,7 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
     m_config.option("dithering_z_step_size", true);
     m_config.option("dithering_local_z_mode", true);
     m_config.option("dithering_local_z_whole_objects", true);
+    m_config.option("dithering_local_z_infill", true);
     m_config.option("dithering_local_z_direct_multicolor", true);
     m_config.option("dithering_step_painted_zones_only", true);
     m_config.option("mixed_filament_gradient_mode", true);
@@ -1237,6 +1239,7 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
     m_default_object_config.option("dithering_z_step_size", true);
     m_default_object_config.option("dithering_local_z_mode", true);
     m_default_object_config.option("dithering_local_z_whole_objects", true);
+    m_default_object_config.option("dithering_local_z_infill", true);
     m_default_object_config.option("dithering_local_z_direct_multicolor", true);
     m_default_object_config.option("dithering_step_painted_zones_only", true);
     m_default_object_config.option("mixed_filament_gradient_mode", true);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4355,6 +4355,15 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("dithering_local_z_infill", coBool);
+    def->label = L("Apply subdivision to infill");
+    def->category = L("Material");
+    def->tooltip = L("Experimental. When Subdivide Mix Layer is enabled, also apply the same subdivision to infill inside mixed-color areas.\n\n"
+                     "This is enabled automatically with Subdivide Mix Layer. Turn it off to keep infill on the normal layer height.\n\n"
+                     "It can improve internal color mixing, but may add toolchanges and affect infill behavior.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(true));
+
     def = this->add("dithering_local_z_direct_multicolor", coBool);
     def->label = L("Use direct multicolor Local-Z solver");
     def->category = L("Others");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1378,6 +1378,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloat,              dithering_z_step_size))
     ((ConfigOptionBool,               dithering_local_z_mode))
     ((ConfigOptionBool,               dithering_local_z_whole_objects))
+    ((ConfigOptionBool,               dithering_local_z_infill))
     ((ConfigOptionBool,               dithering_local_z_direct_multicolor))
     ((ConfigOptionBool,               dithering_step_painted_zones_only))
     ((ConfigOptionString,             printer_model))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1228,7 +1228,8 @@ bool PrintObject::invalidate_state_by_config_options(
         } else if (
                opt_key == "flush_into_infill"
             || opt_key == "flush_into_objects"
-            || opt_key == "flush_into_support") {
+            || opt_key == "flush_into_support"
+            || opt_key == "dithering_local_z_infill") {
             invalidated |= m_print->invalidate_step(psWipeTower);
             invalidated |= m_print->invalidate_step(psGCodeExport);
         } else {

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -785,6 +785,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
         config->has("dithering_local_z_mode") && config->option("dithering_local_z_mode") != nullptr &&
         config->opt_bool("dithering_local_z_mode");
     toggle_line("dithering_local_z_whole_objects", local_z_dithering_enabled);
+    toggle_line("dithering_local_z_infill", local_z_dithering_enabled);
     toggle_line("dithering_local_z_direct_multicolor", local_z_dithering_enabled);
 
     WipeTowerWallType wipe_tower_wall_type = config->opt_enum<WipeTowerWallType>("wipe_tower_wall_type");

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -6285,6 +6285,7 @@ void GUI_App::load_current_presets(bool active_preset_combox/*= false*/, bool ch
             "dithering_z_step_size",
             "dithering_local_z_mode",
             "dithering_local_z_whole_objects",
+            "dithering_local_z_infill",
             "dithering_local_z_direct_multicolor",
             "dithering_step_painted_zones_only",
             "mixed_filament_pointillism_pixel_size",

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10002,6 +10002,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                     "dithering_z_step_size",
                                     "dithering_local_z_mode",
                                     "dithering_local_z_whole_objects",
+                                    "dithering_local_z_infill",
                                     "dithering_local_z_direct_multicolor",
                                     "dithering_step_painted_zones_only"
                                 };

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1528,6 +1528,18 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
     if(opt_key == "purge_in_prime_tower")
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
 
+    if (m_type == Preset::TYPE_PRINT &&
+        opt_key == "dithering_local_z_mode" &&
+        boost::any_cast<bool>(value) &&
+        m_config->has("dithering_local_z_infill") &&
+        !m_config->opt_bool("dithering_local_z_infill")) {
+        DynamicPrintConfig new_conf = *m_config;
+        new_conf.set_key_value("dithering_local_z_infill", new ConfigOptionBool(true));
+        m_config_manipulation.apply(m_config, &new_conf);
+
+        DynamicPrintConfig &project_cfg = wxGetApp().preset_bundle->project_config;
+        project_cfg.set_key_value("dithering_local_z_infill", new ConfigOptionBool(true));
+    }
 
     if (opt_key == "enable_prime_tower") {
         auto timelapse_type = m_config->option<ConfigOptionEnum<TimelapseType>>("timelapse_type");
@@ -1864,6 +1876,7 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
          opt_key == "dithering_z_step_size" ||
          opt_key == "dithering_local_z_mode" ||
          opt_key == "dithering_local_z_whole_objects" ||
+         opt_key == "dithering_local_z_infill" ||
          opt_key == "dithering_local_z_direct_multicolor" ||
          opt_key == "dithering_step_painted_zones_only" ||
          opt_key == "mixed_filament_definitions")) {
@@ -2567,6 +2580,7 @@ void TabPrint::build()
         optgroup = page->new_optgroup(L("Color Mixing (Experimental)"), L"param_mixed_color");
         optgroup->append_single_option_line("dithering_local_z_mode");
         optgroup->append_single_option_line("dithering_local_z_whole_objects");
+        optgroup->append_single_option_line("dithering_local_z_infill");
 
     page = add_options_page(L("Others"), "custom-gcode_other"); // ORCA: icon only visible on placeholders
         optgroup = page->new_optgroup(L("Skirt"), L"param_skirt");


### PR DESCRIPTION
## Summary
- Add a print setting to apply Subdivide Mix Layer refinement to infill, not only perimeters.
- Enable the infill subdivision setting by default and automatically turn it on when Subdivide Mix Layer is enabled.
- Include infill paths in Local-Z clipping/emission and wipe tower planning when the new option is enabled.

## 摘要
- 新增一个打印设置，用于将 Subdivide Mix Layer 细分优化应用到填充，而不只是外墙。
- 默认启用填充细分设置，并在启用 Subdivide Mix Layer 时自动打开该设置。
- 当新选项启用时，将填充路径纳入 Local-Z 裁剪/生成流程以及擦料塔规划。