### PR TITLE
fix: stale m_layers_values causing wrong layer numbers in preview slider

### DIFF
--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -291,6 +291,7 @@ void IMSlider::SetLayersTimes(const std::vector<float> &layers_times, float tota
 
     // Erase duplicates values from m_values and save it to the m_layers_values
     // They will be used for show the correct estimated time for MM print, when "No sparce layer" is enabled
+    m_layers_values.clear();
     if (m_is_wipe_tower && m_values.size() != m_layers_times.size()) {
         m_layers_values = m_values;
         sort(m_layers_values.begin(), m_layers_values.end());


### PR DESCRIPTION
## Summary
- Fix layer height slider showing wrong layer numbers (e.g., "263" instead of "132") after Subdivide Mix Layer creates then removes sublayers

## Root Cause
`IMSlider::SetLayersTimes()` only repopulates `m_layers_values` when `m_values.size() != m_layers_times.size()`. When the counts match (as they do after Subdivide is turned off), stale data from a prior slice persists. The `get_label()` lambda then searches the old array and returns indices from it, producing roughly 2x the correct layer numbers.

## Changes
- `src/slic3r/GUI/IMSlider.cpp`: Add `m_layers_values.clear()` before the conditional block in `SetLayersTimes()`

## Test Plan
- [ ] Single extruder: slider labels match current slice layer count
- [ ] Multi-extruder with wipe tower: layer labels correct
- [ ] Toggle Subdivide Mix Layer on/off: labels update correctly after re-slice
