### PR TITLE
Corrects 0.18mm layer height profile @ 0.6mm nozzle diameter

### DIFF
--- a/resources/profiles/Snapmaker/process/0.18 Standard @Snapmaker U1 (0.6 nozzle).json
+++ b/resources/profiles/Snapmaker/process/0.18 Standard @Snapmaker U1 (0.6 nozzle).json
@@ -15,7 +15,6 @@
     "filter_out_gap_fill": "1",
     "gap_fill_target": "topbottom",
     "internal_bridge_speed": "100%",
-    "layer_height": "0.25",
     "prime_tower_brim_width": "5",
     "prime_tower_width": "30",
     "prime_volume": "41",


### PR DESCRIPTION
Restores the correct 0.18mm layer height.

# Description

Current profile overrides the 0.18mm layer height profile with 0.25mm layer height.

# Screenshots/Recordings/Graphs

<img width="716" height="317" alt="image" src="https://github.com/user-attachments/assets/8ebfd639-36b0-42ca-90ed-e5b13ed224f7" />

## Tests

Visual inspection in slicer.