### PR TITLE
fix: correct cool plate temps for Snapmaker PLA SnapSpeed @U1 (60°C → 35°C)

### DIFF
--- a/resources/profiles/Snapmaker/filament/Snapmaker PLA SnapSpeed @U1 base.json
+++ b/resources/profiles/Snapmaker/filament/Snapmaker PLA SnapSpeed @U1 base.json
@@ -1,127 +1,127 @@
 {
-  "type": "filament",
-  "from": "system",
-  "instantiation": "false",
-  "name": "Snapmaker PLA SnapSpeed @U1 base",
-  "filament_id": "141703112701",
-  "filament_end_gcode": [
-    ""
-  ],
-  "filament_retraction_length": [
-    "nil"
-  ],
-  "filament_loading_speed_start": [
-    "35"
-  ],
-  "filament_loading_speed": [
-    "35"
-  ],
-  "filament_unloading_speed_start": [
-    "35"
-  ],
-  "filament_unloading_speed": [
-    "35"
-  ],
-  "filament_load_time": [
-    "2"
-  ],
-  "filament_unload_time": [
-    "2"
-  ],
-  "filament_cooling_moves": [
-    "2"
-  ],
-  "filament_cooling_initial_speed": [
-    "35"
-  ],
-  "filament_cooling_final_speed": [
-    "60"
-  ],
-  "fan_cooling_layer_time": [
-      "100"
-  ],
-  "filament_max_volumetric_speed": [
-      "12"
-  ],
-  "filament_type": [
-      "PLA"
-  ],
-  "filament_density": [
-      "1.24"
-  ],
-  "filament_cost": [
-      "20"
-  ],
-  "cool_plate_temp" : [
-      "60"
-  ],
-  "eng_plate_temp" : [
-      "60"
-  ],
-  "hot_plate_temp" : [
-      "60"
-  ],
-  "textured_plate_temp" : [
-      "60"
-  ],
-  "cool_plate_temp_initial_layer" : [
-      "60"
-  ],
-  "eng_plate_temp_initial_layer" : [
-      "60"
-  ],
-  "hot_plate_temp_initial_layer" : [
-      "60"
-  ],
-  "textured_plate_temp_initial_layer" : [
-      "60"
-  ],
-  "nozzle_temperature_initial_layer": [
-      "220"
-  ],
-  "reduce_fan_stop_start_freq": [
-      "1"
-  ],
-  "slow_down_for_layer_cooling": [
-      "1"
-  ],
-  "fan_max_speed": [
-      "100"
-  ],
-  "fan_min_speed": [
-      "100"
-  ],
-  "overhang_fan_speed": [
-      "100"
-  ],
-  "overhang_fan_threshold": [
-      "50%"
-  ],
-  "close_fan_the_first_x_layers": [
-      "1"
-  ],
-  "nozzle_temperature": [
-      "220"
-  ],
-  "temperature_vitrification": [
-      "60"
-  ],
-  "nozzle_temperature_range_low": [
-      "190"
-  ],
-  "nozzle_temperature_range_high": [
-      "230"
-  ],
-  "slow_down_min_speed": [
-      "10"
-  ],
-  "slow_down_layer_time": [
-      "4"
-  ],
-  "additional_cooling_fan_speed": [
-      "70"
-  ],
-  "filament_start_gcode": [
-      "; filament start gcode\n"
-  ]
+    "type": "filament",
+    "from": "system",
+    "instantiation": "false",
+    "name": "Snapmaker PLA SnapSpeed @U1 base",
+    "filament_id": "141703112701",
+    "filament_end_gcode": [
+        ""
+    ],
+    "filament_retraction_length": [
+        "nil"
+    ],
+    "filament_loading_speed_start": [
+        "35"
+    ],
+    "filament_loading_speed": [
+        "35"
+    ],
+    "filament_unloading_speed_start": [
+        "35"
+    ],
+    "filament_unloading_speed": [
+        "35"
+    ],
+    "filament_load_time": [
+        "2"
+    ],
+    "filament_unload_time": [
+        "2"
+    ],
+    "filament_cooling_moves": [
+        "2"
+    ],
+    "filament_cooling_initial_speed": [
+        "35"
+    ],
+    "filament_cooling_final_speed": [
+        "60"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "filament_max_volumetric_speed": [
+        "12"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_density": [
+        "1.24"
+    ],
+    "filament_cost": [
+        "20"
+    ],
+    "cool_plate_temp": [
+        "35"
+    ],
+    "eng_plate_temp": [
+        "60"
+    ],
+    "hot_plate_temp": [
+        "60"
+    ],
+    "textured_plate_temp": [
+        "60"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "60"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "60"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "60"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "220"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "overhang_fan_threshold": [
+        "50%"
+    ],
+    "close_fan_the_first_x_layers": [
+        "1"
+    ],
+    "nozzle_temperature": [
+        "220"
+    ],
+    "temperature_vitrification": [
+        "60"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "nozzle_temperature_range_high": [
+        "230"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ]
 }

--- a/resources/profiles/Snapmaker/filament/Snapmaker PLA SnapSpeed @U1.json
+++ b/resources/profiles/Snapmaker/filament/Snapmaker PLA SnapSpeed @U1.json
@@ -42,10 +42,10 @@
         "70"
     ],
     "cool_plate_temp": [
-        "60"
+        "35"
     ],
     "cool_plate_temp_initial_layer": [
-        "60"
+        "35"
     ],
     "dont_slow_down_outer_wall": [
         "0"


### PR DESCRIPTION
## Summary

The `Snapmaker PLA SnapSpeed @U1` and `@U1 base` filament profiles had `cool_plate_temp` and `cool_plate_temp_initial_layer` hardcoded to 60°C, inconsistent with the sibling `@U1 base2` preset (35°C) and generic PLA defaults. This caused the bed to overheat when using a cool/engineering plate.

Closes / supersedes #282.

## Changes

- `Snapmaker PLA SnapSpeed @U1 base.json`: `cool_plate_temp` 60→35, `cool_plate_temp_initial_layer` 60→35
- `Snapmaker PLA SnapSpeed @U1.json`: same corrections

## Test plan

- [ ] Load the Snapmaker PLA SnapSpeed @U1 filament profile with a Cool Plate — verify bed target is 35°C not 60°C
- [ ] Confirm Engineering Plate and High Temp Plate temperatures are unchanged