### PR TITLE
bugfix: Mixed filament — 3MF persistence, Local-Z settings, dialog panel fixes

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -15151,8 +15151,8 @@ msgstr "编辑混色"
 msgid "Order"
 msgstr "顺序"
 
-msgid "Target Color:"
-msgstr "目标色:"
+msgid "Target Color"
+msgstr "目标色"
 
 msgid "Swap filaments"
 msgstr "切换方向"

--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -15205,6 +15205,9 @@ msgstr "参与混色耗材颜色一致，无法混出更多颜色，请选用不
 msgid "Full domain"
 msgstr "全域生效"
 
+msgid "Apply subdivision to infill"
+msgstr "应用到填充"
+
 msgid "Invalid characters found. Only digits, square brackets ([ and ]), and commas (,) are allowed."
 msgstr "包含无效字符。仅允许输入数字、方括号（[ 和]）和逗号（,）。"
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -907,6 +907,7 @@ static std::vector<std::string> s_Preset_print_options {
      "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold", "scarf_joint_speed", "scarf_joint_flow_ratio", "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length", "seam_slope_steps", "seam_slope_inner_walls", "scarf_overhang_threshold",
      "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width",
      "dithering_local_z_mode",
+     "dithering_local_z_whole_objects",
      "dithering_local_z_infill",
      "calib_flowrate_topinfill_special_order",
 };

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -80,6 +80,12 @@ static std::vector<std::string> s_project_options {
     "mixed_filament_definitions",
     "mixed_color_layer_height_a",
     "mixed_color_layer_height_b",
+    "dithering_z_step_size",
+    "dithering_local_z_mode",
+    "dithering_local_z_whole_objects",
+    "dithering_local_z_infill",
+    "dithering_local_z_direct_multicolor",
+    "dithering_step_painted_zones_only",
 };
 
 // SM_FEATURE: add Snapmaker machine as default

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4362,7 +4362,7 @@ void PrintConfigDef::init_fff_params()
                      "This is enabled automatically with Subdivide Mix Layer. Turn it off to keep infill on the normal layer height.\n\n"
                      "It can improve internal color mixing, but may add toolchanges and affect infill behavior.");
     def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionBool(true));
+    def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("dithering_local_z_direct_multicolor", coBool);
     def->label = L("Use direct multicolor Local-Z solver");

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -2231,9 +2231,9 @@ void MixedFilamentDialog::display_warning(const wxString& msg)
         return;
     m_error_panel->Hide();
     m_warning_panel->Show();
-    Layout();
+    Layout(); // land panel width first, so the auto-wrap label's CalcMin gets a real width
     m_warning_text->SetLabel(msg);
-    Layout();
+    Layout(); // re-wrap with correct width; single Layout on macOS may calc height from stale zero-width
 }
 
 void MixedFilamentDialog::set_error(const wxString& msg)
@@ -2242,10 +2242,10 @@ void MixedFilamentDialog::set_error(const wxString& msg)
         return;
     m_warning_panel->Hide();
     m_error_panel->Show();
-    Layout();
+    Layout(); // land panel width first, so the auto-wrap label's CalcMin gets a real width
     m_error_text->SetLabel(msg);
     if (m_btn_confirm) m_btn_confirm->Disable();
-    Layout();
+    Layout(); // re-wrap with correct width; single Layout on macOS may calc height from stale zero-width
 }
 
 wxString MixedFilamentDialog::get_ratio_warning_msg()

--- a/src/slic3r/GUI/MixedFilamentDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentDialog.cpp
@@ -384,7 +384,7 @@ void MixedFilamentDialog::build_ui()
         m_match_input_card->SetBorderColorNormal(wxColour("#F0F0F0"));
         auto* card1_sizer = new wxBoxSizer(wxVERTICAL);
 
-        auto* filament_label = new wxStaticText(m_match_input_card, wxID_ANY, _L("Filaments:"));
+        auto* filament_label = new wxStaticText(m_match_input_card, wxID_ANY, _L("Filaments"));
         filament_label->SetFont(Label::Body_14);
         filament_label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         filament_label->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
@@ -411,7 +411,7 @@ void MixedFilamentDialog::build_ui()
         card1_sizer->Add(m_match_badges_panel, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(16));
 
         // Target Color label
-        auto* target_label = new wxStaticText(m_match_input_card, wxID_ANY, _L("Target Color:"));
+        auto* target_label = new wxStaticText(m_match_input_card, wxID_ANY, _L("Target Color"));
         target_label->SetFont(Label::Body_14);
         target_label->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         target_label->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
@@ -965,7 +965,7 @@ void MixedFilamentDialog::build_ui()
         m_cycle_card_sizer = new wxBoxSizer(wxVERTICAL);
 
         // Title
-        auto* cycle_title = new wxStaticText(m_cycle_card, wxID_ANY, _L("Pattern"));
+        auto* cycle_title = new wxStaticText(m_cycle_card, wxID_ANY, _L("Filaments"));
         cycle_title->SetFont(Label::Body_14);
         cycle_title->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         cycle_title->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
@@ -2230,8 +2230,9 @@ void MixedFilamentDialog::display_warning(const wxString& msg)
     if (!m_warning_panel || !m_warning_text || !m_error_panel)
         return;
     m_error_panel->Hide();
-    m_warning_text->SetLabel(msg);
     m_warning_panel->Show();
+    Layout();
+    m_warning_text->SetLabel(msg);
     Layout();
 }
 
@@ -2240,8 +2241,9 @@ void MixedFilamentDialog::set_error(const wxString& msg)
     if (!m_error_panel || !m_error_text || !m_warning_panel)
         return;
     m_warning_panel->Hide();
-    m_error_text->SetLabel(msg);
     m_error_panel->Show();
+    Layout();
+    m_error_text->SetLabel(msg);
     if (m_btn_confirm) m_btn_confirm->Disable();
     Layout();
 }
@@ -3080,6 +3082,7 @@ void MixedFilamentDialog::rebuild_cycle_legend()
     if (m_scrolled_content) {
         m_scrolled_content->Layout();
         m_scrolled_content->FitInside();
+        m_scrolled_content->Refresh();
     }
 }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10021,31 +10021,9 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             size = int(desired_physical_filaments);
 
                         PresetBundle *preset_bundle = wxGetApp().preset_bundle;
-                        bool imported_print_options = false;
                         if (geometry_only_project_import && preset_bundle != nullptr) {
                             const size_t current_num_filaments = preset_bundle->filament_presets.size();
                             const bool current_project_empty = this->model.objects.empty();
-                            static const t_config_option_keys imported_local_z_option_keys = {
-                                "dithering_z_step_size",
-                                "dithering_local_z_mode",
-                                "dithering_local_z_whole_objects",
-                                "dithering_local_z_infill",
-                                "dithering_local_z_direct_multicolor",
-                                "dithering_step_painted_zones_only"
-                            };
-                            static const t_config_option_keys imported_print_option_keys = {
-                                "dithering_local_z_mode",
-                                "dithering_local_z_whole_objects",
-                                "dithering_local_z_infill"
-                            };
-                            auto apply_imported_print_options = [&preset_bundle, &config_loaded, &imported_print_options]() {
-                                imported_print_options = std::any_of(imported_print_option_keys.begin(),
-                                                                     imported_print_option_keys.end(),
-                                                                     [&config_loaded](const std::string &key) {
-                                                                         return config_loaded.has(key);
-                                                                     });
-                                preset_bundle->prints.get_edited_preset().config.apply_only(config_loaded, imported_print_option_keys, true);
-                            };
                             if (current_project_empty) {
                                 static const t_config_option_keys imported_project_option_keys = {
                                     "filament_colour",
@@ -10057,19 +10035,9 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                     "mixed_filament_pointillism_pixel_size",
                                     "mixed_filament_pointillism_line_gap",
                                     "mixed_filament_component_bias_enabled",
-                                    "mixed_filament_surface_indentation",
-                                    "mixed_filament_region_collapse",
-                                    "mixed_color_layer_height_a",
-                                    "mixed_color_layer_height_b",
-                                    "dithering_z_step_size",
-                                    "dithering_local_z_mode",
-                                    "dithering_local_z_whole_objects",
-                                    "dithering_local_z_infill",
-                                    "dithering_local_z_direct_multicolor",
-                                    "dithering_step_painted_zones_only"
+                                    "mixed_filament_surface_indentation"
                                 };
                                 preset_bundle->project_config.apply_only(config_loaded, imported_project_option_keys, true);
-                                apply_imported_print_options();
                                 if (current_num_filaments != desired_physical_filaments) {
                                     q->confirm_auto_generated_gradients(desired_physical_filaments);
                                     preset_bundle->set_num_filaments(unsigned(desired_physical_filaments));
@@ -10080,19 +10048,15 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                                         << " desired_physical_filaments=" << desired_physical_filaments
                                                         << " mixed_enabled=" << preset_bundle->mixed_filaments.enabled_count();
                                 wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
-                            } else {
-                                preset_bundle->project_config.apply_only(config_loaded, imported_local_z_option_keys, true);
-                                apply_imported_print_options();
-                                if (current_num_filaments < desired_physical_filaments) {
-                                    std::vector<std::string> new_colors;
-                                    if (imported_filament_colors.size() > current_num_filaments) {
-                                        new_colors.assign(imported_filament_colors.begin() + current_num_filaments,
-                                                          imported_filament_colors.begin() + desired_physical_filaments);
-                                    }
-                                    q->confirm_auto_generated_gradients(desired_physical_filaments);
-                                    preset_bundle->set_num_filaments(unsigned(desired_physical_filaments), new_colors);
-                                    wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
+                            } else if (current_num_filaments < desired_physical_filaments) {
+                                std::vector<std::string> new_colors;
+                                if (imported_filament_colors.size() > current_num_filaments) {
+                                    new_colors.assign(imported_filament_colors.begin() + current_num_filaments,
+                                                      imported_filament_colors.begin() + desired_physical_filaments);
                                 }
+                                q->confirm_auto_generated_gradients(desired_physical_filaments);
+                                preset_bundle->set_num_filaments(unsigned(desired_physical_filaments), new_colors);
+                                wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
                             }
                         }
 
@@ -10108,12 +10072,6 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             ++filament_size;
                         }
                         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
-                        if (imported_print_options) {
-                            if (Tab *print_tab = wxGetApp().get_tab(Preset::TYPE_PRINT)) {
-                                print_tab->update_dirty();
-                                print_tab->reload_config();
-                            }
-                        }
                     }
 
                     std::string import_project_action = wxGetApp().app_config->get("import_project_action");

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10024,6 +10024,22 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                         if (geometry_only_project_import && preset_bundle != nullptr) {
                             const size_t current_num_filaments = preset_bundle->filament_presets.size();
                             const bool current_project_empty = this->model.objects.empty();
+                            static const t_config_option_keys imported_local_z_option_keys = {
+                                "dithering_z_step_size",
+                                "dithering_local_z_mode",
+                                "dithering_local_z_whole_objects",
+                                "dithering_local_z_infill",
+                                "dithering_local_z_direct_multicolor",
+                                "dithering_step_painted_zones_only"
+                            };
+                            static const t_config_option_keys imported_print_option_keys = {
+                                "dithering_local_z_mode",
+                                "dithering_local_z_whole_objects",
+                                "dithering_local_z_infill"
+                            };
+                            auto apply_imported_print_options = [&preset_bundle, &config_loaded]() {
+                                preset_bundle->prints.get_edited_preset().config.apply_only(config_loaded, imported_print_option_keys, true);
+                            };
                             if (current_project_empty) {
                                 static const t_config_option_keys imported_project_option_keys = {
                                     "filament_colour",
@@ -10047,6 +10063,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                     "dithering_step_painted_zones_only"
                                 };
                                 preset_bundle->project_config.apply_only(config_loaded, imported_project_option_keys, true);
+                                apply_imported_print_options();
                                 if (current_num_filaments != desired_physical_filaments) {
                                     q->confirm_auto_generated_gradients(desired_physical_filaments);
                                     preset_bundle->set_num_filaments(unsigned(desired_physical_filaments));
@@ -10057,15 +10074,19 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                                         << " desired_physical_filaments=" << desired_physical_filaments
                                                         << " mixed_enabled=" << preset_bundle->mixed_filaments.enabled_count();
                                 wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
-                            } else if (current_num_filaments < desired_physical_filaments) {
-                                std::vector<std::string> new_colors;
-                                if (imported_filament_colors.size() > current_num_filaments) {
-                                    new_colors.assign(imported_filament_colors.begin() + current_num_filaments,
-                                                      imported_filament_colors.begin() + desired_physical_filaments);
+                            } else {
+                                preset_bundle->project_config.apply_only(config_loaded, imported_local_z_option_keys, true);
+                                apply_imported_print_options();
+                                if (current_num_filaments < desired_physical_filaments) {
+                                    std::vector<std::string> new_colors;
+                                    if (imported_filament_colors.size() > current_num_filaments) {
+                                        new_colors.assign(imported_filament_colors.begin() + current_num_filaments,
+                                                          imported_filament_colors.begin() + desired_physical_filaments);
+                                    }
+                                    q->confirm_auto_generated_gradients(desired_physical_filaments);
+                                    preset_bundle->set_num_filaments(unsigned(desired_physical_filaments), new_colors);
+                                    wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
                                 }
-                                q->confirm_auto_generated_gradients(desired_physical_filaments);
-                                preset_bundle->set_num_filaments(unsigned(desired_physical_filaments), new_colors);
-                                wxGetApp().plater()->on_filaments_change(desired_physical_filaments);
                             }
                         }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10021,6 +10021,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             size = int(desired_physical_filaments);
 
                         PresetBundle *preset_bundle = wxGetApp().preset_bundle;
+                        bool imported_print_options = false;
                         if (geometry_only_project_import && preset_bundle != nullptr) {
                             const size_t current_num_filaments = preset_bundle->filament_presets.size();
                             const bool current_project_empty = this->model.objects.empty();
@@ -10037,7 +10038,12 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                 "dithering_local_z_whole_objects",
                                 "dithering_local_z_infill"
                             };
-                            auto apply_imported_print_options = [&preset_bundle, &config_loaded]() {
+                            auto apply_imported_print_options = [&preset_bundle, &config_loaded, &imported_print_options]() {
+                                imported_print_options = std::any_of(imported_print_option_keys.begin(),
+                                                                     imported_print_option_keys.end(),
+                                                                     [&config_loaded](const std::string &key) {
+                                                                         return config_loaded.has(key);
+                                                                     });
                                 preset_bundle->prints.get_edited_preset().config.apply_only(config_loaded, imported_print_option_keys, true);
                             };
                             if (current_project_empty) {
@@ -10102,6 +10108,12 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             ++filament_size;
                         }
                         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
+                        if (imported_print_options) {
+                            if (Tab *print_tab = wxGetApp().get_tab(Preset::TYPE_PRINT)) {
+                                print_tab->update_dirty();
+                                print_tab->reload_config();
+                            }
+                        }
                     }
 
                     std::string import_project_action = wxGetApp().app_config->get("import_project_action");

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10035,7 +10035,16 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                                     "mixed_filament_pointillism_pixel_size",
                                     "mixed_filament_pointillism_line_gap",
                                     "mixed_filament_component_bias_enabled",
-                                    "mixed_filament_surface_indentation"
+                                    "mixed_filament_surface_indentation",
+                                    "mixed_filament_region_collapse",
+                                    "mixed_color_layer_height_a",
+                                    "mixed_color_layer_height_b",
+                                    "dithering_z_step_size",
+                                    "dithering_local_z_mode",
+                                    "dithering_local_z_whole_objects",
+                                    "dithering_local_z_infill",
+                                    "dithering_local_z_direct_multicolor",
+                                    "dithering_step_painted_zones_only"
                                 };
                                 preset_bundle->project_config.apply_only(config_loaded, imported_project_option_keys, true);
                                 if (current_num_filaments != desired_physical_filaments) {

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1528,17 +1528,37 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
     if(opt_key == "purge_in_prime_tower")
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
 
-    if (m_type == Preset::TYPE_PRINT &&
-        opt_key == "dithering_local_z_mode" &&
-        boost::any_cast<bool>(value) &&
-        m_config->has("dithering_local_z_infill") &&
-        !m_config->opt_bool("dithering_local_z_infill")) {
+    if (m_type == Preset::TYPE_PRINT && opt_key == "dithering_local_z_mode") {
+        const bool local_z_enabled = boost::any_cast<bool>(value);
         DynamicPrintConfig new_conf = *m_config;
-        new_conf.set_key_value("dithering_local_z_infill", new ConfigOptionBool(true));
-        m_config_manipulation.apply(m_config, &new_conf);
-
+        bool dependent_config_changed = false;
         DynamicPrintConfig &project_cfg = wxGetApp().preset_bundle->project_config;
-        project_cfg.set_key_value("dithering_local_z_infill", new ConfigOptionBool(true));
+
+        auto set_print_bool = [this, &new_conf, &dependent_config_changed](const char *key, bool enabled) {
+            if (!m_config->has(key) || m_config->option(key) == nullptr || m_config->opt_bool(key) == enabled)
+                return;
+            new_conf.set_key_value(key, new ConfigOptionBool(enabled));
+            dependent_config_changed = true;
+        };
+        auto set_project_bool = [&project_cfg](const char *key, bool enabled) {
+            project_cfg.set_key_value(key, new ConfigOptionBool(enabled));
+        };
+
+        if (local_z_enabled) {
+            set_print_bool("dithering_local_z_infill", true);
+        } else {
+            set_print_bool("dithering_local_z_whole_objects", false);
+            set_print_bool("dithering_local_z_infill", false);
+            set_project_bool("dithering_local_z_direct_multicolor", false);
+        }
+
+        if (dependent_config_changed)
+            m_config_manipulation.apply(m_config, &new_conf);
+
+        if (new_conf.has("dithering_local_z_whole_objects"))
+            set_project_bool("dithering_local_z_whole_objects", new_conf.opt_bool("dithering_local_z_whole_objects"));
+        if (new_conf.has("dithering_local_z_infill"))
+            set_project_bool("dithering_local_z_infill", new_conf.opt_bool("dithering_local_z_infill"));
     }
 
     if (opt_key == "enable_prime_tower") {

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2877,6 +2877,18 @@ static DynamicPrintConfig resolved_model_config_for_tab(const DynamicPrintConfig
     return resolved;
 }
 
+static void sync_plate_bed_type_to_global(DynamicPrintConfig& config)
+{
+    if (wxGetApp().preset_bundle == nullptr)
+        return;
+
+    DynamicConfig& global_cfg = wxGetApp().preset_bundle->project_config;
+    if (global_cfg.has("curr_bed_type")) {
+        BedType global_bed_type = global_cfg.opt_enum<BedType>("curr_bed_type");
+        config.set_key_value("curr_bed_type", new ConfigOptionEnum<BedType>(global_bed_type));
+    }
+}
+
 TabPrintModel::TabPrintModel(ParamsPanel* parent, std::vector<std::string> const & keys)
     : TabPrint(parent, Preset::TYPE_MODEL)
     , m_keys(intersect(Preset::print_options(), keys))
@@ -2941,6 +2953,9 @@ void TabPrintModel::update_model_config()
     m_config->apply(*m_parent_tab->m_config);
     if (m_type != Preset::TYPE_PLATE) {
         m_config->apply_only(*wxGetApp().plate_tab->get_config(), plate_keys);
+    } else {
+        sync_plate_bed_type_to_global(m_prints.get_selected_preset().config);
+        sync_plate_bed_type_to_global(*m_config);
     }
     m_null_keys.clear();
     if (!m_object_configs.empty()) {
@@ -3134,10 +3149,9 @@ void TabPrintPlate::build()
     load_initial_data();
 
     m_config->option("curr_bed_type", true);
-    if (m_preset_bundle->project_config.has("curr_bed_type")) {
-        BedType global_bed_type = m_preset_bundle->project_config.opt_enum<BedType>("curr_bed_type");
-        m_config->set_key_value("curr_bed_type", new ConfigOptionEnum<BedType>(global_bed_type));
-    }
+    m_prints.get_selected_preset().config.option("curr_bed_type", true);
+    sync_plate_bed_type_to_global(m_prints.get_selected_preset().config);
+    sync_plate_bed_type_to_global(*m_config);
     m_config->option("first_layer_sequence_choice", true);
     m_config->option("first_layer_print_sequence", true);
     m_config->option("other_layers_print_sequence", true);

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -5,6 +5,7 @@
 #include "libslic3r/Print.hpp"
 #include "libslic3r/GCode/ToolOrdering.hpp"
 
+#include <algorithm>
 #include <sstream>
 #include <vector>
 
@@ -2789,4 +2790,18 @@ TEST_CASE("dithering_local_z_mode dirty tracking via is_dirty", "[MixedFilament]
     // Change edited to false → should be dirty
     edited.config.set_key_value("dithering_local_z_mode", new ConfigOptionBool(false));
     CHECK(PresetCollection::is_dirty(&edited, &reference));
+}
+
+TEST_CASE("Local Z whole object setting is available for 3MF project config", "[MixedFilament][Config]")
+{
+    const auto &print_options = Preset::print_options();
+    CHECK(std::find(print_options.begin(), print_options.end(), "dithering_local_z_whole_objects") != print_options.end());
+
+    PresetBundle bundle;
+    REQUIRE(bundle.project_config.has("dithering_local_z_whole_objects"));
+
+    bundle.project_config.set_key_value("dithering_local_z_whole_objects", new ConfigOptionBool(true));
+    DynamicPrintConfig full_config = bundle.full_fff_config();
+    REQUIRE(full_config.has("dithering_local_z_whole_objects"));
+    CHECK(full_config.opt_bool("dithering_local_z_whole_objects"));
 }

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -2805,3 +2805,16 @@ TEST_CASE("Local Z whole object setting is available for 3MF project config", "[
     REQUIRE(full_config.has("dithering_local_z_whole_objects"));
     CHECK(full_config.opt_bool("dithering_local_z_whole_objects"));
 }
+
+TEST_CASE("Local Z infill subdivision defaults inactive when Subdivide Mix Layer is off", "[MixedFilament][Config]")
+{
+    PresetBundle bundle;
+    REQUIRE(bundle.project_config.has("dithering_local_z_mode"));
+    REQUIRE(bundle.project_config.has("dithering_local_z_infill"));
+    CHECK_FALSE(bundle.project_config.opt_bool("dithering_local_z_mode"));
+    CHECK_FALSE(bundle.project_config.opt_bool("dithering_local_z_infill"));
+
+    DynamicPrintConfig full_config = bundle.full_fff_config();
+    REQUIRE(full_config.has("dithering_local_z_infill"));
+    CHECK_FALSE(full_config.opt_bool("dithering_local_z_infill"));
+}


### PR DESCRIPTION
## Summary

- Fix mixed color dialog error/warning panel oversized on first display
- Fix 3MF persistence for Local-Z project settings (full domain, subdivision, dithering)
- Stop importing Local-Z process settings with geometry-only 3MF import
- Refresh print tab after importing Local-Z settings
- Keep "Apply subdivision to infill" in sync with Subdivide Mix Layer mode
- Fix inherited plate bed type dirty state
- i18n: add zh_CN translations for new mixed filament UI strings

## Key changes

| Module | Description |
|--------|-------------|
| 3MF I/O | Fix project config allow-list; separate geometry vs project import |
| Local-Z | Add full-domain settings persistence; sync subdivision/infill states |
| UI | Fix `MixedFilamentDialog` label sizing; hide dependent settings correctly |
| i18n | zh_CN translations for infill subdivision and related UI |