### PR TITLE
chore: remove Chinese text from source comments and UI strings

### DIFF
--- a/localization/i18n/Snapmaker_Orca.pot
+++ b/localization/i18n/Snapmaker_Orca.pot
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Click to download new version in default browser: %s"
 msgstr ""
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr ""
 
 msgid "This is the newest version."
@@ -8124,7 +8124,7 @@ msgstr ""
 msgid "Append all"
 msgstr ""
 
-msgid "Add all clustered colors after the existing filaments."
+msgid "Add consumable extruder after existing extruders."
 msgstr ""
 
 msgid "Keep color"

--- a/localization/i18n/ca/Snapmaker_Orca_ca.po
+++ b/localization/i18n/ca/Snapmaker_Orca_ca.po
@@ -1600,7 +1600,7 @@ msgstr "S'està carregant la configuració"
 msgid "Click to download new version in default browser: %s"
 msgstr "Feu clic per descarregar la nova versió al navegador predeterminat: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "L'Snapmaker Orca necessita una actualització"
 
 msgid "This is the newest version."

--- a/localization/i18n/cs/Snapmaker_Orca_cs.po
+++ b/localization/i18n/cs/Snapmaker_Orca_cs.po
@@ -1583,7 +1583,7 @@ msgstr "Načítání konfigurace"
 msgid "Click to download new version in default browser: %s"
 msgstr "Kliknutím stáhnete novou verzi ve výchozím prohlížeči: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca potřebuje aktualizaci"
 
 msgid "This is the newest version."

--- a/localization/i18n/de/Snapmaker_Orca_de.po
+++ b/localization/i18n/de/Snapmaker_Orca_de.po
@@ -1603,7 +1603,7 @@ msgstr ""
 "Klicken Sie hier, um die neueste Version im Standardbrowser herunterzuladen: "
 "%s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca benötigt ein Upgrade"
 
 msgid "This is the newest version."

--- a/localization/i18n/en/Snapmaker_Orca_en.po
+++ b/localization/i18n/en/Snapmaker_Orca_en.po
@@ -1535,7 +1535,7 @@ msgstr ""
 msgid "Click to download new version in default browser: %s"
 msgstr ""
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca needs an update"
 
 msgid "This is the newest version."
@@ -8248,7 +8248,7 @@ msgstr ""
 msgid "Append all"
 msgstr ""
 
-msgid "Add all clustered colors after the existing filaments."
+msgid "Add consumable extruder after existing extruders."
 msgstr ""
 
 msgid "Keep color"

--- a/localization/i18n/es/Snapmaker_Orca_es.po
+++ b/localization/i18n/es/Snapmaker_Orca_es.po
@@ -1605,7 +1605,7 @@ msgid "Click to download new version in default browser: %s"
 msgstr ""
 "Haga clic para descargar la nueva versión en el navegador por defecto: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca necesita una actualización"
 
 msgid "This is the newest version."

--- a/localization/i18n/fr/Snapmaker_Orca_fr.po
+++ b/localization/i18n/fr/Snapmaker_Orca_fr.po
@@ -1617,7 +1617,7 @@ msgstr ""
 "Cliquez pour télécharger la nouvelle version dans le navigateur par défaut : "
 "%s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca a besoin d’être mis à jour"
 
 msgid "This is the newest version."

--- a/localization/i18n/hu/Snapmaker_Orca_hu.po
+++ b/localization/i18n/hu/Snapmaker_Orca_hu.po
@@ -1543,7 +1543,7 @@ msgstr "Konfiguráció betöltése"
 msgid "Click to download new version in default browser: %s"
 msgstr "Kattints az új verzió letöltéséhez az alapértelmezett böngészőben: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "A Snapmaker Orcat frissíteni kell"
 
 msgid "This is the newest version."

--- a/localization/i18n/it/Snapmaker_Orca_it.po
+++ b/localization/i18n/it/Snapmaker_Orca_it.po
@@ -1611,7 +1611,7 @@ msgstr "Caricamento configurazione"
 msgid "Click to download new version in default browser: %s"
 msgstr "Fai clic per scaricare la nuova versione nel browser predefinito: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca necessita di aggiornamento"
 
 msgid "This is the newest version."

--- a/localization/i18n/ja/Snapmaker_Orca_ja.po
+++ b/localization/i18n/ja/Snapmaker_Orca_ja.po
@@ -1561,7 +1561,7 @@ msgstr "構成を読込み中"
 msgid "Click to download new version in default browser: %s"
 msgstr "新バージョンをダウンロードするにはクリックしてください: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca をアップデートする必要があります"
 
 msgid "This is the newest version."

--- a/localization/i18n/ko/Snapmaker_Orca_ko.po
+++ b/localization/i18n/ko/Snapmaker_Orca_ko.po
@@ -1573,7 +1573,7 @@ msgstr "구성 파일 로드 중"
 msgid "Click to download new version in default browser: %s"
 msgstr "기본 브라우저에서 새 버전을 다운로드하려면 클릭: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca 업그레이드가 필요합니다"
 
 msgid "This is the newest version."

--- a/localization/i18n/lt/Snapmaker_Orca_lt.po
+++ b/localization/i18n/lt/Snapmaker_Orca_lt.po
@@ -1591,7 +1591,7 @@ msgid "Click to download new version in default browser: %s"
 msgstr ""
 "Spustelėkite, kad atsisiųstumėte naują versiją numatytoje naršyklėje: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca reikia atnaujinti"
 
 msgid "This is the newest version."

--- a/localization/i18n/nl/Snapmaker_Orca_nl.po
+++ b/localization/i18n/nl/Snapmaker_Orca_nl.po
@@ -1567,7 +1567,7 @@ msgid "Click to download new version in default browser: %s"
 msgstr ""
 "Klik hier om de nieuwe versie te downloaden in je standaard browser: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca heeft een upgrade nodig"
 
 msgid "This is the newest version."

--- a/localization/i18n/pl/Snapmaker_Orca_pl.po
+++ b/localization/i18n/pl/Snapmaker_Orca_pl.po
@@ -1591,7 +1591,7 @@ msgstr "Ładowanie konfiguracji"
 msgid "Click to download new version in default browser: %s"
 msgstr "Kliknij, aby pobrać nową wersję w domyślnej przeglądarce: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca wymaga uaktualnienia"
 
 msgid "This is the newest version."

--- a/localization/i18n/pt_BR/Snapmaker_Orca_pt_BR.po
+++ b/localization/i18n/pt_BR/Snapmaker_Orca_pt_BR.po
@@ -1597,7 +1597,7 @@ msgstr "Carregando configuração"
 msgid "Click to download new version in default browser: %s"
 msgstr "Clique para baixar a nova versão no navegador padrão: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "O Snapmaker Orca precisa de uma atualização"
 
 msgid "This is the newest version."

--- a/localization/i18n/ru/Snapmaker_Orca_ru.po
+++ b/localization/i18n/ru/Snapmaker_Orca_ru.po
@@ -1607,7 +1607,7 @@ msgid "Click to download new version in default browser: %s"
 msgstr ""
 "Нажмите OK, чтобы загрузить последнюю версию в браузере по умолчанию: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Orca Slice нуждается в обновлении."
 
 msgid "This is the newest version."

--- a/localization/i18n/sv/Snapmaker_Orca_sv.po
+++ b/localization/i18n/sv/Snapmaker_Orca_sv.po
@@ -1539,7 +1539,7 @@ msgstr "Konfigurationen laddas"
 msgid "Click to download new version in default browser: %s"
 msgstr "Tryck på ladda ner ny version ifrån standard webbläsaren: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca behöver uppdateras"
 
 msgid "This is the newest version."

--- a/localization/i18n/tr/Snapmaker_Orca_tr.po
+++ b/localization/i18n/tr/Snapmaker_Orca_tr.po
@@ -1585,7 +1585,7 @@ msgstr "Yapılandırma yükleniyor"
 msgid "Click to download new version in default browser: %s"
 msgstr "Yeni sürümü varsayılan tarayıcıda indirmek için tıklayın: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Orca Dilimleyicinin yükseltilmesi gerekiyor"
 
 msgid "This is the newest version."

--- a/localization/i18n/uk/Snapmaker_Orca_uk.po
+++ b/localization/i18n/uk/Snapmaker_Orca_uk.po
@@ -1593,7 +1593,7 @@ msgid "Click to download new version in default browser: %s"
 msgstr ""
 "Натисніть OK, щоб завантажити останню версію в стандартному браузері: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca потребує оновлення"
 
 msgid "This is the newest version."

--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -1537,7 +1537,7 @@ msgstr "正在加载配置"
 msgid "Click to download new version in default browser: %s"
 msgstr "在默认浏览器中点击下载最新版本: %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca需要进行升级"
 
 msgid "This is the newest version."

--- a/localization/i18n/zh_TW/Snapmaker_Orca_zh_TW.po
+++ b/localization/i18n/zh_TW/Snapmaker_Orca_zh_TW.po
@@ -1561,7 +1561,7 @@ msgstr "正在讀取設定檔"
 msgid "Click to download new version in default browser: %s"
 msgstr "在預設瀏覽器中開啟頁面下載最新版本： %s"
 
-msgid "The Snapmaker Orca needs an upgrade"
+msgid "Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca 需要進行升級"
 
 msgid "This is the newest version."

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -234,7 +234,7 @@ std::vector<MixedColorMatchRecipeResult> build_color_match_presets(const std::ve
         }
     }
 
-#if 0 // 四色预设：暂不启用
+#if 0 // four-color presets: disabled
     const size_t quad_limit = std::min<size_t>(palette.size(), 5);
     for (size_t first_idx = 0; first_idx + 3 < quad_limit && presets.size() < k_max_presets; ++first_idx) {
         for (size_t second_idx = first_idx + 1; second_idx + 2 < quad_limit && presets.size() < k_max_presets; ++second_idx) {

--- a/src/slic3r/GUI/MixedColorMatchPanel.cpp
+++ b/src/slic3r/GUI/MixedColorMatchPanel.cpp
@@ -223,13 +223,13 @@ MixedColorMatchPanel::MixedColorMatchPanel(wxWindow *parent,
     m_recipe_formula_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
     right_col->Add(m_recipe_formula_label, 0, wxEXPAND | wxBOTTOM, M2);
 
-    // Large solid color swatch — "混色效果"
+    // Large solid color swatch — "Blend result"
     m_recipe_preview = new wxPanel(this, wxID_ANY, wxDefaultPosition,
                                    wxSize(FromDIP(120), FromDIP(100)), wxBORDER_SIMPLE);
     right_col->Add(m_recipe_preview, 0, wxEXPAND | wxBOTTOM, M2);
     right_col->Add(new wxStaticText(this, wxID_ANY, _L("Blend result")), 0, wxALIGN_CENTER | wxBOTTOM, M);
 
-    // Striped preview — "混色预览"
+    // Striped preview — "Color preview"
     m_striped_preview = new StripedPreviewPanel(this, wxSize(FromDIP(120), FromDIP(100)));
     right_col->Add(m_striped_preview, 0, wxEXPAND | wxBOTTOM, M2);
     right_col->Add(new wxStaticText(this, wxID_ANY, _L("Color preview")), 0, wxALIGN_CENTER);

--- a/src/slic3r/GUI/ObjColorDialog.cpp
+++ b/src/slic3r/GUI/ObjColorDialog.cpp
@@ -471,8 +471,8 @@ wxBoxSizer *ObjColorPanel::create_add_btn_sizer(wxWindow *parent)
     StateColor calc_btn_bd(std::pair<wxColour, int>(wxColour(0, 150, 136), StateColor::Normal));
     StateColor calc_btn_text(std::pair<wxColour, int>(wxColour(255, 255, 254), StateColor::Normal));
     // create btn
-    m_quick_add_btn = new Button(parent, _L("Append all"));
-    m_quick_add_btn->SetToolTip(_L("Add all clustered colors after the existing filaments."));
+    m_quick_add_btn = new Button(parent, _L("Append"));
+    m_quick_add_btn->SetToolTip(_L("Add consumable extruder after existing extruders."));
     auto cur_btn    = m_quick_add_btn;
     cur_btn->SetFont(Label::Body_13);
     cur_btn->SetMinSize(wxSize(FromDIP(60), FromDIP(20)));

--- a/src/slic3r/Utils/Bonjour.cpp
+++ b/src/slic3r/Utils/Bonjour.cpp
@@ -702,10 +702,7 @@ UdpSocket::UdpSocket( Bonjour::ReplyFn replyfn, const asio::ip::address& multica
 UdpSocket::~UdpSocket()
 {
 	boost::system::error_code ec;
-		// 取消所有异步操作
 		socket.cancel(ec);
-		
-		// 关闭socket
 		if (socket.is_open())
 			socket.close(ec);
 		


### PR DESCRIPTION
# Description

- Replace Chinese comments with English in MixedColorMatchHelpers.cpp,
  MixedColorMatchPanel.cpp, and Bonjour.cpp
- Update i18n key: "The Snapmaker Orca needs an upgrade"
  → "Snapmaker Orca needs an upgrade"
- Update i18n key: "Add all clustered colors after the existing filaments."
  → "Add consumable extruder after existing extruders."
- Change button label from "Append all" to "Append" in ObjColorDialog