### PR TITLE
Bugfix 124

### DIFF
--- a/installer.nsi
+++ b/installer.nsi
@@ -11,7 +11,7 @@
 !define PRODUCT_INSTALL_KEY "Software\${PRODUCT_PUBLISHER}\${PRODUCT_NAME}"
 
 !ifndef VERSION
-    !define VERSION "2.2.3"
+    !define VERSION "2.3.3"
 !endif
 
 !ifndef SOURCE_DIR

--- a/scripts/flatpak/io.github.Snapmaker.Snapmaker_Orca.metainfo.xml
+++ b/scripts/flatpak/io.github.Snapmaker.Snapmaker_Orca.metainfo.xml
@@ -38,9 +38,9 @@
 	  <color type="primary" scheme_preference="light">#009688</color>
 	</branding>
     <releases>
-	    <release version="2.3.2" date="2026-3-24">
+	    <release version="2.3.3" date="2026-5-27">
             <description>
-                <p>Version 2.3.2 release with improvements and bug fixes.</p>
+                <p>Version 2.3.3 release with improvements and bug fixes.</p>
             </description>
         </release>
     </releases>

--- a/src/common_func/common_func.hpp
+++ b/src/common_func/common_func.hpp
@@ -6,12 +6,12 @@
 #define SLIC3R_APP_NAME "Snapmaker Orca"
 #define SLIC3R_APP_KEY "Snapmaker_Orca"
 #define SLIC3R_VERSION "01.10.01.50"
-#define Snapmaker_VERSION "2.3.2"
+#define Snapmaker_VERSION "2.3.3"
 #define MIN_FIRM_VER "1.0.0"
 #ifndef GIT_COMMIT_HASH
 #define GIT_COMMIT_HASH "0000000" // 0000000 means uninitialized
 #endif
-#define SLIC3R_BUILD_ID "2.3.2"
+#define SLIC3R_BUILD_ID "2.3.3"
 // #define SLIC3R_RC_VERSION "01.10.01.50"
 #define BBL_RELEASE_TO_PUBLIC 1
 #define BBL_INTERNAL_TESTING 0

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2877,6 +2877,18 @@ static DynamicPrintConfig resolved_model_config_for_tab(const DynamicPrintConfig
     return resolved;
 }
 
+static void sync_plate_bed_type_to_global(DynamicPrintConfig& config)
+{
+    if (wxGetApp().preset_bundle == nullptr)
+        return;
+
+    DynamicConfig& global_cfg = wxGetApp().preset_bundle->project_config;
+    if (global_cfg.has("curr_bed_type")) {
+        BedType global_bed_type = global_cfg.opt_enum<BedType>("curr_bed_type");
+        config.set_key_value("curr_bed_type", new ConfigOptionEnum<BedType>(global_bed_type));
+    }
+}
+
 TabPrintModel::TabPrintModel(ParamsPanel* parent, std::vector<std::string> const & keys)
     : TabPrint(parent, Preset::TYPE_MODEL)
     , m_keys(intersect(Preset::print_options(), keys))
@@ -2941,6 +2953,9 @@ void TabPrintModel::update_model_config()
     m_config->apply(*m_parent_tab->m_config);
     if (m_type != Preset::TYPE_PLATE) {
         m_config->apply_only(*wxGetApp().plate_tab->get_config(), plate_keys);
+    } else {
+        sync_plate_bed_type_to_global(m_prints.get_selected_preset().config);
+        sync_plate_bed_type_to_global(*m_config);
     }
     m_null_keys.clear();
     if (!m_object_configs.empty()) {
@@ -3134,10 +3149,9 @@ void TabPrintPlate::build()
     load_initial_data();
 
     m_config->option("curr_bed_type", true);
-    if (m_preset_bundle->project_config.has("curr_bed_type")) {
-        BedType global_bed_type = m_preset_bundle->project_config.opt_enum<BedType>("curr_bed_type");
-        m_config->set_key_value("curr_bed_type", new ConfigOptionEnum<BedType>(global_bed_type));
-    }
+    m_prints.get_selected_preset().config.option("curr_bed_type", true);
+    sync_plate_bed_type_to_global(m_prints.get_selected_preset().config);
+    sync_plate_bed_type_to_global(*m_config);
     m_config->option("first_layer_sequence_choice", true);
     m_config->option("first_layer_print_sequence", true);
     m_config->option("other_layers_print_sequence", true);

--- a/version.inc
+++ b/version.inc
@@ -10,7 +10,7 @@ endif()
 if(NOT DEFINED BBL_INTERNAL_TESTING)
 set(BBL_INTERNAL_TESTING "0")
 endif()
-set(Snapmaker_VERSION "2.3.2")
+set(Snapmaker_VERSION "2.3.3")
 set(MIN_FIRM_VER "1.0.0")
 string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)"
        Snapmaker_VERSION_MATCH ${Snapmaker_VERSION})


### PR DESCRIPTION
## Summary
Fixes Bug #124 where a new project showed Plate Settings > Bed type as modified by default.

The plate tab was copying the inherited global `curr_bed_type` into the edited plate pseudo-config, but the comparison baseline did not contain the same value. `append_missing_nondefault_options()` then treated the inherited bed type as a local non-default modification.

This syncs the inherited global bed type into the plate tab baseline as well, so only real plate-level overrides are marked modified.

## Testing
- Ran `git diff --check` for `src/slic3r/GUI/Tab.cpp`.
- Full CMake build not run.