### PR TITLE
fix: replace fatal exceptions with graceful fallbacks and fix UI lifetime issues

### DIFF
--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -1659,7 +1659,7 @@ WipeTower::ToolChangeResult WipeTower2::tool_change(size_t tool)
                                      << " current_tool=" << m_current_tool
                                      << " requested_new_tool=" << tool
                                      << " planned_sequence=[" << planned_sequence.str() << "]";
-            throw Slic3r::RuntimeError("Wipe tower toolchange not found in plan.");
+            return {};
         }
     }
 

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -133,7 +133,9 @@ Flow LayerRegion::flow(FlowRole role, double layer_height) const
     } else if (role == frTopSolidInfill) {
         config_width = m_region->config().top_surface_line_width;
     } else {
-        throw Slic3r::InvalidArgument("Unknown role");
+        BOOST_LOG_TRIVIAL(error) << "Unknown role in LayerRegion::flow: " << int(role);
+        assert(false);
+        return Flow();
     }
 
     if (config_width.value == 0)

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -109,8 +109,10 @@ void change_opt_value(DynamicPrintConfig& config, const t_config_option_key& opt
 	try{
 
         const ConfigOptionDef *opt_def = config.def()->get(opt_key);
-        if (opt_def == nullptr)
-            throw Slic3r::RuntimeError("Unknown config option key: " + opt_key);
+        if (opt_def == nullptr) {
+            BOOST_LOG_TRIVIAL(error) << "Unknown config option key: " << opt_key;
+            return;
+        }
 
         // Some older presets may not carry newly introduced keys. Ensure the
         // option exists before mutating it through typed accessors below.

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -575,10 +575,13 @@ void MixedFilamentDialog::build_ui()
                 m_tri_wx = 1.0/3.0; m_tri_wy = 1.0/3.0; m_tri_wz = 1.0/3.0;
             }
             resize_gradient_ids(new_count);
-            CallAfter([this]() {
-                rebuild_filament_rows();
-                update_compatibility_warning();
-                Layout(); Fit();
+            wxWeakRef<wxWindow> weak_self(this);
+            CallAfter([weak_self]() {
+                if (!weak_self) return;
+                auto* self = static_cast<MixedFilamentDialog*>(weak_self.get());
+                self->rebuild_filament_rows();
+                self->update_compatibility_warning();
+                self->Layout(); self->Fit();
             });
         });
         card_title_row->Add(m_btn_remove_filament, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
@@ -589,10 +592,13 @@ void MixedFilamentDialog::build_ui()
         m_btn_add_filament->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
             sync_rows_to_result();
             resize_gradient_ids((int)m_filament_rows.size() + 1);
-            CallAfter([this]() {
-                rebuild_filament_rows();
-                update_compatibility_warning();
-                Layout(); Fit();
+            wxWeakRef<wxWindow> weak_self(this);
+            CallAfter([weak_self]() {
+                if (!weak_self) return;
+                auto* self = static_cast<MixedFilamentDialog*>(weak_self.get());
+                self->rebuild_filament_rows();
+                self->update_compatibility_warning();
+                self->Layout(); self->Fit();
             });
         });
         card_title_row->Add(m_btn_add_filament, 0, wxALIGN_CENTER_VERTICAL);
@@ -1268,6 +1274,8 @@ void MixedFilamentDialog::build_ui()
         collect_result();
         EndModal(wxID_OK);
     });
+
+    Bind(wxEVT_CLOSE_WINDOW, [this](wxCloseEvent&) { EndModal(wxID_CANCEL); });
 
     Fit();
     CentreOnParent();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1246,6 +1246,8 @@ public:
             });
         }
 
+        Bind(wxEVT_CLOSE_WINDOW, [this](wxCloseEvent&) { EndModal(wxID_CANCEL); });
+
         CentreOnParent();
         wxGetApp().UpdateDlgDarkUI(this);
     }
@@ -3295,6 +3297,8 @@ public:
         SetSizerAndFit(root);
         SetMinSize(wxSize(FromDIP(380), std::max(GetSize().GetHeight(), FromDIP(460))));
         update_weight_labels();
+
+        Bind(wxEVT_CLOSE_WINDOW, [this](wxCloseEvent&) { EndModal(wxID_CANCEL); });
 
         if (m_color_map) {
             m_color_map->Bind(wxEVT_SLIDER, [this](wxCommandEvent &) {


### PR DESCRIPTION
### Summary

- Replace hard exceptions with graceful degradation (log + early return) in three locations where unexpected input can reach production: wipe tower tool change, layer region flow role, and config option parsing
- Fix potential use-after-free in MixedFilamentDialog::CallAfter lambdas by using wxWeakRef instead of raw this capture
- Wire up wxEVT_CLOSE_WINDOW on modal dialogs so the title-bar close button properly ends the modal session
### Motivation

- These are defensive robustness improvements discovered during mixed filament feature testing. The exception-to-return changes prevent crashes when hitting edge cases (e.g., sentinel tool values in wipe tower cleanup, unknown flow roles from future configs). The wxWeakRef fix prevents a crash when a dialog is closed before its CallAfter callback fires. The close-event bindings fix a UX paper-cut where clicking X did nothing.