### PR TITLE
Fix 3MF config persistence and Local-Z mixed domains

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -907,6 +907,7 @@ static std::vector<std::string> s_Preset_print_options {
      "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold", "scarf_joint_speed", "scarf_joint_flow_ratio", "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length", "seam_slope_steps", "seam_slope_inner_walls", "scarf_overhang_threshold",
      "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width",
      "dithering_local_z_mode",
+     "dithering_local_z_whole_objects",
      "dithering_local_z_infill",
      "calib_flowrate_topinfill_special_order",
 };

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -80,6 +80,12 @@ static std::vector<std::string> s_project_options {
     "mixed_filament_definitions",
     "mixed_color_layer_height_a",
     "mixed_color_layer_height_b",
+    "dithering_z_step_size",
+    "dithering_local_z_mode",
+    "dithering_local_z_whole_objects",
+    "dithering_local_z_infill",
+    "dithering_local_z_direct_multicolor",
+    "dithering_step_painted_zones_only",
 };
 
 // SM_FEATURE: add Snapmaker machine as default

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -2860,13 +2860,14 @@ static std::vector<std::vector<ExPolygons>> local_z_planner_segmentation_with_wh
                 continue;
 
             const unsigned int state_id = segmentation_channel_filament_id(channel_idx);
+            if (!mixed_mgr.is_mixed(state_id, num_physical))
+                continue;
             if (channel_idx >= augmented[layer_id].size())
                 augmented[layer_id].resize(channel_idx + 1);
 
             append(augmented[layer_id][channel_idx], state_masks);
             layer_has_overlay = true;
-            if (mixed_mgr.is_mixed(state_id, num_physical))
-                ++overlay_mixed_channels;
+            ++overlay_mixed_channels;
         }
 
         for (size_t channel_idx = num_physical + 1; channel_idx < augmented[layer_id].size(); ++channel_idx) {
@@ -3159,9 +3160,9 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
     // Multi-color layer-cycle rows choose a pair once per nominal layer/zone
     // and rotate that pair independently from per-subpass A/B cadence.
     std::vector<int> row_layer_cycle_index(mixed_rows.size(), 0);
-    // Painted-only Local-Z keeps cadence isolated per zone. Whole-object Local-Z
-    // instead syncs newly introduced painted rows to the dominant mixed cadence
-    // so painted islands do not restart their phase at the boundary.
+    // Keep Local-Z cadence isolated per mixed row. Different mixed rows may
+    // share a component filament, but their ratios and phase must not bleed
+    // into one another.
     std::vector<uint8_t> row_active_prev_layer(mixed_rows.size(), uint8_t(0));
 
     std::vector<std::vector<int>> per_row_gradient_layers(mixed_rows.size());
@@ -3270,18 +3271,8 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
                     row_direct_component_error_mm[row_idx].size() == row_direct_component_ids[row_idx].size()) {
                     std::fill(row_direct_component_error_mm[row_idx].begin(), row_direct_component_error_mm[row_idx].end(), 0.0);
                 }
-                const bool can_sync_to_dominant =
-                    local_z_whole_objects &&
-                    dominant_mixed_idx < mixed_rows.size() &&
-                    dominant_mixed_idx != row_idx &&
-                    row_active_this_layer[dominant_mixed_idx] != 0;
-                if (can_sync_to_dominant) {
-                    row_cadence_index[row_idx]     = row_cadence_index[dominant_mixed_idx];
-                    row_layer_cycle_index[row_idx] = row_layer_cycle_index[dominant_mixed_idx];
-                } else {
-                    row_cadence_index[row_idx]     = 0;
-                    row_layer_cycle_index[row_idx] = 0;
-                }
+                row_cadence_index[row_idx]     = 0;
+                row_layer_cycle_index[row_idx] = 0;
             }
         }
         std::vector<LocalZActivePair> row_active_pairs(mixed_rows.size());
@@ -3336,7 +3327,10 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
                 continue;
             const unsigned int state_id = segmentation_channel_filament_id(channel_idx);
             if (state_id >= 1 && state_id <= num_physical) {
-                if (!dominant_is_gradient)
+                // Whole-object Local-Z uses physical paint only as a blocker
+                // when building augmented mixed masks. Do not put ordinary
+                // filaments into the Local-Z split domain.
+                if (!local_z_whole_objects && !dominant_is_gradient)
                     append(fixed_state_masks_by_extruder[state_id - 1], state_masks);
                 continue;
             }
@@ -3420,17 +3414,20 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
 
         std::vector<std::vector<double>> isolated_row_pass_heights(mixed_rows.size());
         bool isolated_multi_row_mode = false;
-        if (interval.has_mixed_paint &&
-            preferred_a <= EPSILON &&
-            preferred_b <= EPSILON &&
-            active_mixed_rows > 1) {
+        if (interval.has_mixed_paint && active_mixed_rows > 1) {
             size_t isolated_rows_with_split = 0;
             for (size_t row_idx = 0; row_idx < row_active_this_layer.size(); ++row_idx) {
                 if (row_active_this_layer[row_idx] == 0)
                     continue;
 
                 std::vector<double> row_passes;
-                if (row_uses_direct_multicolor_solver[row_idx] != 0) {
+                if (preferred_a > EPSILON || preferred_b > EPSILON) {
+                    row_passes = build_local_z_pass_heights(interval.base_height,
+                                                            mixed_lower,
+                                                            mixed_upper,
+                                                            preferred_a,
+                                                            preferred_b);
+                } else if (row_uses_direct_multicolor_solver[row_idx] != 0) {
                     row_passes = build_local_z_direct_multicolor_pass_heights(mixed_rows[row_idx],
                                                                              row_direct_component_weights[row_idx],
                                                                              interval.base_height,

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10035,7 +10035,16 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                     "mixed_filament_pointillism_pixel_size",
                                     "mixed_filament_pointillism_line_gap",
                                     "mixed_filament_component_bias_enabled",
-                                    "mixed_filament_surface_indentation"
+                                    "mixed_filament_surface_indentation",
+                                    "mixed_filament_region_collapse",
+                                    "mixed_color_layer_height_a",
+                                    "mixed_color_layer_height_b",
+                                    "dithering_z_step_size",
+                                    "dithering_local_z_mode",
+                                    "dithering_local_z_whole_objects",
+                                    "dithering_local_z_infill",
+                                    "dithering_local_z_direct_multicolor",
+                                    "dithering_step_painted_zones_only"
                                 };
                                 preset_bundle->project_config.apply_only(config_loaded, imported_project_option_keys, true);
                                 if (current_num_filaments != desired_physical_filaments) {

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -5,6 +5,7 @@
 #include "libslic3r/Print.hpp"
 #include "libslic3r/GCode/ToolOrdering.hpp"
 
+#include <algorithm>
 #include <sstream>
 #include <vector>
 
@@ -2789,4 +2790,18 @@ TEST_CASE("dithering_local_z_mode dirty tracking via is_dirty", "[MixedFilament]
     // Change edited to false → should be dirty
     edited.config.set_key_value("dithering_local_z_mode", new ConfigOptionBool(false));
     CHECK(PresetCollection::is_dirty(&edited, &reference));
+}
+
+TEST_CASE("Local Z whole object setting is available for 3MF project config", "[MixedFilament][Config]")
+{
+    const auto &print_options = Preset::print_options();
+    CHECK(std::find(print_options.begin(), print_options.end(), "dithering_local_z_whole_objects") != print_options.end());
+
+    PresetBundle bundle;
+    REQUIRE(bundle.project_config.has("dithering_local_z_whole_objects"));
+
+    bundle.project_config.set_key_value("dithering_local_z_whole_objects", new ConfigOptionBool(true));
+    DynamicPrintConfig full_config = bundle.full_fff_config();
+    REQUIRE(full_config.has("dithering_local_z_whole_objects"));
+    CHECK(full_config.opt_bool("dithering_local_z_whole_objects"));
 }


### PR DESCRIPTION
## 摘要
- 将 Local-Z Full Domain 以及相关混色耗材项目设置加入 3MF 项目配置/导入路径，避免模型导入后参数丢失。
- 将 whole-object Local-Z 的遮罩作用范围限制在混色耗材行内，避免单色区域被混色 Local-Z 逻辑影响。
- 隔离不同混色行之间的 Local-Z 节奏，避免一个混色组合影响另一个混色组合。

Fixes #125.
Fixes #126.

## 验证
- 已运行 `git diff --check`。
- 已构建 `libslic3r` Release。
- 已构建 `libslic3r_gui` Release。

## Summary
- Persist Local-Z Full Domain and related mixed-filament project settings through 3MF project config/import paths.
- Keep whole-object Local-Z masks scoped to mixed filament rows so single-color regions do not inherit mixed Local-Z behavior.
- Isolate Local-Z cadence between separate mixed rows so one mixed pair does not influence another.

Fixes #125.
Fixes #126.

## Validation
- Ran `git diff --check`.
- Built `libslic3r` Release.
- Built `libslic3r_gui` Release.