### PR TITLE
feat:add FlutterPlatform abstraction layer

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -115,6 +115,7 @@ set(SLIC3R_GUI_SOURCES
     GUI/Flutter/FlutterPanel.cpp
     GUI/Flutter/FlutterPanel.hpp
     GUI/Flutter/flutter_host.h
+    GUI/Flutter/flutter_platform.h
     GUI/format.hpp
     GUI/GCodeViewer.cpp
     GUI/GCodeViewer.hpp
@@ -621,6 +622,8 @@ set(SLIC3R_GUI_SOURCES
 
 add_subdirectory(GUI/DeviceTab)
 
+ensure_flutter_deps()
+
 if (WIN32)
     list(APPEND SLIC3R_GUI_SOURCES
             GUI/dark_mode/dark_mode.hpp
@@ -628,7 +631,13 @@ if (WIN32)
             GUI/dark_mode/UAHMenuBar.hpp
             GUI/dark_mode.hpp
             GUI/dark_mode.cpp
+        )
+endif ()
+
+if (FLUTTER_DEPS_AVAILABLE AND WIN32)
+    list(APPEND SLIC3R_GUI_SOURCES
             GUI/Flutter/flutter_host_win.cpp
+            GUI/Flutter/flutter_platform_win.cpp
         )
 endif ()
 
@@ -644,9 +653,14 @@ if (APPLE)
             GUI/GUI_UtilsMac.mm
             GUI/wxMediaCtrl2.mm
             GUI/wxMediaCtrl2.h
-            GUI/Flutter/flutter_host_macos.mm
         )
     FIND_LIBRARY(DISKARBITRATION_LIBRARY DiskArbitration)
+    if (FLUTTER_DEPS_AVAILABLE)
+        list(APPEND SLIC3R_GUI_SOURCES
+                GUI/Flutter/flutter_host_macos.mm
+                GUI/Flutter/flutter_platform_macos.mm
+            )
+    endif()
 else ()
     list(APPEND SLIC3R_GUI_SOURCES
             GUI/wxMediaCtrl2.cpp
@@ -657,7 +671,13 @@ endif ()
 if (UNIX AND NOT APPLE)
     list(APPEND SLIC3R_GUI_SOURCES
         GUI/Printer/gstbambusrc.c
+    )
+endif ()
+
+if (FLUTTER_DEPS_AVAILABLE AND UNIX AND NOT APPLE)
+    list(APPEND SLIC3R_GUI_SOURCES
         GUI/Flutter/flutter_host_linux.cpp
+        GUI/Flutter/flutter_platform_linux.cpp
     )
 endif ()
 
@@ -691,8 +711,10 @@ if (WIN32)
 
     # Flutter — from deps (CMAKE_PREFIX_PATH), auto-populated from SDK if missing
     ensure_flutter_deps()
-    target_include_directories(libslic3r_gui PRIVATE "${CMAKE_PREFIX_PATH}/include/flutter")
-    target_link_libraries(libslic3r_gui "${CMAKE_PREFIX_PATH}/lib/flutter_windows.dll.lib")
+    if(FLUTTER_DEPS_AVAILABLE)
+        target_include_directories(libslic3r_gui PRIVATE "${CMAKE_PREFIX_PATH}/include/flutter")
+        target_link_libraries(libslic3r_gui "${CMAKE_PREFIX_PATH}/lib/flutter_windows.dll.lib")
+    endif()
 endif()
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SLIC3R_GUI_SOURCES})
@@ -720,19 +742,27 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 
     # Flutter — from deps (CMAKE_PREFIX_PATH), auto-populated from SDK if missing
     ensure_flutter_deps()
-    target_include_directories(libslic3r_gui PRIVATE
-        "${CMAKE_PREFIX_PATH}/include/flutter")
-    target_link_libraries(libslic3r_gui "${CMAKE_PREFIX_PATH}/lib/libflutter_linux_gtk.so")
+    if(FLUTTER_DEPS_AVAILABLE)
+        target_include_directories(libslic3r_gui PRIVATE
+            "${CMAKE_PREFIX_PATH}/include/flutter")
+        target_link_libraries(libslic3r_gui "${CMAKE_PREFIX_PATH}/lib/libflutter_linux_gtk.so")
+    endif()
 elseif (APPLE)
     target_link_libraries(libslic3r_gui ${DISKARBITRATION_LIBRARY} "-framework Security")
 
     # Flutter framework — from deps (CMAKE_PREFIX_PATH), auto-populated from SDK if missing
     ensure_flutter_deps()
-    target_include_directories(libslic3r_gui PRIVATE "${CMAKE_PREFIX_PATH}/FlutterMacOS.framework/Headers")
-    target_compile_options(libslic3r_gui PRIVATE "-F${CMAKE_PREFIX_PATH}")
-    set_source_files_properties(
-        GUI/Flutter/flutter_host_macos.mm
-        PROPERTIES COMPILE_FLAGS "-fobjc-arc")
+    if(FLUTTER_DEPS_AVAILABLE)
+        target_include_directories(libslic3r_gui PRIVATE "${CMAKE_PREFIX_PATH}/FlutterMacOS.framework/Headers")
+        target_compile_options(libslic3r_gui PRIVATE "-F${CMAKE_PREFIX_PATH}")
+        set_source_files_properties(
+            GUI/Flutter/flutter_host_macos.mm
+            PROPERTIES COMPILE_FLAGS "-fobjc-arc")
+    endif()
+endif()
+
+if(FLUTTER_DEPS_AVAILABLE)
+    target_compile_definitions(libslic3r_gui PRIVATE HAS_FLUTTER)
 endif()
 
 if (SLIC3R_STATIC)

--- a/src/slic3r/GUI/Flutter/flutter_host.h
+++ b/src/slic3r/GUI/Flutter/flutter_host.h
@@ -32,9 +32,7 @@ public:
 
     virtual void focus() = 0;
 
-#ifdef __WXMSW__
-    virtual void* nativeHandle() const { return nullptr; }
-#endif
+    virtual void* nativeHandle() const = 0;
 };
 
 // ── Engine layer (one per process, creates views) ──────────────────────

--- a/src/slic3r/GUI/Flutter/flutter_host_linux.cpp
+++ b/src/slic3r/GUI/Flutter/flutter_host_linux.cpp
@@ -227,6 +227,8 @@ public:
         if (m_view) gtk_widget_grab_focus(GTK_WIDGET(m_view));
     }
 
+    void* nativeHandle() const override { return nullptr; }
+
     void setMethodCallHandler(MethodCallHandler h) override {
         m_handler = std::move(h);
     }

--- a/src/slic3r/GUI/Flutter/flutter_host_macos.mm
+++ b/src/slic3r/GUI/Flutter/flutter_host_macos.mm
@@ -60,6 +60,8 @@ public:
             [controller.view.window makeFirstResponder:controller.view];
     }
 
+    void* nativeHandle() const override { return nullptr; }
+
     void invokeMethod(const std::string& method,
                       const std::string& arguments) override {
         if (!channel) return;
@@ -96,7 +98,7 @@ public:
 
     bool start() override {
         project = [[FlutterDartProject alloc] initWithPrecompiledDartBundle:nil];
-        return true;
+        return project != nil;
     }
 
     void stop() override {

--- a/src/slic3r/GUI/Flutter/flutter_host_win.cpp
+++ b/src/slic3r/GUI/Flutter/flutter_host_win.cpp
@@ -340,13 +340,11 @@ public:
         if (hwnd) ::SetFocus(hwnd);
     }
 
-#ifdef __WXMSW__
     void* nativeHandle() const override {
         FlutterDesktopViewRef view =
             FlutterDesktopViewControllerGetView(m_controller);
         return (void*)FlutterDesktopViewGetHWND(view);
     }
-#endif
 
     void setMethodCallHandler(MethodCallHandler h) override {
         m_handler = std::move(h);
@@ -394,6 +392,7 @@ public:
         props.assets_path = assets.c_str();
         props.icu_data_path = icu.c_str();
         props.aot_library_path = aot.c_str();
+        props.dart_entrypoint = entrypoint.empty() ? nullptr : entrypoint.c_str();
 
         FlutterDesktopEngineRef engine =
             FlutterDesktopEngineCreate(&props);

--- a/src/slic3r/GUI/Flutter/flutter_platform.h
+++ b/src/slic3r/GUI/Flutter/flutter_platform.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "flutter_host.h"
+#include <string>
+#include <memory>
+#include <cstdint>
+
+namespace FlutterPlatform {
+
+std::unique_ptr<FlutterEngineHost> createEngine();
+
+enum class RendererBackend : uint8_t { RENDERER_IMPELLER, RENDERER_METAL, RENDERER_SOFTWARE };
+enum class PlatformId : uint8_t { PLATFORM_WINDOWS, PLATFORM_LINUX, PLATFORM_MACOS };
+
+struct Capabilities
+{
+    bool            supportsCustomEntrypoint;
+    bool            supportsMultiView;
+    RendererBackend rendererBackend;
+    PlatformId      platformId;
+};
+const Capabilities& capabilities();
+
+} // namespace FlutterPlatform

--- a/src/slic3r/GUI/Flutter/flutter_platform_linux.cpp
+++ b/src/slic3r/GUI/Flutter/flutter_platform_linux.cpp
@@ -1,0 +1,15 @@
+#include "flutter_platform.h"
+
+namespace FlutterPlatform {
+
+std::unique_ptr<FlutterEngineHost> createEngine() {
+    return ::createFlutterEngine("", "");
+}
+
+static const Capabilities kCaps = {
+    false, false, RendererBackend::RENDERER_SOFTWARE, PlatformId::PLATFORM_LINUX
+};
+
+const Capabilities& capabilities() { return kCaps; }
+
+} // namespace FlutterPlatform

--- a/src/slic3r/GUI/Flutter/flutter_platform_macos.mm
+++ b/src/slic3r/GUI/Flutter/flutter_platform_macos.mm
@@ -1,0 +1,15 @@
+#include "flutter_platform.h"
+
+namespace FlutterPlatform {
+
+std::unique_ptr<FlutterEngineHost> createEngine() {
+    return ::createFlutterEngine("", "");
+}
+
+static const Capabilities kCaps = {
+    true, false, RendererBackend::RENDERER_METAL, PlatformId::PLATFORM_MACOS
+};
+
+const Capabilities& capabilities() { return kCaps; }
+
+} // namespace FlutterPlatform

--- a/src/slic3r/GUI/Flutter/flutter_platform_win.cpp
+++ b/src/slic3r/GUI/Flutter/flutter_platform_win.cpp
@@ -1,0 +1,15 @@
+#include "flutter_platform.h"
+
+namespace FlutterPlatform {
+
+std::unique_ptr<FlutterEngineHost> createEngine() {
+    return ::createFlutterEngine("", "");
+}
+
+static const Capabilities kCaps = {
+    true, false, RendererBackend::RENDERER_IMPELLER, PlatformId::PLATFORM_WINDOWS
+};
+
+const Capabilities& capabilities() { return kCaps; }
+
+} // namespace FlutterPlatform

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(${_TEST_NAME}_tests
 	test_config.cpp
 	test_custom_gcode.cpp
 	test_elephant_foot_compensation.cpp
+	test_flutter_platform.cpp
 	test_geometry.cpp
 	test_mixed_filament.cpp
 	test_triangle_selector.cpp
@@ -32,7 +33,8 @@ if (TARGET OpenVDB::openvdb)
     target_sources(${_TEST_NAME}_tests PRIVATE test_hollowing.cpp)
 endif()
     
-target_link_libraries(${_TEST_NAME}_tests test_common libslic3r OpenSSL::Crypto)
+target_link_libraries(${_TEST_NAME}_tests test_common libslic3r libslic3r_gui OpenSSL::Crypto)
+target_include_directories(${_TEST_NAME}_tests PRIVATE "${CMAKE_SOURCE_DIR}/src/slic3r/GUI")
 if (WIN32)
     target_link_libraries(${_TEST_NAME}_tests bcrypt.lib)
 endif()

--- a/tests/libslic3r/test_flutter_platform.cpp
+++ b/tests/libslic3r/test_flutter_platform.cpp
@@ -1,0 +1,49 @@
+#include <catch2/catch.hpp>
+#include "Flutter/flutter_platform.h"
+
+TEST_CASE("FlutterPlatform::capabilities returns correct platform values", "[FlutterPlatform]")
+{
+    auto& caps = FlutterPlatform::capabilities();
+    REQUIRE(caps.supportsMultiView == false);
+}
+
+TEST_CASE("FlutterPlatform::capabilities returns identical reference", "[FlutterPlatform]")
+{
+    auto& c1 = FlutterPlatform::capabilities();
+    auto& c2 = FlutterPlatform::capabilities();
+    REQUIRE(&c1 == &c2);
+}
+
+TEST_CASE("FlutterPlatform::createEngine returns non-null engine", "[FlutterPlatform]")
+{
+    auto engine = FlutterPlatform::createEngine();
+    REQUIRE(engine != nullptr);
+}
+
+TEST_CASE("FlutterViewHost::nativeHandle requires AOT data", "[FlutterPlatform][.aot]")
+{
+    auto engine = FlutterPlatform::createEngine();
+    REQUIRE(engine != nullptr);
+    engine->start();
+    // On Windows, createView loads flutter_app.dll — returns nullptr without it
+    auto view = engine->createView("", "test.channel");
+    if (!view) {
+        WARN("createView skipped — flutter_app.dll not found (expected in CI)");
+        return;
+    }
+    void* handle = view->nativeHandle();
+    REQUIRE(handle != nullptr);
+    view->resize(800, 600);
+}
+
+TEST_CASE("Capabilities per-platform invariant checks", "[FlutterPlatform]")
+{
+    using namespace FlutterPlatform;
+    auto& caps = FlutterPlatform::capabilities();
+    if (caps.platformId == PlatformId::PLATFORM_WINDOWS)
+        REQUIRE(caps.supportsCustomEntrypoint == true);
+    else if (caps.platformId == PlatformId::PLATFORM_MACOS)
+        REQUIRE(caps.supportsCustomEntrypoint == true);
+    else if (caps.platformId == PlatformId::PLATFORM_LINUX)
+        REQUIRE(caps.supportsCustomEntrypoint == false);
+}


### PR DESCRIPTION
## Summary

  Add `FlutterPlatform` abstraction layer to eliminate `#ifdef` from the business layer and unify engine creation across Windows/macOS/Linux.

  ## What's included

  - **`flutter_platform.h`** — Single header for business layer: `FlutterPlatform::createEngine()` factory + `FlutterPlatform::Capabilities` query (`platformName`, `rendererBackend`, `supportsCustomEntrypoint`,
   `supportsMultiView`)
  - **3 platform implementation files** (`_win.cpp`, `_macos.mm`, `_linux.cpp`) — Each delegates to `::createFlutterEngine()` and provides compile-time static `Capabilities`

  ## Other changes

  - **`FlutterViewHost::nativeHandle()`** — Changed from `#ifdef __WXMSW__`-guarded to pure virtual `= 0` on ALL platforms (macOS/Linux return `nullptr`)
  - **macOS `start()` fix** — Now returns `project != nil` instead of always `true`
  - **`flutter_host_win.cpp`** — Removed redundant `#ifdef __WXMSW__` wrapper (file is Windows-only via CMake)
  - **CMakeLists** — All Flutter source files guarded by `FLUTTER_DEPS_AVAILABLE`; `HAS_FLUTTER` defined only when deps available

  ## Tests

  - **`test_flutter_platform.cpp`** — 5 Catch2 test cases covering capabilities, engine creation, platform invariants, and `nativeHandle()` (AOT-dependent test gracefully skips without `flutter_app.dll`)