### PR TITLE
fix: Add missing Chinese translation for "Swap filaments"

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -15154,6 +15154,9 @@ msgstr "顺序"
 msgid "Target Color:"
 msgstr "目标色:"
 
+msgid "Swap filaments"
+msgstr "切换方向"
+
 msgid "Min Mix Ratio"
 msgstr "最低混色比例"
 

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -3120,7 +3120,7 @@ void MixedFilamentDialog::validate_cycle_pattern()
             return;
         }
         if (!parsed.invalid_token.empty()) {
-            set_error(_L("Invalid token in pattern. Please check the pattern syntax."));
+            set_error(_L("Unrecognized pattern format. Please check the pattern syntax."));
             return;
         }
     }


### PR DESCRIPTION
# Description

## Summary
- Reword pattern validation error message for clarity
- Add missing Chinese translation for "Swap filaments"

## Changes
- `src/slic3r/GUI/MixedFilamentDialog.cpp`: "Invalid token in pattern" → "Unrecognized pattern format"
- `localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po`: Add "Swap filaments" → "切换方向"

