### PR TITLE
feat: add sw_StartLocalPrint command for local file printing via MQTT

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -2162,6 +2162,8 @@ void SSWCP_MachineOption_Instance::process()
         sw_CancelPullCloudFile();
     } else if (m_cmd == "sw_StartCloudPrint") {
         sw_StartCloudPrint();
+    } else if (m_cmd == "sw_StartLocalPrint") {
+        sw_StartLocalPrint();
     } else if (m_cmd == "sw_SetDeviceName") {
         sw_SetDeviceName();
     } else if (m_cmd == "sw_ControlLed") {
@@ -2690,6 +2692,37 @@ void SSWCP_MachineOption_Instance::sw_StartCloudPrint()
     catch (std::exception& e) {
         handle_general_fail();
     }
+}
+
+void SSWCP_MachineOption_Instance::sw_StartLocalPrint()
+{
+    if (!m_param_data.count("type") || !m_param_data.count("path")) {
+        BOOST_LOG_TRIVIAL(error) << "[WCP] sw_StartLocalPrint: param [type] or [path] required!";
+        handle_general_fail(-1, "param [type] or [path] required!");
+        return;
+    }
+
+    BOOST_LOG_TRIVIAL(warning) << "[WCP] sw_StartLocalPrint params: " << m_param_data.dump();
+
+    std::shared_ptr<PrintHost> host = nullptr;
+    wxGetApp().get_connect_host(host);
+
+    if (!host) {
+        BOOST_LOG_TRIVIAL(error) << "[WCP] sw_StartLocalPrint: Can't find the active machine";
+        handle_general_fail(-1, "Can't find the active machine");
+        return;
+    }
+
+    json items = m_param_data;
+
+    auto weak_self = std::weak_ptr<SSWCP_Instance>(shared_from_this());
+    host->async_start_local_print(items, [weak_self](const json& response) {
+        auto self = weak_self.lock();
+        if (self) {
+            BOOST_LOG_TRIVIAL(warning) << "[WCP] sw_StartLocalPrint response: " << response.dump();
+            SSWCP_Instance::on_mqtt_msg_arrived(self, response);
+        }
+    });
 }
 
 void SSWCP_MachineOption_Instance::sw_MachineFilesRoots()
@@ -6206,6 +6239,7 @@ std::unordered_set<std::string> SSWCP::m_machine_option_cmd_list = {
     "sw_PullCloudFile",
     "sw_CancelPullCloudFile",
     "sw_StartCloudPrint",
+    "sw_StartLocalPrint",
     "sw_SetDeviceName",
     "sw_ControlLed",
     "sw_ControlPrintSpeed",

--- a/src/slic3r/GUI/SSWCP.hpp
+++ b/src/slic3r/GUI/SSWCP.hpp
@@ -463,6 +463,9 @@ private:
     // 请求设备下载文件并打印
     void sw_StartCloudPrint();
 
+    // Request device to start local file print
+    void sw_StartLocalPrint();
+
     // 设备耗材同步
     void sw_UpdateMachineFilamentInfo();
 

--- a/src/slic3r/Utils/MoonRaker.cpp
+++ b/src/slic3r/Utils/MoonRaker.cpp
@@ -2542,6 +2542,23 @@ void Moonraker_Mqtt::async_start_cloud_print(const nlohmann::json& targets,
     }
 }
 
+// Request device to start local file print
+static const std::string METHOD_START_LOCAL_PRINT = "server.files.start_local_print";
+
+void Moonraker_Mqtt::async_start_local_print(const nlohmann::json& targets,
+                                              std::function<void(const nlohmann::json& response)> callback)
+{
+    if (!send_to_request(METHOD_START_LOCAL_PRINT, targets, true, callback,
+                         [callback]() {
+                             json res;
+                             res["error"] = "timeout";
+                             callback(res);
+                         }) &&
+        callback) {
+        callback(json::value_t::null);
+    }
+}
+
 // 请求设备开启云打印
 void Moonraker_Mqtt::async_pull_cloud_file(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)> callback)
 {

--- a/src/slic3r/Utils/MoonRaker.hpp
+++ b/src/slic3r/Utils/MoonRaker.hpp
@@ -269,6 +269,8 @@ public:
 
     virtual void async_start_cloud_print(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)>) override;
 
+    virtual void async_start_local_print(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)>) override;
+
     virtual void async_cancel_pull_cloud_file(std::function<void(const nlohmann::json& response)>) override;
 
     virtual void async_upload_camera_timelapse(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)>) override;

--- a/src/slic3r/Utils/PrintHost.hpp
+++ b/src/slic3r/Utils/PrintHost.hpp
@@ -139,6 +139,8 @@ public:
 
     virtual void async_start_cloud_print(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)>) {}
 
+    virtual void async_start_local_print(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)>) {}
+
     virtual void async_cancel_pull_cloud_file(std::function<void(const nlohmann::json& response)>) {}
 
     virtual void async_set_device_name(const std::string& device_name, std::function<void(const nlohmann::json& response)>) {}


### PR DESCRIPTION
Add WCP command sw_StartLocalPrint that requests the connected device to print a local file via Moonraker MQTT (server.files.start_local_print).

# Description
Adds the sw_StartLocalPrint WCP command, enabling the web frontend to request the connected device to start printing a local file on the device via Moonraker MQTT protocol (server.files.start_local_print)

# Testing
1. Launch Orca, connect to a Moonraker MQTT device
2. Load a model, slice, enter the preprint dialog
3. Run the JS snippet above in DevTools
4. Verify the device receives the server.files.start_local_print RPC and starts printing the local file