### PR TITLE
fix: restore correct 0.18mm layer height in U1 0.6 nozzle process profile

### DIFF
--- a/resources/profiles/Snapmaker/process/0.18 Standard @Snapmaker U1 (0.6 nozzle).json
+++ b/resources/profiles/Snapmaker/process/0.18 Standard @Snapmaker U1 (0.6 nozzle).json
@@ -15,7 +15,6 @@
     "filter_out_gap_fill": "1",
     "gap_fill_target": "topbottom",
     "internal_bridge_speed": "100%",
-    "layer_height": "0.25",
     "prime_tower_brim_width": "5",
     "prime_tower_width": "30",
     "prime_volume": "41",


### PR DESCRIPTION
## Summary

The `0.18 Standard @Snapmaker U1 (0.6 nozzle)` profile incorrectly overrides `layer_height` to `0.25mm`, defeating the purpose of the 0.18mm profile. This removes the erroneous override so the profile correctly inherits the `0.18mm` value from its parent `fdm_process_U1_0.18_nozzle_0.6`.

Closes / supersedes #365.

## Changes

- `resources/profiles/Snapmaker/process/0.18 Standard @Snapmaker U1 (0.6 nozzle).json`: remove `layer_height: "0.25"` override; add missing trailing newline

## Test plan

- [ ] Load the 0.18mm Standard profile for U1 (0.6 nozzle) — confirm layer height shows 0.18mm not 0.25mm
- [ ] Slice a test model and verify layer count matches 0.18mm expectations