### PR TITLE
Fix mixed-color painted region invalidation by deduplicating PrintRegions

### DIFF
--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -1017,11 +1017,6 @@ static PrintObjectRegions* generate_print_object_regions(
         region_set.emplace(it, region);
         return region;
     };
-    auto create_unique_region = [&all_regions](PrintRegionConfig &&config) -> PrintRegion* {
-        size_t hash = config.hash();
-        all_regions.emplace_back(std::make_unique<PrintRegion>(std::move(config), hash, int(all_regions.size())));
-        return all_regions.back().get();
-    };
     // Chain the regions in the order they are stored in the volumes list.
     for (int volume_id = 0; volume_id < int(model_volumes.size()); ++ volume_id) {
         const ModelVolume &volume = *model_volumes[volume_id];
@@ -1077,7 +1072,9 @@ static PrintObjectRegions* generate_print_object_regions(
                     cfg.wall_filament.value    = painted_extruder_id;
                     cfg.solid_infill_filament.value = painted_extruder_id;
                     cfg.sparse_infill_filament.value       = painted_extruder_id;
-                    PrintRegion *painted_region = create_unique_region(std::move(cfg));
+                    // Keep PrintRegion config-interned. If a painted target resolves to the same
+                    // config as its parent, alias it instead of creating a duplicate PrintRegion.
+                    PrintRegion *painted_region = get_create_region(std::move(cfg));
                     if (painted_region->config().wall_filament.value != painted_extruder_id ||
                         painted_region->config().solid_infill_filament.value != painted_extruder_id ||
                         painted_region->config().sparse_infill_filament.value != painted_extruder_id) {


### PR DESCRIPTION
## Summary

Fixes secondary slicing after mixed-color painting by restoring config-based deduplication for painted `PrintRegion`s.

Painted regions were using `create_unique_region()`, which always created a new `PrintRegion` even when the generated config matched the parent or another painted target. That broke the existing `PrintObjectRegions::all_regions` invariant that regions are deduplicated by config. On a later `Print::apply()`, `verify_update_print_object_regions()` detected duplicate configs and returned false, causing invalidation and a reslice.

This changes painted region creation back to `get_create_region()` and removes the unused unique-region helper.

## Behavior

- Same-config painted targets now share the existing `PrintRegion`.
- Duplicate same-config `PrintRegion`s are no longer generated for mixed component targets.
- Existing UI guard against unnecessary preview-tab reslicing remains unchanged.

## Testing

- Manually tested mixed-color painting flow with the preview reslice guard temporarily removed.
- Confirmed the backend change prevents the secondary slicing behavior.


## 摘要

通过恢复 painted `PrintRegion` 的基于配置的去重，修复混色涂色后触发二次切片的问题。

此前 painted region 使用 `create_unique_region()`，即使生成的配置与父 region 或其他 painted target 完全一致，也会创建新的 `PrintRegion`。这破坏了现有的 `PrintObjectRegions::all_regions` 不变量：region 应该按 config 去重。后续再次执行 `Print::apply()` 时，`verify_update_print_object_regions()` 会检测到重复配置并返回 false，从而触发 invalidation 和重新切片。

本次修改将 painted region 的创建方式改回 `get_create_region()`，并移除了未使用的 unique-region helper。

## 行为变化

- 相同配置的 painted target 现在会共享已有的 `PrintRegion`。
- mixed component target 不再生成重复的相同配置 `PrintRegion`。
- 现有用于避免 Preview tab 不必要重切片的 UI guard 保持不变。

## 测试

- 手动测试了混色涂色流程，并临时移除 Preview reslice guard 进行验证。
- 确认 backend 修改可以阻止二次切片行为。