### PR TITLE
fix(macos): add NSLocalNetworkUsageDescription for macOS 26 webview blank tabs

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -132,7 +132,14 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
-	<key>NSAppTransportSecurity</key>  
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Snapmaker Orca needs access to your local network to discover and connect to your 3D printer(s), and to serve the app's device interface on localhost.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_http._tcp</string>
+		<string>_printer._tcp</string>
+	</array>
+	<key>NSAppTransportSecurity</key>
 	<dict>
 		<!-- Disable App Transport Security. Resolves https://github.com/SoftFever/OrcaSlicer/issues/791 -->
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
## Summary

On macOS 26 (Tahoe), the **Print Preprocessing** window shows a blank white screen. macOS 26 tightened local network access permissions and now requires `NSLocalNetworkUsageDescription` in the app bundle's `Info.plist` to display a user-facing permission prompt instead of silently blocking localhost webview content.

Closes / supersedes #249.

## Changes

- `cmake/modules/MacOSXBundleInfo.plist.in`: add `NSLocalNetworkUsageDescription` string and `NSBonjourServices` array before `NSAppTransportSecurity`

## Test plan

- [ ] Build on macOS 26 — verify Print Preprocessing window shows content instead of blank white screen
- [ ] Verify the system shows a local network permission dialog on first launch
- [ ] Confirm existing macOS < 26 behavior is unaffected