### PR TITLE
feat: add sw_MachineHeartbeat with JSON-RPC passthrough support

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -2164,6 +2164,8 @@ void SSWCP_MachineOption_Instance::process()
         sw_StartCloudPrint();
     } else if (m_cmd == "sw_StartLocalPrint") {
         sw_StartLocalPrint();
+    } else if (m_cmd == "sw_MachineHeartbeat") {
+        sw_MachineHeartbeat();
     } else if (m_cmd == "sw_SetDeviceName") {
         sw_SetDeviceName();
     } else if (m_cmd == "sw_ControlLed") {
@@ -2720,6 +2722,29 @@ void SSWCP_MachineOption_Instance::sw_StartLocalPrint()
         auto self = weak_self.lock();
         if (self) {
             BOOST_LOG_TRIVIAL(warning) << "[WCP] sw_StartLocalPrint response: " << response.dump();
+            SSWCP_Instance::on_mqtt_msg_arrived(self, response);
+        }
+    });
+}
+
+void SSWCP_MachineOption_Instance::sw_MachineHeartbeat()
+{
+    BOOST_LOG_TRIVIAL(warning) << "[WCP] sw_MachineHeartbeat params: " << m_param_data.dump();
+
+    std::shared_ptr<PrintHost> host = nullptr;
+    wxGetApp().get_connect_host(host);
+
+    if (!host) {
+        BOOST_LOG_TRIVIAL(error) << "[WCP] sw_MachineHeartbeat: Can't find the active machine";
+        handle_general_fail(-1, "Can't find the active machine");
+        return;
+    }
+
+    auto weak_self = std::weak_ptr<SSWCP_Instance>(shared_from_this());
+    host->async_machine_heartbeat(m_param_data, [weak_self](const json& response) {
+        auto self = weak_self.lock();
+        if (self) {
+            BOOST_LOG_TRIVIAL(warning) << "[WCP] sw_MachineHeartbeat response: " << response.dump();
             SSWCP_Instance::on_mqtt_msg_arrived(self, response);
         }
     });
@@ -6240,6 +6265,7 @@ std::unordered_set<std::string> SSWCP::m_machine_option_cmd_list = {
     "sw_CancelPullCloudFile",
     "sw_StartCloudPrint",
     "sw_StartLocalPrint",
+    "sw_MachineHeartbeat",
     "sw_SetDeviceName",
     "sw_ControlLed",
     "sw_ControlPrintSpeed",

--- a/src/slic3r/GUI/SSWCP.hpp
+++ b/src/slic3r/GUI/SSWCP.hpp
@@ -466,6 +466,9 @@ private:
     // Request device to start local file print
     void sw_StartLocalPrint();
 
+    // Request device heartbeat
+    void sw_MachineHeartbeat();
+
     // 设备耗材同步
     void sw_UpdateMachineFilamentInfo();
 

--- a/src/slic3r/Utils/MoonRaker.cpp
+++ b/src/slic3r/Utils/MoonRaker.cpp
@@ -3006,10 +3006,11 @@ void Moonraker_Mqtt::on_auth_arrived(const std::string& payload) {
     }
 
     int64_t id = body["id"].get<int64_t>();
-    auto [cb, _] = get_request_callback(id);
+    auto cb = get_request_callback(id).first;
     delete_response_target(id);
 
     if (!cb) {
+        BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] auth callback not found, id: " << id;
         return;
     }
 
@@ -3034,6 +3035,7 @@ void Moonraker_Mqtt::on_response_arrived(const std::string& payload)
     delete_response_target(id);
 
     if (!cb) {
+        BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] response callback not found, id: " << id;
         return;
     }
 

--- a/src/slic3r/Utils/MoonRaker.cpp
+++ b/src/slic3r/Utils/MoonRaker.cpp
@@ -3031,7 +3031,9 @@ void Moonraker_Mqtt::on_response_arrived(const std::string& payload)
     }
 
     int64_t id = body["id"].get<int64_t>();
-    auto [cb, passthrough] = get_request_callback(id);
+    auto cb_result = get_request_callback(id);
+    auto cb         = cb_result.first;
+    auto passthrough = cb_result.second;
     delete_response_target(id);
 
     if (!cb) {

--- a/src/slic3r/Utils/MoonRaker.cpp
+++ b/src/slic3r/Utils/MoonRaker.cpp
@@ -1257,7 +1257,7 @@ bool Moonraker_Mqtt::ask_for_tls_info(const nlohmann::json& cn_params)
         auth_promise.set_value(false);
     };
 
-    if (!add_response_target(seq_id, callback, timeout_callback, std::chrono::seconds(60))) {
+    if (!add_response_target(seq_id, callback, timeout_callback, false, std::chrono::seconds(60))) {
             return false;
     }
     body["id"] = seq_id;
@@ -2559,6 +2559,50 @@ void Moonraker_Mqtt::async_start_local_print(const nlohmann::json& targets,
     }
 }
 
+// Request device heartbeat
+void Moonraker_Mqtt::async_machine_heartbeat(const nlohmann::json& targets,
+                                              std::function<void(const nlohmann::json& response)> callback)
+{
+    if (!callback)
+        return;
+
+    if (!targets.count("id")) {
+        callback(json::value_t::null);
+        return;
+    }
+    int64_t id = targets["id"].get<int64_t>();
+
+    if (!add_response_target(id, callback,
+                             [callback]() {
+                                 json res;
+                                 res["error"] = "timeout";
+                                 callback(res);
+                             }, true)) {
+        callback(json::value_t::null);
+        return;
+    }
+
+    if (!m_mqtt_client_tls) {
+        delete_response_target(id);
+        callback(json::value_t::null);
+        return;
+    }
+
+    m_sn_mtx.lock();
+    std::string main_layer = m_sn;
+    m_sn_mtx.unlock();
+
+    if (main_layer == "+" || main_layer == "") {
+        delete_response_target(id);
+        callback(json::value_t::null);
+        return;
+    }
+
+    std::string topic = main_layer + m_request_topic;
+    std::string pub_msg{};
+    m_mqtt_client_tls->Publish(topic, targets.dump(), 1, pub_msg);
+}
+
 // 请求设备开启云打印
 void Moonraker_Mqtt::async_pull_cloud_file(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)> callback)
 {
@@ -2831,14 +2875,12 @@ bool Moonraker_Mqtt::add_response_target(
     int64_t id,
     std::function<void(const nlohmann::json&)> callback,
     std::function<void()> timeout_callback,
+    bool passthrough,
     std::chrono::milliseconds timeout)
 {
-    auto& wcp_loger = GUI::WCP_Logger::getInstance();
-    BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 注册响应回调，ID: " << id << ", 超时: " << timeout.count() << "ms";
-    wcp_loger.add_log("注册响应回调，ID: " + std::to_string(id) + ", 超时: " + std::to_string(timeout.count()) + "ms", false, "", "Moonraker_Mqtt", "info");
     return m_request_cb_map.add(
         id,
-        RequestCallback(std::move(callback), std::move(timeout_callback)),
+        RequestCallback(std::move(callback), std::move(timeout_callback), passthrough),
         timeout
     );
 }
@@ -2860,13 +2902,12 @@ bool Moonraker_Mqtt::check_sn_arrived() {
 }
 
 // Get and remove callback for a request
-std::function<void(const json&)> Moonraker_Mqtt::get_request_callback(int64_t id)
+std::pair<std::function<void(const json&)>, bool> Moonraker_Mqtt::get_request_callback(int64_t id)
 {
-    auto& wcp_loger = GUI::WCP_Logger::getInstance();
-    BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 获取并移除请求回调，ID: " << id;
-    wcp_loger.add_log("获取并移除请求回调，ID: " + std::to_string(id), false, "", "Moonraker_Mqtt", "info");
     auto request_cb = m_request_cb_map.get_and_remove(id);
-    return request_cb ? request_cb->success_cb : nullptr;
+    if (!request_cb)
+        return {nullptr, false};
+    return {request_cb->success_cb, request_cb->passthrough};
 }
 
 // Handle incoming MQTTs messages
@@ -2954,111 +2995,64 @@ void Moonraker_Mqtt::on_mqtt_message_arrived(const std::string& topic, const std
 
 // Handle auth messages
 void Moonraker_Mqtt::on_auth_arrived(const std::string& payload) {
-    auto& wcp_loger = GUI::WCP_Logger::getInstance();
-    BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 处理认证到达消息";
-    wcp_loger.add_log("处理认证到达消息", false, "", "Moonraker_Mqtt", "info");
-    try {
-        json body = json::parse(payload);
+    json body = json::parse(payload);
 
-        // 更新时间同步状态
-        if (time_sync_manager_) {
-            time_sync_manager_->updateFromResponse(body);
-        }
-
-        if(!body.count("id")){
-            BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 认证响应缺少ID字段";
-            wcp_loger.add_log("认证响应缺少ID字段", false, "", "Moonraker_Mqtt", "warning");
-            return;
-        }
-
-        int64_t id = body["id"].get<int64_t>();
-        BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 认证响应ID: " << id;
-        wcp_loger.add_log("认证响应ID: " + std::to_string(id), false, "", "Moonraker_Mqtt", "info");
-        auto cb = get_request_callback(id);
-        delete_response_target(id);
-
-        if (!cb) {
-            BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 未找到对应的认证回调";
-            wcp_loger.add_log("未找到对应的认证回调", false, "", "Moonraker_Mqtt", "warning");
-            return;
-        }
-
-        json res = body["result"];
-        BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 认证响应处理完成";
-        wcp_loger.add_log("认证响应处理完成", false, "", "Moonraker_Mqtt", "info");
-        cb(res);
-
-    } catch (std::exception& e) {
-        BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] 处理认证响应异常: " << e.what();
-        wcp_loger.add_log("处理认证响应异常: " + std::string(e.what()), false, "", "Moonraker_Mqtt", "error");
+    if (time_sync_manager_) {
+        time_sync_manager_->updateFromResponse(body);
     }
+
+    if (!body.count("id")) {
+        return;
+    }
+
+    int64_t id = body["id"].get<int64_t>();
+    auto [cb, _] = get_request_callback(id);
+    delete_response_target(id);
+
+    if (!cb) {
+        return;
+    }
+
+    cb(body["result"]);
 }
 
 // Handle response messages
 void Moonraker_Mqtt::on_response_arrived(const std::string& payload)
 {
-    auto& wcp_loger = GUI::WCP_Logger::getInstance();
-    BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 处理响应到达消息";
-    wcp_loger.add_log("处理响应到达消息", false, "", "Moonraker_Mqtt", "info");
-    try {
-        json body = json::parse(payload);
+    json body = json::parse(payload);
 
-        // 更新时间同步状态
-        if (time_sync_manager_) {
-            time_sync_manager_->updateFromResponse(body);
-        }
+    if (time_sync_manager_) {
+        time_sync_manager_->updateFromResponse(body);
+    }
 
-        if (!body.count("id")) {
-            BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 响应消息缺少ID字段";
-            wcp_loger.add_log("响应消息缺少ID字段", false, "", "Moonraker_Mqtt", "warning");
-            return;
-        }
+    if (!body.count("id")) {
+        return;
+    }
 
-        int64_t id = -1;
-        id         = body["id"].get<int64_t>();
-        BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 响应ID: " << id;
-        wcp_loger.add_log("响应ID: " + std::to_string(id), false, "", "Moonraker_Mqtt", "info");
-        auto cb = get_request_callback(id);
-        delete_response_target(id);
+    int64_t id = body["id"].get<int64_t>();
+    auto [cb, passthrough] = get_request_callback(id);
+    delete_response_target(id);
 
-        if (!cb) {
-            BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 未找到对应的响应回调，ID: " << id;
-            wcp_loger.add_log("未找到对应的响应回调，ID: " + std::to_string(id), false, "", "Moonraker_Mqtt", "warning");
-            return;
-        }
+    if (!cb) {
+        return;
+    }
 
+    if (passthrough || id == 20252025) {
+        cb(body);
+    } else {
         json res;
-
-        if (/*id.find("mqtt") != std::string::npos*/ id == 20252025) {
-            BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 特殊MQTT请求，直接返回原始响应";
-            wcp_loger.add_log("特殊MQTT请求，直接返回原始响应", false, "", "Moonraker_Mqtt", "info");
-            cb(body);
+        if (!body.count("result")) {
+            if (body.count("error")) {
+                res["error"] = body["error"];
+            }
         } else {
-            if (!body.count("result")) {
-                if (body.count("error")) {
-                    json error   = body["error"];
-                    res["error"] = error;
-                    BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] 响应包含错误信息";
-                    wcp_loger.add_log("响应包含错误信息", false, "", "Moonraker_Mqtt", "warning");
-                }
-            } else {
-                res["data"] = body["result"];
-                BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 响应包含结果数据";
-                wcp_loger.add_log("响应包含结果数据", false, "", "Moonraker_Mqtt", "info");
-            }
-            res["method"] = "";
-            if (body.count("method")) {
-                res["method"] = body["method"];
-                BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] 响应包含方法: " << body["method"].get<std::string>();
-                wcp_loger.add_log("响应包含方法: " + body["method"].get<std::string>(), false, "", "Moonraker_Mqtt", "info");
-            }
-            cb(res);
+            res["data"] = body["result"];
         }
-        
-
-    } catch (std::exception& e) {
-        BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] 处理响应消息异常: " << e.what();
-        wcp_loger.add_log("处理响应消息异常: " + std::string(e.what()), false, "", "Moonraker_Mqtt", "error");
+        res["method"] = "";
+        if (body.count("method")) {
+            res["method"] = body["method"];
+        }
+        cb(res);
     }
 }
 

--- a/src/slic3r/Utils/MoonRaker.hpp
+++ b/src/slic3r/Utils/MoonRaker.hpp
@@ -271,6 +271,8 @@ public:
 
     virtual void async_start_local_print(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)>) override;
 
+    virtual void async_machine_heartbeat(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)>) override;
+
     virtual void async_cancel_pull_cloud_file(std::function<void(const nlohmann::json& response)>) override;
 
     virtual void async_upload_camera_timelapse(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)>) override;
@@ -330,9 +332,10 @@ private:
     bool add_response_target(int64_t id,
                            std::function<void(const nlohmann::json&)> callback,
                            std::function<void()> timeout_callback = nullptr,
+                           bool passthrough = false,
                            std::chrono::milliseconds timeout = std::chrono::milliseconds(80000));
 
-    std::function<void(const nlohmann::json& response)> get_request_callback(int64_t id);
+    std::pair<std::function<void(const nlohmann::json&)>, bool> get_request_callback(int64_t id);
     void delete_response_target(int64_t id);
 
     bool wait_for_sn(int timeout_seconds = 6);
@@ -356,12 +359,15 @@ public:
     struct RequestCallback {
         std::function<void(const nlohmann::json&)> success_cb;  // Success callback
         std::function<void()> timeout_cb;                       // Timeout callback
+        bool passthrough{false};                                // If true, pass raw JSON-RPC body to callback
 
         RequestCallback(
             std::function<void(const nlohmann::json&)> success,
-            std::function<void()> timeout = nullptr)
+            std::function<void()> timeout = nullptr,
+            bool passthrough = false)
             : success_cb(std::move(success))
             , timeout_cb(std::move(timeout))
+            , passthrough(passthrough)
         {}
     };
 

--- a/src/slic3r/Utils/PrintHost.hpp
+++ b/src/slic3r/Utils/PrintHost.hpp
@@ -141,6 +141,8 @@ public:
 
     virtual void async_start_local_print(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)>) {}
 
+    virtual void async_machine_heartbeat(const nlohmann::json& targets, std::function<void(const nlohmann::json& response)>) {}
+
     virtual void async_cancel_pull_cloud_file(std::function<void(const nlohmann::json& response)>) {}
 
     virtual void async_set_device_name(const std::string& device_name, std::function<void(const nlohmann::json& response)>) {}


### PR DESCRIPTION
- Add sw_MachineHeartbeat WCP command for device heartbeat
- Add async_machine_heartbeat passthrough to MoonRaker_Mqtt
- Add passthrough flag to RequestCallback and add_response_target
- Clean up on_response_arrived: remove logs, try-catch, Chinese comments
- Clean up on_auth_arrived: remove logs, try-catch, Chinese comments
- Clean up add_response_target and get_request_callback: remove logs

## Summary
- Add `sw_MachineHeartbeat` WCP command for device heartbeat via MQTT
- Implement passthrough mechanism in `RequestCallback` to support raw JSON-RPC request/response
- Bypass `send_to_request` wrapping for heartbeat (raw params published directly)

## Changes
- **PrintHost.hpp**: Add `async_machine_heartbeat` virtual method
- **MoonRaker.hpp/cpp**: Add passthrough flag to `RequestCallback`, `add_response_target`, `get_request_callback`; implement heartbeat bypassing `send_to_request`
- **SSWCP.hpp/cpp**: Add `sw_MachineHeartbeat` handler with pass-through logic
- Clean up `on_response_arrived` and `on_auth_arrived`: remove logs, try-catch, Chinese comments
