### PR TITLE
fix: use max bed temp across extruders in multi-material layer 2 transition

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4931,8 +4931,13 @@ LayerResult GCode::process_layer(const Print& print,
                 gcode += m_writer.set_temperature(temperature, false, extruder.id());
         }
 
-        // BBS
-        int bed_temp = get_bed_temperature(first_extruder_id, false, print.config().curr_bed_type);
+        // Use the maximum bed temperature across all active extruders so that a mixed-material
+        // print (e.g. PLA + TPU) does not drop the bed temp to the lower-temp material's value
+        // on layer 2, which would cause adhesion failures for the higher-temp material.
+        int bed_temp = 0;
+        for (const Extruder& extruder : m_writer.extruders()) {
+            bed_temp = std::max(bed_temp, get_bed_temperature(extruder.id(), false, print.config().curr_bed_type));
+        }
         gcode += m_writer.set_bed_temperature(bed_temp);
         // Mark the temperature transition from 1st to 2nd layer to be finished.
         m_second_layer_things_done = true;


### PR DESCRIPTION
## Summary

In mixed-material prints (e.g. PLA at 65°C bed + TPU at 35°C bed), the bed temperature was set using only the **first** extruder's "other layers" value on the layer 2 transition. When the first extruder is the lower-temp material (TPU), the bed drops to 35°C on layer 2, causing adhesion failures for PLA.

Fix by iterating all active extruders and using the **maximum** bed temperature.

Closes / supersedes #332.

## Changes

- `src/libslic3r/GCode.cpp`: replace single-extruder `get_bed_temperature(first_extruder_id, ...)` with loop over all extruders taking `std::max`

## Test plan

- [ ] Slice a multi-material print with PLA (65°C bed) + TPU (35°C bed), first extruder = TPU
- [ ] Verify the layer 2 gcode sets bed to 65°C (max), not 35°C
- [ ] Single-material print bed temperature unchanged