### PR TITLE
fix: disable add-filament button in ratio mode when no spare physical

### DIFF
--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -101,7 +101,7 @@ private:
         int thumb_x = track_x + active_w - thumb_d / 2;
         thumb_x = std::clamp(thumb_x, track_x - thumb_d/2, track_x + track_w - thumb_d/2);
         int thumb_y = (sz.y - thumb_d) / 2;
-        dc.SetBrush(wxBrush(StateColor::darkModeColorFor(wxColour("#FFFFFF"))));
+        dc.SetBrush(wxBrush(wxGetApp().dark_mode() ? wxColour("#FFFFFF") : StateColor::darkModeColorFor(wxColour("#FFFFFF"))));
         dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour("#009688")), FromDIP(1)));
         dc.DrawEllipse(thumb_x, thumb_y, thumb_d, thumb_d);
     }
@@ -136,7 +136,7 @@ MixedFilamentDialog::MixedFilamentDialog(wxWindow* parent,
                                      const std::vector<std::string>& filament_colours)
     : DPIDialog(parent, wxID_ANY, _L("Add Mix"),
                 wxDefaultPosition, wxDefaultSize,
-                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+                wxDEFAULT_DIALOG_STYLE)
     , m_filament_colours(filament_colours)
 {
     m_result.component_a   = 1;
@@ -150,7 +150,7 @@ MixedFilamentDialog::MixedFilamentDialog(wxWindow* parent,
                                      const Slic3r::MixedFilament& existing)
     : DPIDialog(parent, wxID_ANY, _L("Edit Mix"),
                 wxDefaultPosition, wxDefaultSize,
-                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+                wxDEFAULT_DIALOG_STYLE)
     , m_filament_colours(filament_colours)
     , m_result(existing)
 {
@@ -881,7 +881,7 @@ void MixedFilamentDialog::build_ui()
 
         // Mix Effect title (same font as Blended Color)
         auto* effect_title = new wxStaticText(m_gradient_effect_card, wxID_ANY, _L("Mix Effect"));
-        effect_title->SetFont(Label::Body_12);
+        effect_title->SetFont(Label::Body_14);
         effect_title->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         effect_title->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         m_gradient_effect_card_sizer->Add(effect_title, 0, wxTOP | wxLEFT | wxRIGHT, FromDIP(16));
@@ -1675,7 +1675,7 @@ void MixedFilamentDialog::rebuild_filament_rows()
 
         auto* row_lbl = new wxStaticText(m_filament_rows_panel, wxID_ANY,
                                          wxString::Format(_L("Filament %d"), i + 1),
-                                         wxDefaultPosition, wxSize(FromDIP(48), -1));
+                                         wxDefaultPosition, wxSize(FromDIP(50), -1));
         row_lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         row_lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         row->Add(row_lbl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -2073,8 +2073,8 @@ void MixedFilamentDialog::update_ratio_or_tri_visibility()
 
     // Update add/remove button visibility
     bool can_remove = !is_match_mode && !is_gradient_mode && !is_cycle_mode && (n > 2);
-    bool can_add = !is_match_mode && !is_gradient_mode && !is_cycle_mode && (n < max_filaments_for_mode(m_current_mode)) && (n < (int)m_filament_colours.size());
-    bool show_add = !is_match_mode && !is_gradient_mode && !is_cycle_mode;
+    bool show_add = !is_match_mode && !is_gradient_mode && !is_cycle_mode && n < max_filaments_for_mode(m_current_mode);
+    bool can_add = n < (int)m_filament_colours.size();
     if (m_btn_remove_filament) m_btn_remove_filament->Show(can_remove);
     if (m_btn_add_filament) {
         m_btn_add_filament->Show(show_add);

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -2073,9 +2073,13 @@ void MixedFilamentDialog::update_ratio_or_tri_visibility()
 
     // Update add/remove button visibility
     bool can_remove = !is_match_mode && !is_gradient_mode && !is_cycle_mode && (n > 2);
-    bool can_add = !is_match_mode && !is_gradient_mode && !is_cycle_mode && (n < max_filaments_for_mode(m_current_mode));
+    bool can_add = !is_match_mode && !is_gradient_mode && !is_cycle_mode && (n < max_filaments_for_mode(m_current_mode)) && (n < (int)m_filament_colours.size());
+    bool show_add = !is_match_mode && !is_gradient_mode && !is_cycle_mode;
     if (m_btn_remove_filament) m_btn_remove_filament->Show(can_remove);
-    if (m_btn_add_filament)    m_btn_add_filament->Show(can_add);
+    if (m_btn_add_filament) {
+        m_btn_add_filament->Show(show_add);
+        m_btn_add_filament->Enable(can_add);
+    }
 
     // Update filament card title visibility
     if (m_filament_card_title) m_filament_card_title->Show(show_filament_rows);

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -101,7 +101,7 @@ private:
         int thumb_x = track_x + active_w - thumb_d / 2;
         thumb_x = std::clamp(thumb_x, track_x - thumb_d/2, track_x + track_w - thumb_d/2);
         int thumb_y = (sz.y - thumb_d) / 2;
-        dc.SetBrush(wxBrush(wxGetApp().dark_mode() ? wxColour("#FFFFFF") : StateColor::darkModeColorFor(wxColour("#FFFFFF"))));
+        dc.SetBrush(wxBrush(wxColour("#FFFFFF")));
         dc.SetPen(wxPen(StateColor::darkModeColorFor(wxColour("#009688")), FromDIP(1)));
         dc.DrawEllipse(thumb_x, thumb_y, thumb_d, thumb_d);
     }


### PR DESCRIPTION
# Description

## Summary
- Fix add-filament button in ratio mode not being disabled when physical filaments are insufficient

## Root Cause
The `can_add` condition in `update_ratio_or_tri_visibility()` only checked
`n < max_filaments_for_mode()` (max 3 for ratio) but never verified that
enough physical filaments exist. With 2 physical filaments and 2 rows,
the button remained enabled.

## Changes
- `MixedFilamentDialog.cpp`: Added `n < m_filament_colours.size()` guard to `can_add`
- Split `Show` (always visible in ratio mode) from `Enable` (only when addable)
