### PR TITLE
chore: refine UI string wording and sync i18n

### DIFF
--- a/localization/i18n/Snapmaker_Orca.pot
+++ b/localization/i18n/Snapmaker_Orca.pot
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Click to download new version in default browser: %s"
 msgstr ""
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr ""
 
 msgid "This is the newest version."
@@ -8121,7 +8121,7 @@ msgstr ""
 msgid "Approximate color matching."
 msgstr ""
 
-msgid "Append all"
+msgid "Append"
 msgstr ""
 
 msgid "Add consumable extruder after existing extruders."

--- a/localization/i18n/ca/Snapmaker_Orca_ca.po
+++ b/localization/i18n/ca/Snapmaker_Orca_ca.po
@@ -1600,7 +1600,7 @@ msgstr "S'està carregant la configuració"
 msgid "Click to download new version in default browser: %s"
 msgstr "Feu clic per descarregar la nova versió al navegador predeterminat: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "L'Snapmaker Orca necessita una actualització"
 
 msgid "This is the newest version."

--- a/localization/i18n/cs/Snapmaker_Orca_cs.po
+++ b/localization/i18n/cs/Snapmaker_Orca_cs.po
@@ -1583,7 +1583,7 @@ msgstr "Načítání konfigurace"
 msgid "Click to download new version in default browser: %s"
 msgstr "Kliknutím stáhnete novou verzi ve výchozím prohlížeči: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca potřebuje aktualizaci"
 
 msgid "This is the newest version."

--- a/localization/i18n/de/Snapmaker_Orca_de.po
+++ b/localization/i18n/de/Snapmaker_Orca_de.po
@@ -1603,7 +1603,7 @@ msgstr ""
 "Klicken Sie hier, um die neueste Version im Standardbrowser herunterzuladen: "
 "%s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca benötigt ein Upgrade"
 
 msgid "This is the newest version."

--- a/localization/i18n/en/Snapmaker_Orca_en.po
+++ b/localization/i18n/en/Snapmaker_Orca_en.po
@@ -1535,7 +1535,7 @@ msgstr ""
 msgid "Click to download new version in default browser: %s"
 msgstr ""
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca needs an update"
 
 msgid "This is the newest version."
@@ -8245,7 +8245,7 @@ msgstr ""
 msgid "Approximate color matching."
 msgstr ""
 
-msgid "Append all"
+msgid "Append"
 msgstr ""
 
 msgid "Add consumable extruder after existing extruders."

--- a/localization/i18n/es/Snapmaker_Orca_es.po
+++ b/localization/i18n/es/Snapmaker_Orca_es.po
@@ -1605,7 +1605,7 @@ msgid "Click to download new version in default browser: %s"
 msgstr ""
 "Haga clic para descargar la nueva versión en el navegador por defecto: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca necesita una actualización"
 
 msgid "This is the newest version."

--- a/localization/i18n/fr/Snapmaker_Orca_fr.po
+++ b/localization/i18n/fr/Snapmaker_Orca_fr.po
@@ -1617,7 +1617,7 @@ msgstr ""
 "Cliquez pour télécharger la nouvelle version dans le navigateur par défaut : "
 "%s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca a besoin d’être mis à jour"
 
 msgid "This is the newest version."

--- a/localization/i18n/hu/Snapmaker_Orca_hu.po
+++ b/localization/i18n/hu/Snapmaker_Orca_hu.po
@@ -1543,7 +1543,7 @@ msgstr "Konfiguráció betöltése"
 msgid "Click to download new version in default browser: %s"
 msgstr "Kattints az új verzió letöltéséhez az alapértelmezett böngészőben: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "A Snapmaker Orcat frissíteni kell"
 
 msgid "This is the newest version."

--- a/localization/i18n/it/Snapmaker_Orca_it.po
+++ b/localization/i18n/it/Snapmaker_Orca_it.po
@@ -1611,7 +1611,7 @@ msgstr "Caricamento configurazione"
 msgid "Click to download new version in default browser: %s"
 msgstr "Fai clic per scaricare la nuova versione nel browser predefinito: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca necessita di aggiornamento"
 
 msgid "This is the newest version."

--- a/localization/i18n/ja/Snapmaker_Orca_ja.po
+++ b/localization/i18n/ja/Snapmaker_Orca_ja.po
@@ -1561,7 +1561,7 @@ msgstr "構成を読込み中"
 msgid "Click to download new version in default browser: %s"
 msgstr "新バージョンをダウンロードするにはクリックしてください: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca をアップデートする必要があります"
 
 msgid "This is the newest version."
@@ -7254,9 +7254,6 @@ msgstr "アップデート中では造形タスクを送信できません"
 
 msgid "The selected printer is incompatible with the chosen printer presets."
 msgstr ""
-
-msgid "Incompatible filament types cannot be mixed. Please correct the selection."
-msgstr "互換性のないフィラメントタイプは混合できません。選択を修正してください。"
 
 msgid "An SD card needs to be inserted before send to printer SD card."
 msgstr ""

--- a/localization/i18n/ko/Snapmaker_Orca_ko.po
+++ b/localization/i18n/ko/Snapmaker_Orca_ko.po
@@ -1573,7 +1573,7 @@ msgstr "구성 파일 로드 중"
 msgid "Click to download new version in default browser: %s"
 msgstr "기본 브라우저에서 새 버전을 다운로드하려면 클릭: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca 업그레이드가 필요합니다"
 
 msgid "This is the newest version."

--- a/localization/i18n/lt/Snapmaker_Orca_lt.po
+++ b/localization/i18n/lt/Snapmaker_Orca_lt.po
@@ -1591,7 +1591,7 @@ msgid "Click to download new version in default browser: %s"
 msgstr ""
 "Spustelėkite, kad atsisiųstumėte naują versiją numatytoje naršyklėje: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca reikia atnaujinti"
 
 msgid "This is the newest version."

--- a/localization/i18n/nl/Snapmaker_Orca_nl.po
+++ b/localization/i18n/nl/Snapmaker_Orca_nl.po
@@ -1567,7 +1567,7 @@ msgid "Click to download new version in default browser: %s"
 msgstr ""
 "Klik hier om de nieuwe versie te downloaden in je standaard browser: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca heeft een upgrade nodig"
 
 msgid "This is the newest version."

--- a/localization/i18n/pl/Snapmaker_Orca_pl.po
+++ b/localization/i18n/pl/Snapmaker_Orca_pl.po
@@ -1591,7 +1591,7 @@ msgstr "Ładowanie konfiguracji"
 msgid "Click to download new version in default browser: %s"
 msgstr "Kliknij, aby pobrać nową wersję w domyślnej przeglądarce: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca wymaga uaktualnienia"
 
 msgid "This is the newest version."

--- a/localization/i18n/pt_BR/Snapmaker_Orca_pt_BR.po
+++ b/localization/i18n/pt_BR/Snapmaker_Orca_pt_BR.po
@@ -1597,7 +1597,7 @@ msgstr "Carregando configuração"
 msgid "Click to download new version in default browser: %s"
 msgstr "Clique para baixar a nova versão no navegador padrão: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "O Snapmaker Orca precisa de uma atualização"
 
 msgid "This is the newest version."

--- a/localization/i18n/ru/Snapmaker_Orca_ru.po
+++ b/localization/i18n/ru/Snapmaker_Orca_ru.po
@@ -1607,7 +1607,7 @@ msgid "Click to download new version in default browser: %s"
 msgstr ""
 "Нажмите OK, чтобы загрузить последнюю версию в браузере по умолчанию: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Orca Slice нуждается в обновлении."
 
 msgid "This is the newest version."

--- a/localization/i18n/sv/Snapmaker_Orca_sv.po
+++ b/localization/i18n/sv/Snapmaker_Orca_sv.po
@@ -1539,7 +1539,7 @@ msgstr "Konfigurationen laddas"
 msgid "Click to download new version in default browser: %s"
 msgstr "Tryck på ladda ner ny version ifrån standard webbläsaren: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca behöver uppdateras"
 
 msgid "This is the newest version."

--- a/localization/i18n/tr/Snapmaker_Orca_tr.po
+++ b/localization/i18n/tr/Snapmaker_Orca_tr.po
@@ -1585,7 +1585,7 @@ msgstr "Yapılandırma yükleniyor"
 msgid "Click to download new version in default browser: %s"
 msgstr "Yeni sürümü varsayılan tarayıcıda indirmek için tıklayın: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Orca Dilimleyicinin yükseltilmesi gerekiyor"
 
 msgid "This is the newest version."

--- a/localization/i18n/uk/Snapmaker_Orca_uk.po
+++ b/localization/i18n/uk/Snapmaker_Orca_uk.po
@@ -1593,7 +1593,7 @@ msgid "Click to download new version in default browser: %s"
 msgstr ""
 "Натисніть OK, щоб завантажити останню версію в стандартному браузері: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca потребує оновлення"
 
 msgid "This is the newest version."

--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -1537,7 +1537,7 @@ msgstr "正在加载配置"
 msgid "Click to download new version in default browser: %s"
 msgstr "在默认浏览器中点击下载最新版本: %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca需要进行升级"
 
 msgid "This is the newest version."

--- a/localization/i18n/zh_TW/Snapmaker_Orca_zh_TW.po
+++ b/localization/i18n/zh_TW/Snapmaker_Orca_zh_TW.po
@@ -1561,7 +1561,7 @@ msgstr "正在讀取設定檔"
 msgid "Click to download new version in default browser: %s"
 msgstr "在預設瀏覽器中開啟頁面下載最新版本： %s"
 
-msgid "Snapmaker Orca needs an upgrade"
+msgid "The Snapmaker Orca needs an upgrade"
 msgstr "Snapmaker Orca 需要進行升級"
 
 msgid "This is the newest version."
@@ -7316,9 +7316,6 @@ msgstr "設備升級中，無法傳送列印作業"
 
 msgid "The selected printer is incompatible with the chosen printer presets."
 msgstr "所選列印設備與選擇的列印設備預設檔不相容。"
-
-msgid "Incompatible filament types cannot be mixed. Please correct the selection."
-msgstr "不同類型耗材不可混色列印，請修正異常混色設定。"
 
 msgid "An SD card needs to be inserted before send to printer SD card."
 msgstr "傳送到列印設備需要插入 SD 記憶卡。"
@@ -16739,12 +16736,6 @@ msgstr "經由列印主機連接的列印設備連接失敗。"
 #, c-format, boost-format
 msgid "Mismatched type of print host: %s"
 msgstr "列印主機類型不符：%s"
-
-msgid "Mixed Color (Experimental)"
-msgstr "混色(實驗)"
-
-msgid "Mixed Color Layer Thinner"
-msgstr "混色層高細化"
 
 msgid "Connection to AstroBox is working correctly."
 msgstr "與 AstroBox 的連接工作正常。"

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2674,7 +2674,7 @@ bool GUI_App::on_init_inner()
                 wxString tips = wxString::Format(_L("Click to download new version in default browser: %s"), version_str);
                 DownloadDialog dialog(this->mainframe,
                     tips,
-                    _L("Snapmaker Orca needs an upgrade"),
+                    _L("The Snapmaker Orca needs an upgrade"),
                     false,
                     wxCENTER | wxICON_INFORMATION);
                 dialog.SetExtendedMessage(description_text);


### PR DESCRIPTION
## Summary

Two small UI string refinements and cleanup of orphaned translations:

- **"Snapmaker Orca needs an upgrade" → "The Snapmaker Orca needs an upgrade"**
  Adds the missing article for natural English wording. Updated in source (`GUI_App.cpp`), template (`.pot`), and all 18 locale `.po` files.
- **"Append all" → "Append"**
  Simplified label text. Updated in `.pot` and `en.po`.
- **Removed 3 orphaned translations from `ja.po` and `zh_TW.po`**
  Strings no longer present in source ("Incompatible filament types cannot be mixed", "Mixed Color (Experimental)", "Mixed Color Layer Thinner").