### PR TITLE
fix: use raw filament_type in sw_GetFileFilamentMapping to prevent PLA-S remapping

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -3205,15 +3205,17 @@ void SSWCP_MachineOption_Instance::sw_GetFileFilamentMapping()
         // filament type
         if (full_config.has("filament_type")) {
             std::vector<std::string> filament_types;
-            size_t                   filament_count = full_config.option<ConfigOptionStrings>("filament_type")->values.size();
+            const auto*              filament_type_opt = full_config.option<ConfigOptionStrings>("filament_type");
+            size_t                   filament_count    = filament_type_opt->values.size();
             if (full_config.has("filament_colour")) {
                 filament_count = std::max(filament_count, full_config.option<ConfigOptionStrings>("filament_colour")->values.size());
             }
 
             filament_types.reserve(filament_count);
             for (size_t i = 0; i < filament_count; ++i) {
-                std::string displayed_filament_type;
-                std::string filament_type = full_config.get_filament_type(displayed_filament_type, int(i));
+                // Use raw filament_type value to avoid get_filament_type() remapping
+                // "Generic Support For PLA" -> "PLA-S", which breaks filament matching in the web UI.
+                std::string filament_type = filament_type_opt->get_at(int(i));
                 boost::trim(filament_type);
                 filament_types.emplace_back(std::move(filament_type));
             }


### PR DESCRIPTION
## Summary

`sw_GetFileFilamentMapping()` was calling `full_config.get_filament_type()` to populate the filament type list sent to the web UI. That function remaps `"Generic Support For PLA"` to `"PLA-S"` for display purposes — but the web UI's filament matcher expects the raw stored value, causing filament matching to fail silently for support filaments.

Closes / supersedes #413.

## Changes

- `src/slic3r/GUI/SSWCP.cpp`: cache `filament_type` option pointer; use `filament_type_opt->get_at(i)` instead of `get_filament_type()` to read the raw stored type without display remapping

## Test plan

- [ ] Slice a model with Generic Support For PLA as filament 2
- [ ] Open Print Preprocessing — verify the filament type shows `"Support PLA"` (or equivalent raw value) rather than `"PLA-S"`
- [ ] Verify filament matching succeeds in the web UI