### PR TITLE
Fix painted region rebuild after mixed filament edits

### DIFF
--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -1177,6 +1177,41 @@ static void append_mixed_component_extruders(const MixedFilamentManager &mixed_m
     }
 }
 
+static bool painted_region_targets_match(const PrintObjectRegions           &print_object_regions,
+                                         const std::vector<unsigned int>    &painting_extruders)
+{
+    std::vector<unsigned int> expected_extruders = painting_extruders;
+    std::sort(expected_extruders.begin(), expected_extruders.end());
+    expected_extruders.erase(std::unique(expected_extruders.begin(), expected_extruders.end()), expected_extruders.end());
+
+    for (const PrintObjectRegions::LayerRangeRegions &layer_range : print_object_regions.layer_ranges) {
+        std::vector<std::pair<int, unsigned int>> expected_targets;
+        expected_targets.reserve(layer_range.volume_regions.size() * expected_extruders.size());
+
+        for (int parent_region_id = 0; parent_region_id < int(layer_range.volume_regions.size()); ++parent_region_id) {
+            const PrintObjectRegions::VolumeRegion &parent_region = layer_range.volume_regions[parent_region_id];
+            if (parent_region.region != nullptr &&
+                (parent_region.model_volume->is_model_part() || parent_region.model_volume->is_modifier()) &&
+                mm_paint_applies_to_parent_region(layer_range, parent_region_id)) {
+                for (unsigned int extruder_id : expected_extruders)
+                    expected_targets.emplace_back(parent_region_id, extruder_id);
+            }
+        }
+
+        std::vector<std::pair<int, unsigned int>> actual_targets;
+        actual_targets.reserve(layer_range.painted_regions.size());
+        for (const PrintObjectRegions::PaintedRegion &painted_region : layer_range.painted_regions)
+            actual_targets.emplace_back(painted_region.parent, painted_region.extruder_id);
+
+        std::sort(expected_targets.begin(), expected_targets.end());
+        std::sort(actual_targets.begin(), actual_targets.end());
+        if (actual_targets != expected_targets)
+            return false;
+    }
+
+    return true;
+}
+
 static bool same_layer_pointillism_enabled(const MixedFilamentManager &mixed_mgr)
 {
 #if 0
@@ -1896,6 +1931,10 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
                 invalidate();
                 print_object_regions->clear();
                 model_object_status.print_object_regions_status = ModelObjectStatus::PrintObjectRegionsStatus::Invalid;
+                print_regions_reshuffled = true;
+            } else if (print_object_regions && !painted_region_targets_match(*print_object_regions, painting_extruders)) {
+                invalidate();
+                model_object_status.print_object_regions_status = ModelObjectStatus::PrintObjectRegionsStatus::PartiallyValid;
                 print_regions_reshuffled = true;
             } else if (print_object_regions &&
                 verify_update_print_object_regions(

--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -1214,6 +1214,7 @@ static bool painted_region_targets_match(const PrintObjectRegions           &pri
 
 static bool same_layer_pointillism_enabled(const MixedFilamentManager &mixed_mgr)
 {
+    // Deprecated: same-layer pointillism is disabled and will be removed.
 #if 0
     for (const MixedFilament &mf : mixed_mgr.mixed_filaments())
         if (mf.enabled && mf.distribution_mode == int(MixedFilament::SameLayerPointillisme))

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -4,6 +4,8 @@
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/Print.hpp"
 #include "libslic3r/GCode/ToolOrdering.hpp"
+#include "libslic3r/TriangleMesh.hpp"
+#include "libslic3r/TriangleSelector.hpp"
 
 #include <algorithm>
 #include <sstream>
@@ -47,6 +49,57 @@ static unsigned int virtual_id_for_stable_id(const std::vector<MixedFilament> &m
         ++next_virtual_id;
     }
     return 0;
+}
+
+static std::string single_custom_mixed_definition(unsigned int component_a, unsigned int component_b, uint64_t stable_id)
+{
+    const std::vector<std::string> colors = {"#FF0000", "#00FF00", "#0000FF", "#FFFF00"};
+    MixedFilamentManager           mgr;
+    mgr.add_custom_filament(component_a, component_b, 50, colors);
+
+    MixedFilament &row = mgr.mixed_filaments().front();
+    row.stable_id         = stable_id;
+    row.distribution_mode = int(MixedFilament::Simple);
+    row.manual_pattern.clear();
+
+    return mgr.serialize_custom_entries();
+}
+
+static DynamicPrintConfig mixed_region_print_config(const std::string &mixed_definitions)
+{
+    DynamicPrintConfig config = DynamicPrintConfig::full_print_config();
+    config.set_num_extruders(4);
+    config.set_num_filaments(4);
+    // Print::apply uses filament_diameter.size() as the physical filament count.
+    config.option<ConfigOptionFloats>("filament_diameter")->values = {1.75, 1.76, 1.77, 1.78};
+    config.option<ConfigOptionStrings>("filament_colour")->values = {"#FF0000", "#00FF00", "#0000FF", "#FFFF00"};
+    config.set("mixed_filament_definitions", mixed_definitions);
+    return config;
+}
+
+static std::vector<unsigned int> first_layer_range_painted_extruders(const Print &print)
+{
+    std::vector<unsigned int> extruders;
+    if (print.objects().empty())
+        return extruders;
+
+    const PrintObjectRegions *regions = print.objects().front()->shared_regions();
+    if (regions == nullptr || regions->layer_ranges.empty())
+        return extruders;
+
+    for (const PrintObjectRegions::PaintedRegion &painted_region : regions->layer_ranges.front().painted_regions)
+        extruders.emplace_back(painted_region.extruder_id);
+
+    std::sort(extruders.begin(), extruders.end());
+    extruders.erase(std::unique(extruders.begin(), extruders.end()), extruders.end());
+    return extruders;
+}
+
+static const PrintObjectRegions *first_print_object_regions(const Print &print)
+{
+    if (print.objects().empty())
+        return nullptr;
+    return print.objects().front()->shared_regions();
 }
 
 struct MixedAutoGenerateGuard
@@ -502,6 +555,49 @@ TEST_CASE("Mixed filament painted-region resolver preserves virtual channels for
     row.distribution_mode = int(MixedFilament::SameLayerPointillisme);
     CHECK(mgr.effective_painted_region_filament_id(3, 2, 0) == 3);
     CHECK_THAT(double(mgr.component_surface_offset(3, 2, 0)), WithinAbs(0.0, 0.0001));
+}
+
+TEST_CASE("Mixed filament component edits rebuild painted region targets", "[MixedFilament][PrintApply]")
+{
+    MixedAutoGenerateGuard guard(false);
+
+    Model model;
+    ModelObject *object = model.add_object();
+    object->name = "mixed-painted-object.stl";
+    ModelVolume *volume = object->add_volume(make_cube(20., 20., 20.));
+    object->add_instance();
+    object->ensure_on_bed();
+
+    constexpr unsigned int mixed_virtual_id = 5;
+    TriangleSelector selector(volume->mesh());
+    selector.set_facet(0, EnforcerBlockerType(mixed_virtual_id));
+    REQUIRE(volume->mmu_segmentation_facets.set(selector));
+
+    constexpr uint64_t stable_id = 4242;
+    DynamicPrintConfig config = mixed_region_print_config(single_custom_mixed_definition(1, 2, stable_id));
+
+    Print print;
+    print.set_status_silent();
+    print.apply(model, config);
+    REQUIRE(print.objects().size() == 1);
+    const PrintObjectRegions *initial_regions = first_print_object_regions(print);
+    REQUIRE(initial_regions != nullptr);
+    REQUIRE_FALSE(initial_regions->layer_ranges.empty());
+    const std::vector<unsigned int> expected_initial_extruders {1, 2, mixed_virtual_id};
+    CHECK(first_layer_range_painted_extruders(print) == expected_initial_extruders);
+
+    config.set("mixed_filament_definitions", single_custom_mixed_definition(3, 2, stable_id));
+    print.apply(model, config);
+    const PrintObjectRegions *updated_regions = first_print_object_regions(print);
+    REQUIRE(updated_regions != nullptr);
+    REQUIRE_FALSE(updated_regions->layer_ranges.empty());
+    const std::vector<unsigned int> expected_updated_extruders {2, 3, mixed_virtual_id};
+    CHECK(first_layer_range_painted_extruders(print) == expected_updated_extruders);
+
+    config.set("mixed_filament_definitions", single_custom_mixed_definition(3, 4, stable_id));
+    print.apply(model, config);
+    const std::vector<unsigned int> expected_updated_second_component_extruders {3, 4, mixed_virtual_id};
+    CHECK(first_layer_range_painted_extruders(print) == expected_updated_second_component_extruders);
 }
 
 TEST_CASE("ExtrusionPath copies preserve inset index", "[MixedFilament]")
@@ -2801,7 +2897,8 @@ TEST_CASE("Local Z whole object setting is available for 3MF project config", "[
     REQUIRE(bundle.project_config.has("dithering_local_z_whole_objects"));
 
     bundle.project_config.set_key_value("dithering_local_z_whole_objects", new ConfigOptionBool(true));
-    DynamicPrintConfig full_config = bundle.full_fff_config();
+    DynamicPrintConfig full_config = DynamicPrintConfig::full_print_config();
+    full_config.apply(bundle.project_config);
     REQUIRE(full_config.has("dithering_local_z_whole_objects"));
     CHECK(full_config.opt_bool("dithering_local_z_whole_objects"));
 }
@@ -2814,7 +2911,8 @@ TEST_CASE("Local Z infill subdivision defaults inactive when Subdivide Mix Layer
     CHECK_FALSE(bundle.project_config.opt_bool("dithering_local_z_mode"));
     CHECK_FALSE(bundle.project_config.opt_bool("dithering_local_z_infill"));
 
-    DynamicPrintConfig full_config = bundle.full_fff_config();
+    DynamicPrintConfig full_config = DynamicPrintConfig::full_print_config();
+    full_config.apply(bundle.project_config);
     REQUIRE(full_config.has("dithering_local_z_infill"));
     CHECK_FALSE(full_config.opt_bool("dithering_local_z_infill"));
 }


### PR DESCRIPTION
# Description

Fixes stale painted-region reuse after editing a custom mixed filament formula.

When a painted mixed filament keeps the same virtual filament slot but changes components, for example `1+2 -> 3+2 -> 3+4`, `Print::apply()` could reuse the old `PaintedRegions` table because the total filament count had not changed. That left the table with old physical targets, so slicing could keep the previous mix or fail to find the newly required physical filament target.

This PR compares cached painted-region targets against the currently required `(parent region, extruder id)` set. If they differ, shared print-object regions are rebuilt before slicing.

Also marks same-layer pointillism as deprecated in code.

## Tests

- Built `libslic3r`
- Built `libslic3r_tests`
- Ran focused regression:
  - `Mixed filament component edits rebuild painted region targets`
- Ran full mixed filament test filter:
  - `[MixedFilament]`
  - `104 test cases`, `539 assertions`

---

# 描述

修复自定义混色耗材配方修改后，旧的 painted-region 表被错误复用的问题。

当已涂色的混色耗材保持同一个虚拟耗材槽位，但组件发生变化时，例如 `1+2 -> 3+2 -> 3+4`，`Print::apply()` 可能因为总耗材数量未变化而复用旧的 `PaintedRegions` 表。旧表中仍然记录旧的物理耗材目标，导致切片结果继续使用旧混色，或找不到新的物理耗材目标区域。

本 PR 会比较缓存的 painted-region 目标与当前实际需要的 `(parent region, extruder id)` 集合。如果不一致，则在切片前重建共享的 print-object regions。

同时在代码中标记 same-layer pointillism 已废弃，后续会移除。

## 测试

- 已构建 `libslic3r`
- 已构建 `libslic3r_tests`
- 已运行定向回归测试：
  - `Mixed filament component edits rebuild painted region targets`
- 已运行完整混色耗材测试过滤：
  - `[MixedFilament]`
  - `104` 个 test cases，`539` 个 assertions