### PR TITLE
Fix paint-on fuzzy skin not working + wxFileDialog crash

### DIFF
--- a/src/libslic3r/Format/bbs_3mf.cpp
+++ b/src/libslic3r/Format/bbs_3mf.cpp
@@ -275,7 +275,8 @@ static constexpr const char* OFFSET_ATTR = "offset";
 static constexpr const char* PRINTABLE_ATTR = "printable";
 static constexpr const char* INSTANCESCOUNT_ATTR = "instances_count";
 static constexpr const char* CUSTOM_SUPPORTS_ATTR = "paint_supports";
-static constexpr const char* CUSTOM_FUZZY_SKIN_ATTR  = "paint_fuzzy_skin";
+static constexpr const char* CUSTOM_FUZZY_SKIN_ATTR      = "paint_fuzzy_skin";
+static constexpr const char* CUSTOM_FUZZY_SKIN_ATTR_OLD  = "paint_fuzzy";
 static constexpr const char* CUSTOM_SEAM_ATTR = "paint_seam";
 static constexpr const char* MMU_SEGMENTATION_ATTR = "paint_color";
 // BBS
@@ -437,6 +438,18 @@ std::string bbs_get_attribute_value_string(const char** attributes, unsigned int
 {
     const char* text = bbs_get_attribute_value_charptr(attributes, attributes_size, attribute_key);
     return (text != nullptr) ? text : "";
+}
+
+// Try each key in order, returning the first non-empty value.
+// Supports any number of fallback keys for backward compatibility.
+static std::string bbs_get_attribute_value_string(const char** attributes, unsigned int attributes_size,
+                                                   std::initializer_list<const char*> keys)
+{
+    for (const char* key : keys) {
+        std::string data = bbs_get_attribute_value_string(attributes, attributes_size, key);
+        if (!data.empty()) return data;
+    }
+    return "";
 }
 
 float bbs_get_attribute_value_float(const char** attributes, unsigned int attributes_size, const char* attribute_key)
@@ -3653,7 +3666,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
             m_curr_object->geometry.custom_supports.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_SUPPORTS_ATTR));
             m_curr_object->geometry.custom_seam.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_SEAM_ATTR));
             m_curr_object->geometry.mmu_segmentation.push_back(bbs_get_attribute_value_string(attributes, num_attributes, MMU_SEGMENTATION_ATTR));
-            m_curr_object->geometry.fuzzy_skin.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_FUZZY_SKIN_ATTR));
+            m_curr_object->geometry.fuzzy_skin.push_back(bbs_get_attribute_value_string(attributes, num_attributes, {CUSTOM_FUZZY_SKIN_ATTR, CUSTOM_FUZZY_SKIN_ATTR_OLD}));
             // BBS
             m_curr_object->geometry.face_properties.push_back(bbs_get_attribute_value_string(attributes, num_attributes, FACE_PROPERTY_ATTR));
         }
@@ -5295,7 +5308,7 @@ void PlateData::parse_filament_info(GCodeProcessorResult *result)
             current_object->geometry.custom_supports.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_SUPPORTS_ATTR));
             current_object->geometry.custom_seam.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_SEAM_ATTR));
             current_object->geometry.mmu_segmentation.push_back(bbs_get_attribute_value_string(attributes, num_attributes, MMU_SEGMENTATION_ATTR));
-            current_object->geometry.fuzzy_skin.push_back(bbs_get_attribute_value_string(attributes, num_attributes, CUSTOM_FUZZY_SKIN_ATTR));
+            current_object->geometry.fuzzy_skin.push_back(bbs_get_attribute_value_string(attributes, num_attributes, {CUSTOM_FUZZY_SKIN_ATTR, CUSTOM_FUZZY_SKIN_ATTR_OLD}));
             // BBS
             current_object->geometry.face_properties.push_back(bbs_get_attribute_value_string(attributes, num_attributes, FACE_PROPERTY_ATTR));
         }

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -5096,8 +5096,8 @@ void apply_fuzzy_skin_segmentation(PrintObject &print_object, ThrowOnCancel thro
             it_layer_range = layer_range_next(layer_ranges, it_layer_range, layer.slice_z);
             const PrintObjectRegions::LayerRangeRegions &layer_range = *it_layer_range;
 
-            assert(segmentation[layer_idx].size() == 1);
-            const ExPolygons &fuzzy_skin_segmentation      = segmentation[layer_idx][0];
+            assert(segmentation[layer_idx].size() >= 2);
+            const ExPolygons &fuzzy_skin_segmentation      = segmentation[layer_idx][1];
             const BoundingBox fuzzy_skin_segmentation_bbox = get_extents(fuzzy_skin_segmentation);
             if (fuzzy_skin_segmentation.empty())
                 continue;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3979,7 +3979,7 @@ void GUI_App::load_project(wxWindow *parent, wxString& input_file) const
     input_file.Clear();
     wxFileDialog dialog(parent ? parent : GetTopWindow(),
         _L("Choose one file (3mf):"),
-        app_config->get_last_dir(), "",
+        from_u8(app_config->get_last_dir()), "",
         file_wildcards(FT_PROJECT), wxFD_OPEN | wxFD_FILE_MUST_EXIST);
 
     if (dialog.ShowModal() == wxID_OK)
@@ -4018,7 +4018,7 @@ void GUI_App::load_gcode(wxWindow* parent, wxString& input_file) const
     input_file.Clear();
     wxFileDialog dialog(parent ? parent : GetTopWindow(),
         _L("Choose one file (gcode/3mf):"),
-        app_config->get_last_dir(), "",
+        from_u8(app_config->get_last_dir()), "",
         file_wildcards(FT_GCODE), wxFD_OPEN | wxFD_FILE_MUST_EXIST);
 
     if (dialog.ShowModal() == wxID_OK)


### PR DESCRIPTION
@
## Summary

This PR fixes two independent bugs discovered during v2.3.3 beta investigation.

---

## Bug 1 (Primary): Paint-on Fuzzy Skin completely broken

### Root Cause

The mixed filament feature (commit ac3dafe08a, 2026-05-26) changed merge_segmented_layers() in MultiMaterialSegmentation.cpp to output all facet states instead of skipping state 0:

Before (original fuzzy skin code):
  skipped state 0 (unpainted), shifted state 1 -> index 0
  output: 1 slot per layer -> segmentation[layer][0] = painted areas (correct)

After (mixed filament change):
  includes state 0, no index shift
  output: 2 slots per layer -> segmentation[layer][0] = unpainted (always empty), [1] = painted

But apply_fuzzy_skin_segmentation() in PrintObjectSlice.cpp was never updated. It still reads segmentation[layer_idx][0], which is now the unpainted state (always empty for fuzzy skin). The painted data sits unused at index 1.

### Effect

- fuzzy_skin_segmentation.empty() is always true
- The function skips every layer, doing nothing
- Painted regions are never stolen into fuzzy-skin PrintRegions
- Paint-on fuzzy skin is effectively a no-op

### Fix

src/libslic3r/PrintObjectSlice.cpp line 5099-5100:
  assert(segmentation[layer_idx].size() == 1)  ->  assert(segmentation[layer_idx].size() >= 2)
  segmentation[layer_idx][0]  ->  segmentation[layer_idx][1]

---

## Bug 2 (Secondary): 3MF backward compatibility broken

### Root Cause

Commit e44ec1f27b changed the 3MF XML attribute key from "paint_fuzzy" to "paint_fuzzy_skin" to match BBS, but did not add fallback reading of the old key. Project files saved with older versions silently lose fuzzy skin painting data on open.

### Fix

src/libslic3r/Format/bbs_3mf.cpp:
- Added CUSTOM_FUZZY_SKIN_ATTR_OLD constant for the legacy key
- Added an initializer_list-based bbs_get_attribute_value_string() overload that tries each key in order and returns the first non-empty value — supports any number of fallback keys
- Both call sites use the overload with {CUSTOM_FUZZY_SKIN_ATTR, CUSTOM_FUZZY_SKIN_ATTR_OLD}

---

## Bug 3: wxFileDialog crash on ShowModal()

### Root Cause

load_project() and load_gcode() in GUI_App.cpp passed app_config->get_last_dir() directly to wxFileDialog. On Windows the native IFileDialog requires locale-encoded paths, but get_last_dir() returns UTF-8. Other dialog functions (import_model, import_zip) already used the correct from_u8() wrapper.

### Fix

src/slic3r/GUI/GUI_App.cpp:
Wrap get_last_dir() with from_u8() in load_project() and load_gcode().

---

## Files Changed

| File | Change |
|------|--------|
| src/libslic3r/PrintObjectSlice.cpp | Fix segmentation state index [0] -> [1] |
| src/libslic3r/Format/bbs_3mf.cpp | Add initializer_list-based fallback helper + old key constant |
| src/slic3r/GUI/GUI_App.cpp | Add missing from_u8() in load_project and load_gcode |

---

## TODOs / Follow-ups

### 1. Replace assert() with runtime validation

The current code uses assert() to guard the segmentation state index. assert() is compiled out in Release builds, which means any future mismatch between merge_segmented_layers() output and apply_fuzzy_skin_segmentation() expectations will silently produce wrong results instead of failing fast.

```cpp
// Current (fragile):
assert(segmentation[layer_idx].size() >= 2);    // compiled out in Release
const auto &seg = segmentation[layer_idx][1];    // magic number

// Recommended:
constexpr size_t painted_idx = size_t(EnforcerBlockerType::FUZZY_SKIN); // = 1
if (segmentation[layer_idx].size() <= painted_idx) {
    BOOST_LOG_TRIVIAL(error) << "Fuzzy skin segmentation state count mismatch";
    continue;
}
const auto &seg = segmentation[layer_idx][painted_idx];
```

### 2. Replace magic number with EnforcerBlockerType::FUZZY_SKIN

The index 1 is semantically size_t(EnforcerBlockerType::FUZZY_SKIN). Using the named constant from TriangleSelector.hpp makes the intent self-documenting and eliminates the need to keep two files in sync if the enum values ever change.
@