### PR TITLE
bugfix: mix dialog error/warning panel oversized on first display

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -15151,8 +15151,8 @@ msgstr "编辑混色"
 msgid "Order"
 msgstr "顺序"
 
-msgid "Target Color:"
-msgstr "目标色:"
+msgid "Target Color"
+msgstr "目标色"
 
 msgid "Swap filaments"
 msgstr "切换方向"

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -384,7 +384,7 @@ void MixedFilamentDialog::build_ui()
         m_match_input_card->SetBorderColorNormal(wxColour("#F0F0F0"));
         auto* card1_sizer = new wxBoxSizer(wxVERTICAL);
 
-        auto* filament_label = new wxStaticText(m_match_input_card, wxID_ANY, _L("Filaments:"));
+        auto* filament_label = new wxStaticText(m_match_input_card, wxID_ANY, _L("Filaments"));
         filament_label->SetFont(Label::Body_14);
         filament_label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         filament_label->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
@@ -411,7 +411,7 @@ void MixedFilamentDialog::build_ui()
         card1_sizer->Add(m_match_badges_panel, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(16));
 
         // Target Color label
-        auto* target_label = new wxStaticText(m_match_input_card, wxID_ANY, _L("Target Color:"));
+        auto* target_label = new wxStaticText(m_match_input_card, wxID_ANY, _L("Target Color"));
         target_label->SetFont(Label::Body_14);
         target_label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         target_label->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
@@ -965,7 +965,7 @@ void MixedFilamentDialog::build_ui()
         m_cycle_card_sizer = new wxBoxSizer(wxVERTICAL);
 
         // Title
-        auto* cycle_title = new wxStaticText(m_cycle_card, wxID_ANY, _L("Pattern"));
+        auto* cycle_title = new wxStaticText(m_cycle_card, wxID_ANY, _L("Filaments"));
         cycle_title->SetFont(Label::Body_14);
         cycle_title->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         cycle_title->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
@@ -2230,8 +2230,9 @@ void MixedFilamentDialog::display_warning(const wxString& msg)
     if (!m_warning_panel || !m_warning_text || !m_error_panel)
         return;
     m_error_panel->Hide();
-    m_warning_text->SetLabel(msg);
     m_warning_panel->Show();
+    Layout();
+    m_warning_text->SetLabel(msg);
     Layout();
 }
 
@@ -2240,8 +2241,9 @@ void MixedFilamentDialog::set_error(const wxString& msg)
     if (!m_error_panel || !m_error_text || !m_warning_panel)
         return;
     m_warning_panel->Hide();
-    m_error_text->SetLabel(msg);
     m_error_panel->Show();
+    Layout();
+    m_error_text->SetLabel(msg);
     if (m_btn_confirm) m_btn_confirm->Disable();
     Layout();
 }
@@ -3080,6 +3082,7 @@ void MixedFilamentDialog::rebuild_cycle_legend()
     if (m_scrolled_content) {
         m_scrolled_content->Layout();
         m_scrolled_content->FitInside();
+        m_scrolled_content->Refresh();
     }
 }
 


### PR DESCRIPTION
  ## Problem
  macOS: mix dialog error/warning panel too wide on first display.

  ## Root Cause
  Hidden Label(LB_AUTO_WRAP) → GetSize().x==0 → SetLabel skips
  wrapping → NSTextField intrinsicContentSize extremely wide.

  ## Fix
  - set_error/display_warning: Show → Layout → SetLabel → Layout
  - Drop unnecessary colons from i18n keys, fix cycle card title
  - Sync zh_CN translations