### PR TITLE
Fix 3MF persistence for Local-Z project settings

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -907,6 +907,7 @@ static std::vector<std::string> s_Preset_print_options {
      "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold", "scarf_joint_speed", "scarf_joint_flow_ratio", "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length", "seam_slope_steps", "seam_slope_inner_walls", "scarf_overhang_threshold",
      "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width",
      "dithering_local_z_mode",
+     "dithering_local_z_whole_objects",
      "dithering_local_z_infill",
      "calib_flowrate_topinfill_special_order",
 };

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -80,6 +80,12 @@ static std::vector<std::string> s_project_options {
     "mixed_filament_definitions",
     "mixed_color_layer_height_a",
     "mixed_color_layer_height_b",
+    "dithering_z_step_size",
+    "dithering_local_z_mode",
+    "dithering_local_z_whole_objects",
+    "dithering_local_z_infill",
+    "dithering_local_z_direct_multicolor",
+    "dithering_step_painted_zones_only",
 };
 
 // SM_FEATURE: add Snapmaker machine as default

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4362,7 +4362,7 @@ void PrintConfigDef::init_fff_params()
                      "This is enabled automatically with Subdivide Mix Layer. Turn it off to keep infill on the normal layer height.\n\n"
                      "It can improve internal color mixing, but may add toolchanges and affect infill behavior.");
     def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionBool(true));
+    def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("dithering_local_z_direct_multicolor", coBool);
     def->label = L("Use direct multicolor Local-Z solver");

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10021,31 +10021,9 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             size = int(desired_physical_filaments);
 
                         PresetBundle *preset_bundle = wxGetApp().preset_bundle;
-                        bool imported_print_options = false;
                         if (geometry_only_project_import && preset_bundle != nullptr) {
                             const size_t current_num_filaments = preset_bundle->filament_presets.size();
                             const bool current_project_empty = this->model.objects.empty();
-                            static const t_config_option_keys imported_local_z_option_keys = {
-                                "dithering_z_step_size",
-                                "dithering_local_z_mode",
-                                "dithering_local_z_whole_objects",
-                                "dithering_local_z_infill",
-                                "dithering_local_z_direct_multicolor",
-                                "dithering_step_painted_zones_only"
-                            };
-                            static const t_config_option_keys imported_print_option_keys = {
-                                "dithering_local_z_mode",
-                                "dithering_local_z_whole_objects",
-                                "dithering_local_z_infill"
-                            };
-                            auto apply_imported_print_options = [&preset_bundle, &config_loaded, &imported_print_options]() {
-                                imported_print_options = std::any_of(imported_print_option_keys.begin(),
-                                                                     imported_print_option_keys.end(),
-                                                                     [&config_loaded](const std::string &key) {
-                                                                         return config_loaded.has(key);
-                                                                     });
-                                preset_bundle->prints.get_edited_preset().config.apply_only(config_loaded, imported_print_option_keys, true);
-                            };
                             if (current_project_empty) {
                                 static const t_config_option_keys imported_project_option_keys = {
                                     "filament_colour",
@@ -10057,19 +10035,9 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                     "mixed_filament_pointillism_pixel_size",
                                     "mixed_filament_pointillism_line_gap",
                                     "mixed_filament_component_bias_enabled",
-                                    "mixed_filament_surface_indentation",
-                                    "mixed_filament_region_collapse",
-                                    "mixed_color_layer_height_a",
-                                    "mixed_color_layer_height_b",
-                                    "dithering_z_step_size",
-                                    "dithering_local_z_mode",
-                                    "dithering_local_z_whole_objects",
-                                    "dithering_local_z_infill",
-                                    "dithering_local_z_direct_multicolor",
-                                    "dithering_step_painted_zones_only"
+                                    "mixed_filament_surface_indentation"
                                 };
                                 preset_bundle->project_config.apply_only(config_loaded, imported_project_option_keys, true);
-                                apply_imported_print_options();
                                 if (current_num_filaments != desired_physical_filaments) {
                                     q->confirm_auto_generated_gradients(desired_physical_filaments);
                                     preset_bundle->set_num_filaments(unsigned(desired_physical_filaments));
@@ -10080,19 +10048,15 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                                         << " desired_physical_filaments=" << desired_physical_filaments
                                                         << " mixed_enabled=" << preset_bundle->mixed_filaments.enabled_count();
                                 wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
-                            } else {
-                                preset_bundle->project_config.apply_only(config_loaded, imported_local_z_option_keys, true);
-                                apply_imported_print_options();
-                                if (current_num_filaments < desired_physical_filaments) {
-                                    std::vector<std::string> new_colors;
-                                    if (imported_filament_colors.size() > current_num_filaments) {
-                                        new_colors.assign(imported_filament_colors.begin() + current_num_filaments,
-                                                          imported_filament_colors.begin() + desired_physical_filaments);
-                                    }
-                                    q->confirm_auto_generated_gradients(desired_physical_filaments);
-                                    preset_bundle->set_num_filaments(unsigned(desired_physical_filaments), new_colors);
-                                    wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
+                            } else if (current_num_filaments < desired_physical_filaments) {
+                                std::vector<std::string> new_colors;
+                                if (imported_filament_colors.size() > current_num_filaments) {
+                                    new_colors.assign(imported_filament_colors.begin() + current_num_filaments,
+                                                      imported_filament_colors.begin() + desired_physical_filaments);
                                 }
+                                q->confirm_auto_generated_gradients(desired_physical_filaments);
+                                preset_bundle->set_num_filaments(unsigned(desired_physical_filaments), new_colors);
+                                wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
                             }
                         }
 
@@ -10108,12 +10072,6 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             ++filament_size;
                         }
                         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
-                        if (imported_print_options) {
-                            if (Tab *print_tab = wxGetApp().get_tab(Preset::TYPE_PRINT)) {
-                                print_tab->update_dirty();
-                                print_tab->reload_config();
-                            }
-                        }
                     }
 
                     std::string import_project_action = wxGetApp().app_config->get("import_project_action");

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10024,6 +10024,22 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                         if (geometry_only_project_import && preset_bundle != nullptr) {
                             const size_t current_num_filaments = preset_bundle->filament_presets.size();
                             const bool current_project_empty = this->model.objects.empty();
+                            static const t_config_option_keys imported_local_z_option_keys = {
+                                "dithering_z_step_size",
+                                "dithering_local_z_mode",
+                                "dithering_local_z_whole_objects",
+                                "dithering_local_z_infill",
+                                "dithering_local_z_direct_multicolor",
+                                "dithering_step_painted_zones_only"
+                            };
+                            static const t_config_option_keys imported_print_option_keys = {
+                                "dithering_local_z_mode",
+                                "dithering_local_z_whole_objects",
+                                "dithering_local_z_infill"
+                            };
+                            auto apply_imported_print_options = [&preset_bundle, &config_loaded]() {
+                                preset_bundle->prints.get_edited_preset().config.apply_only(config_loaded, imported_print_option_keys, true);
+                            };
                             if (current_project_empty) {
                                 static const t_config_option_keys imported_project_option_keys = {
                                     "filament_colour",
@@ -10047,6 +10063,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                     "dithering_step_painted_zones_only"
                                 };
                                 preset_bundle->project_config.apply_only(config_loaded, imported_project_option_keys, true);
+                                apply_imported_print_options();
                                 if (current_num_filaments != desired_physical_filaments) {
                                     q->confirm_auto_generated_gradients(desired_physical_filaments);
                                     preset_bundle->set_num_filaments(unsigned(desired_physical_filaments));
@@ -10057,15 +10074,19 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                                         << " desired_physical_filaments=" << desired_physical_filaments
                                                         << " mixed_enabled=" << preset_bundle->mixed_filaments.enabled_count();
                                 wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
-                            } else if (current_num_filaments < desired_physical_filaments) {
-                                std::vector<std::string> new_colors;
-                                if (imported_filament_colors.size() > current_num_filaments) {
-                                    new_colors.assign(imported_filament_colors.begin() + current_num_filaments,
-                                                      imported_filament_colors.begin() + desired_physical_filaments);
+                            } else {
+                                preset_bundle->project_config.apply_only(config_loaded, imported_local_z_option_keys, true);
+                                apply_imported_print_options();
+                                if (current_num_filaments < desired_physical_filaments) {
+                                    std::vector<std::string> new_colors;
+                                    if (imported_filament_colors.size() > current_num_filaments) {
+                                        new_colors.assign(imported_filament_colors.begin() + current_num_filaments,
+                                                          imported_filament_colors.begin() + desired_physical_filaments);
+                                    }
+                                    q->confirm_auto_generated_gradients(desired_physical_filaments);
+                                    preset_bundle->set_num_filaments(unsigned(desired_physical_filaments), new_colors);
+                                    wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
                                 }
-                                q->confirm_auto_generated_gradients(desired_physical_filaments);
-                                preset_bundle->set_num_filaments(unsigned(desired_physical_filaments), new_colors);
-                                wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
                             }
                         }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10021,6 +10021,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             size = int(desired_physical_filaments);
 
                         PresetBundle *preset_bundle = wxGetApp().preset_bundle;
+                        bool imported_print_options = false;
                         if (geometry_only_project_import && preset_bundle != nullptr) {
                             const size_t current_num_filaments = preset_bundle->filament_presets.size();
                             const bool current_project_empty = this->model.objects.empty();
@@ -10037,7 +10038,12 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                 "dithering_local_z_whole_objects",
                                 "dithering_local_z_infill"
                             };
-                            auto apply_imported_print_options = [&preset_bundle, &config_loaded]() {
+                            auto apply_imported_print_options = [&preset_bundle, &config_loaded, &imported_print_options]() {
+                                imported_print_options = std::any_of(imported_print_option_keys.begin(),
+                                                                     imported_print_option_keys.end(),
+                                                                     [&config_loaded](const std::string &key) {
+                                                                         return config_loaded.has(key);
+                                                                     });
                                 preset_bundle->prints.get_edited_preset().config.apply_only(config_loaded, imported_print_option_keys, true);
                             };
                             if (current_project_empty) {
@@ -10102,6 +10108,12 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             ++filament_size;
                         }
                         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
+                        if (imported_print_options) {
+                            if (Tab *print_tab = wxGetApp().get_tab(Preset::TYPE_PRINT)) {
+                                print_tab->update_dirty();
+                                print_tab->reload_config();
+                            }
+                        }
                     }
 
                     std::string import_project_action = wxGetApp().app_config->get("import_project_action");

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10035,7 +10035,16 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                     "mixed_filament_pointillism_pixel_size",
                                     "mixed_filament_pointillism_line_gap",
                                     "mixed_filament_component_bias_enabled",
-                                    "mixed_filament_surface_indentation"
+                                    "mixed_filament_surface_indentation",
+                                    "mixed_filament_region_collapse",
+                                    "mixed_color_layer_height_a",
+                                    "mixed_color_layer_height_b",
+                                    "dithering_z_step_size",
+                                    "dithering_local_z_mode",
+                                    "dithering_local_z_whole_objects",
+                                    "dithering_local_z_infill",
+                                    "dithering_local_z_direct_multicolor",
+                                    "dithering_step_painted_zones_only"
                                 };
                                 preset_bundle->project_config.apply_only(config_loaded, imported_project_option_keys, true);
                                 if (current_num_filaments != desired_physical_filaments) {

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1528,17 +1528,37 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
     if(opt_key == "purge_in_prime_tower")
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
 
-    if (m_type == Preset::TYPE_PRINT &&
-        opt_key == "dithering_local_z_mode" &&
-        boost::any_cast<bool>(value) &&
-        m_config->has("dithering_local_z_infill") &&
-        !m_config->opt_bool("dithering_local_z_infill")) {
+    if (m_type == Preset::TYPE_PRINT && opt_key == "dithering_local_z_mode") {
+        const bool local_z_enabled = boost::any_cast<bool>(value);
         DynamicPrintConfig new_conf = *m_config;
-        new_conf.set_key_value("dithering_local_z_infill", new ConfigOptionBool(true));
-        m_config_manipulation.apply(m_config, &new_conf);
-
+        bool dependent_config_changed = false;
         DynamicPrintConfig &project_cfg = wxGetApp().preset_bundle->project_config;
-        project_cfg.set_key_value("dithering_local_z_infill", new ConfigOptionBool(true));
+
+        auto set_print_bool = [this, &new_conf, &dependent_config_changed](const char *key, bool enabled) {
+            if (!m_config->has(key) || m_config->option(key) == nullptr || m_config->opt_bool(key) == enabled)
+                return;
+            new_conf.set_key_value(key, new ConfigOptionBool(enabled));
+            dependent_config_changed = true;
+        };
+        auto set_project_bool = [&project_cfg](const char *key, bool enabled) {
+            project_cfg.set_key_value(key, new ConfigOptionBool(enabled));
+        };
+
+        if (local_z_enabled) {
+            set_print_bool("dithering_local_z_infill", true);
+        } else {
+            set_print_bool("dithering_local_z_whole_objects", false);
+            set_print_bool("dithering_local_z_infill", false);
+            set_project_bool("dithering_local_z_direct_multicolor", false);
+        }
+
+        if (dependent_config_changed)
+            m_config_manipulation.apply(m_config, &new_conf);
+
+        if (new_conf.has("dithering_local_z_whole_objects"))
+            set_project_bool("dithering_local_z_whole_objects", new_conf.opt_bool("dithering_local_z_whole_objects"));
+        if (new_conf.has("dithering_local_z_infill"))
+            set_project_bool("dithering_local_z_infill", new_conf.opt_bool("dithering_local_z_infill"));
     }
 
     if (opt_key == "enable_prime_tower") {

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -5,6 +5,7 @@
 #include "libslic3r/Print.hpp"
 #include "libslic3r/GCode/ToolOrdering.hpp"
 
+#include <algorithm>
 #include <sstream>
 #include <vector>
 
@@ -2789,4 +2790,18 @@ TEST_CASE("dithering_local_z_mode dirty tracking via is_dirty", "[MixedFilament]
     // Change edited to false → should be dirty
     edited.config.set_key_value("dithering_local_z_mode", new ConfigOptionBool(false));
     CHECK(PresetCollection::is_dirty(&edited, &reference));
+}
+
+TEST_CASE("Local Z whole object setting is available for 3MF project config", "[MixedFilament][Config]")
+{
+    const auto &print_options = Preset::print_options();
+    CHECK(std::find(print_options.begin(), print_options.end(), "dithering_local_z_whole_objects") != print_options.end());
+
+    PresetBundle bundle;
+    REQUIRE(bundle.project_config.has("dithering_local_z_whole_objects"));
+
+    bundle.project_config.set_key_value("dithering_local_z_whole_objects", new ConfigOptionBool(true));
+    DynamicPrintConfig full_config = bundle.full_fff_config();
+    REQUIRE(full_config.has("dithering_local_z_whole_objects"));
+    CHECK(full_config.opt_bool("dithering_local_z_whole_objects"));
 }

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -2805,3 +2805,16 @@ TEST_CASE("Local Z whole object setting is available for 3MF project config", "[
     REQUIRE(full_config.has("dithering_local_z_whole_objects"));
     CHECK(full_config.opt_bool("dithering_local_z_whole_objects"));
 }
+
+TEST_CASE("Local Z infill subdivision defaults inactive when Subdivide Mix Layer is off", "[MixedFilament][Config]")
+{
+    PresetBundle bundle;
+    REQUIRE(bundle.project_config.has("dithering_local_z_mode"));
+    REQUIRE(bundle.project_config.has("dithering_local_z_infill"));
+    CHECK_FALSE(bundle.project_config.opt_bool("dithering_local_z_mode"));
+    CHECK_FALSE(bundle.project_config.opt_bool("dithering_local_z_infill"));
+
+    DynamicPrintConfig full_config = bundle.full_fff_config();
+    REQUIRE(full_config.has("dithering_local_z_infill"));
+    CHECK_FALSE(full_config.opt_bool("dithering_local_z_infill"));
+}


### PR DESCRIPTION
## Summary
- Add Local-Z Full Domain to saved print preset/project options.
- Persist related Local-Z mixed-filament settings in the 3MF project config.
- Allow those settings to be restored during geometry-only 3MF/model import.

Fixes #125.

## Validation
- Ran `git diff --check`.
- Split branch verified to contain only config/import persistence changes.