### PR TITLE
fix issue where generic support for pla inherits bbl behaviour

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -3205,15 +3205,15 @@ void SSWCP_MachineOption_Instance::sw_GetFileFilamentMapping()
         // filament type
         if (full_config.has("filament_type")) {
             std::vector<std::string> filament_types;
-            size_t                   filament_count = full_config.option<ConfigOptionStrings>("filament_type")->values.size();
+            const auto*              filament_type_opt = full_config.option<ConfigOptionStrings>("filament_type");
+            size_t                   filament_count = filament_type_opt->values.size();
             if (full_config.has("filament_colour")) {
                 filament_count = std::max(filament_count, full_config.option<ConfigOptionStrings>("filament_colour")->values.size());
             }
 
             filament_types.reserve(filament_count);
             for (size_t i = 0; i < filament_count; ++i) {
-                std::string displayed_filament_type;
-                std::string filament_type = full_config.get_filament_type(displayed_filament_type, int(i));
+                std::string filament_type = filament_type_opt->get_at(int(i));
                 boost::trim(filament_type);
                 filament_types.emplace_back(std::move(filament_type));
             }

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -3203,12 +3203,12 @@ void SSWCP_MachineOption_Instance::sw_GetFileFilamentMapping()
         
 
         // filament type
-        if (full_config.has("filament_type")) {
+        if (const auto* filament_type_opt = full_config.option<ConfigOptionStrings>("filament_type");
+            filament_type_opt != nullptr && !filament_type_opt->values.empty()) {
             std::vector<std::string> filament_types;
-            const auto*              filament_type_opt = full_config.option<ConfigOptionStrings>("filament_type");
             size_t                   filament_count = filament_type_opt->values.size();
-            if (full_config.has("filament_colour")) {
-                filament_count = std::max(filament_count, full_config.option<ConfigOptionStrings>("filament_colour")->values.size());
+            if (const auto* filament_colour_opt = full_config.option<ConfigOptionStrings>("filament_colour")) {
+                filament_count = std::max(filament_count, filament_colour_opt->values.size());
             }
 
             filament_types.reserve(filament_count);


### PR DESCRIPTION
## 概要

修复 Snapmaker Web 打印预处理页中，Generic Support For PLA 被发送为 `PLA-S` 导致耗材匹配失败的问题。
保留使用 `full_print_config()` 生成完整、与颜色槽位对齐的耗材类型列表。
在该 Web 匹配接口中使用原始 `filament_type`，避免把 Snapmaker 耗材映射成 Bambu 风格的 `PLA-S` / `PA-S` 支撑耗材类型。

## 原因

`get_filament_type()` 会把带有 `GFS00` / `filament_is_support` 的支撑 PLA 规范化为 `PLA-S`，但 Snapmaker 设备端并没有 `PLA-S` 这种挂载耗材类型。
因此 Generic Support For PLA 在切片配置中是支撑耗材，但设备端实际只会上报 `PLA`，导致打印预处理页出现耗材类型不匹配。

## Summary

Fix Snapmaker web preprint filament matching when Generic Support For PLA was sent as `PLA-S`.
Keep using `full_print_config()` so the filament type list remains complete and aligned with filament/color slots.
Use the raw configured `filament_type` in this web matching payload to avoid sending Bambu-style support tokens such as `PLA-S` / `PA-S` to Snapmaker devices.

## Why

`get_filament_type()` normalizes support PLA with `GFS00` / `filament_is_support` into `PLA-S`, but Snapmaker devices do not expose `PLA-S` as a mounted filament type.

Generic Support For PLA is a support filament in the slicer config, while the device reports the mounted material as `PLA`, which caused the preprint matcher to reject an otherwise valid mapping.