### PR TITLE
feat: integrate FlutterChannel into FlutterPanel, remove Dispatcher

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -114,6 +114,10 @@ set(SLIC3R_GUI_SOURCES
     GUI/FileArchiveDialog.hpp
     GUI/Flutter/FlutterPanel.cpp
     GUI/Flutter/FlutterPanel.hpp
+    GUI/Flutter/FlutterChannel.cpp
+    GUI/Flutter/FlutterChannel.h
+    GUI/Flutter/FlutterMiddleware.cpp
+    GUI/Flutter/FlutterMiddleware.h
     GUI/Flutter/flutter_host.h
     GUI/Flutter/flutter_platform.h
     GUI/format.hpp

--- a/src/slic3r/GUI/Flutter/FlutterChannel.cpp
+++ b/src/slic3r/GUI/Flutter/FlutterChannel.cpp
@@ -79,17 +79,9 @@ FlutterChannel::handler(FlutterViewHost* view) {
     auto middleware = std::make_shared<std::vector<std::shared_ptr<Middleware>>>(
         m_middleware);
 
-    auto replied = std::make_shared<bool>(false);
-    return [routes = std::move(routes), middleware, replied](
+    return [routes = std::move(routes), middleware](
                const std::string& method, const std::string& args,
-               FlutterViewHost::Reply rawReply) {
-
-        FlutterViewHost::Reply reply = [replied, rawReply = std::move(rawReply)]
-            (const std::string& r) {
-            if (*replied) return;
-            *replied = true;
-            rawReply(r);
-        };
+               FlutterViewHost::Reply reply) {
 
         auto& mws = *middleware;
 
@@ -99,10 +91,15 @@ FlutterChannel::handler(FlutterViewHost* view) {
                 mws[j]->onOutbound(m, a);
         };
 
-        auto executeChain = [&](const std::string& m, const std::string& a,
-                                FlutterViewHost::Reply r, size_t startIdx = 0) {
+        std::function<void(const std::string&, const std::string&, FlutterViewHost::Reply, size_t)> executeChain;
+        executeChain = [&](const std::string& m, const std::string& a,
+                           FlutterViewHost::Reply r, size_t startIdx = 0) {
             for (size_t i = startIdx; i < mws.size(); ++i) {
                 if (!mws[i]->onInbound(m, a, r)) {
+                    if (auto guard = std::dynamic_pointer_cast<ThreadGuardMiddleware>(mws[i])) {
+                        guard->CallAfter([=]() { executeChain(m, a, r, i); });
+                        return;
+                    }
                     rollbackOnOutbound(m, a, i - 1);
                     return;
                 }
@@ -116,28 +113,7 @@ FlutterChannel::handler(FlutterViewHost* view) {
                 mws[i]->onOutbound(m, a);
         };
 
-        for (size_t i = 0; i < mws.size(); ++i) {
-            if (!mws[i]->onInbound(method, args, reply)) {
-                // ThreadGuardMiddleware defers execution to UI thread via CallAfter.
-                if (auto guard = std::dynamic_pointer_cast<ThreadGuardMiddleware>(mws[i])) {
-                    guard->CallAfter([executeChain, method, args, reply, i]() {
-                        executeChain(method, args, reply, i);
-                    });
-                    return;
-                }
-                rollbackOnOutbound(method, args, i - 1);
-                return;
-            }
-        }
-
-        // All middlewares passed — run handler + onOutbound
-        auto it = routes.find(method);
-        if (it != routes.end())
-            it->second(args, reply);
-        else
-            reply("");
-        for (int i = static_cast<int>(mws.size()) - 1; i >= 0; --i)
-            mws[i]->onOutbound(method, args);
+        executeChain(method, args, reply, 0);
     };
 }
 

--- a/src/slic3r/GUI/Flutter/FlutterPanel.cpp
+++ b/src/slic3r/GUI/Flutter/FlutterPanel.cpp
@@ -1,4 +1,6 @@
 #include "FlutterPanel.hpp"
+#include "FlutterMiddleware.h"
+#include <cassert>
 
 FlutterPanel::FlutterPanel(wxWindow* parent)
     : wxWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
@@ -9,20 +11,35 @@ FlutterPanel::FlutterPanel(wxWindow* parent)
     Bind(wxEVT_SET_FOCUS, &FlutterPanel::onSetFocus, this);
 }
 
+// Lazy-init — first call creates the channel with the given name; subsequent
+// calls return the existing channel (name parameter is ignored).
+FlutterChannel& FlutterPanel::channel(const std::string& name) {
+    if (!m_channel) {
+        m_channel = std::make_unique<FlutterChannel>(name);
+    }
+    return *m_channel;
+}
+
+FlutterChannel& FlutterPanel::channel() {
+    assert(m_channel);
+    return *m_channel;
+}
+
 bool FlutterPanel::startView(FlutterEngineHost* engine,
                               const std::string& entrypoint,
-                              const std::string& channelName,
-                              FlutterViewHost::MethodCallHandler handler) {
+                              const std::string& channelName) {
     m_view = engine->createView(entrypoint, channelName);
     if (!m_view) return false;
-    if (handler) m_view->setMethodCallHandler(std::move(handler));
 
-    // Defer embedInto until the panel has a valid size.  When this panel
-    // is on a non-selected notebook page it has a 0×0 or 1×1 allocation,
-    // and calling embedInto would fall back to a hard-coded default
-    // (800×600) that is visible for one frame before the first wxEVT_SIZE
-    // corrects it.  tryEmbed() is called from onShow / onSize and handles
-    // the one-shot embed at the real client size.
+    if (!m_channel) {
+        m_channel = std::make_unique<FlutterChannel>(channelName);
+    }
+
+    m_channel->use(makeThreadGuardMiddleware());
+    m_channel->use(makeLoggingMiddleware());
+
+    m_view->setMethodCallHandler(m_channel->handler(m_view.get()));
+
     tryEmbed();
     if (m_embedded) {
         wxSize sz = GetSize();
@@ -32,17 +49,13 @@ bool FlutterPanel::startView(FlutterEngineHost* engine,
     return true;
 }
 
-void FlutterPanel::setHandler(FlutterViewHost::MethodCallHandler handler) {
-    if (m_view) m_view->setMethodCallHandler(std::move(handler));
+void FlutterPanel::resizeView(int width, int height) {
+    if (m_view) m_view->resize(width, height);
 }
 
 void FlutterPanel::onShow(wxShowEvent& event) {
     if (event.IsShown() && m_view) {
         tryEmbed();
-        // Use GetSize() (wxWidgets-tracked size) rather than
-        // GetClientSize() (GTK allocation).  After DoSetSelection
-        // calls SetSize, the wx size is correct even if GTK hasn't
-        // updated the widget allocation yet.
         wxSize sz = GetSize();
         if (sz.GetWidth() > 1 && sz.GetHeight() > 1)
             m_view->resize(sz.GetWidth(), sz.GetHeight());
@@ -59,8 +72,6 @@ void FlutterPanel::tryEmbed() {
 }
 
 void FlutterPanel::onSetFocus(wxFocusEvent& event) {
-    // Defer via CallAfter: on Windows, calling ::SetFocus during
-    // WM_SETFOCUS processing is silently ignored by the OS.
     CallAfter([this] {
         if (m_view) m_view->focus();
     });
@@ -69,10 +80,6 @@ void FlutterPanel::onSetFocus(wxFocusEvent& event) {
 
 void FlutterPanel::SetFocus() {
 #ifdef __WXMSW__
-    // MSWGetFocusHWND() override returns the Flutter child HWND, so
-    // wxWindow::SetFocus() calls ::SetFocus(childHwnd) directly.  No
-    // two-step focus dance needed — eliminates the race where notebook
-    // or mouse-click handling could reclaim focus from child to panel.
     wxWindow::SetFocus();
 #else
     wxWindow::SetFocus();
@@ -83,9 +90,6 @@ void FlutterPanel::SetFocus() {
 void FlutterPanel::onSize(wxSizeEvent& event) {
     if (m_view) {
         tryEmbed();
-        // Use event.GetSize() rather than GetClientSize(): on wxGTK,
-        // GetClientSize() queries the GTK allocation which may be stale
-        // if GTK hasn't processed the size allocation yet.
         wxSize sz = event.GetSize();
         if (sz.GetWidth() > 1 && sz.GetHeight() > 1)
             m_view->resize(sz.GetWidth(), sz.GetHeight());
@@ -94,18 +98,6 @@ void FlutterPanel::onSize(wxSizeEvent& event) {
 }
 
 #ifdef __WXMSW__
-// wxWidgets' PreProcessMessage walks the parent chain from msg.hwnd up
-// through WS_CHILD parents, finds this FlutterPanel, and calls
-// MSWTranslateMessage on it.  The base MSWTranslateMessage calls
-// ::TranslateMessage (which generates WM_CHAR and posts it) and returns
-// true — consuming WM_KEYDOWN before Flutter's WndProc ever sees it.
-// The orphaned WM_CHAR then arrives at the Flutter child but its
-// KeyboardManager has no pending key-down to pair it with.
-//
-// Returning false here skips the entire PreProcessMessage parent-chain
-// walk for messages targeted at the Flutter child HWND, letting the
-// main loop's native ::TranslateMessage + ::DispatchMessage deliver
-// both WM_KEYDOWN and WM_CHAR to the Flutter child in order.
 bool FlutterPanel::MSWShouldPreProcessMessage(WXMSG* msg) {
     if (m_view) {
         HWND child = (HWND)m_view->nativeHandle();

--- a/src/slic3r/GUI/Flutter/FlutterPanel.hpp
+++ b/src/slic3r/GUI/Flutter/FlutterPanel.hpp
@@ -1,78 +1,43 @@
 #pragma once
 #include <wx/wx.h>
 #include <memory>
-#include <functional>
-#include <unordered_map>
-#include "flutter_host.h"
-
-// Simple dispatch table for Dart↔C++ MethodChannel communication.
-// @deprecated Use FlutterChannel instead (namespace + middleware + view binding).
-class Dispatcher {
-public:
-    using Fn = std::function<void(
-        const std::string& args, FlutterViewHost::Reply reply)>;
-
-    Dispatcher& on(const std::string& method, Fn fn) {
-        m_map[method] = std::move(fn);
-        return *this;
-    }
-
-    FlutterViewHost::MethodCallHandler handler() {
-        auto map = m_map;
-        return [map](const std::string& method,
-                     const std::string& args,
-                     FlutterViewHost::Reply reply) {
-            auto it = map.find(method);
-            if (it != map.end()) {
-                try {
-                    it->second(args, reply);
-                } catch (const std::exception& e) {
-                    reply(std::string("Error: ") + e.what());
-                } catch (...) {
-                    reply("Error: unknown");
-                }
-            } else {
-                reply("");
-            }
-        };
-    }
-
-private:
-    std::unordered_map<std::string, Fn> m_map;
-};
+#include "FlutterChannel.h"
 
 class FlutterPanel : public wxWindow {
 public:
     FlutterPanel(wxWindow* parent);
+
+    /// Creates the FlutterChannel with the given name. Must be called BEFORE
+    /// startView() so that handlers registered via on() are captured when
+    /// the channel is bound to the view.
+    FlutterChannel& channel(const std::string& name);
+
+    /// Creates the FlutterView and binds the channel.  Handlers must be
+    /// registered via channel().on(...) before calling startView().
     bool startView(FlutterEngineHost* engine,
                    const std::string& entrypoint,
-                   const std::string& channelName,
-                   FlutterViewHost::MethodCallHandler handler = {});
-    FlutterViewHost* view() { return m_view.get(); }
-    void setHandler(FlutterViewHost::MethodCallHandler handler);
+                   const std::string& channelName);
+
+    /// Access the already-created channel (asserts if not yet created).
+    FlutterChannel& channel();
+
+    void resizeView(int width, int height);
 
     void onSize(wxSizeEvent& event);
     void onShow(wxShowEvent& event);
     void onSetFocus(wxFocusEvent& event);
 
-    // Override SetFocus to transfer keyboard focus to the Flutter child
-    // HWND immediately, rather than relying on the CallAfter deferral in
-    // onSetFocus (which races with wxWidgets' internal focus bookkeeping).
-    // Keeping onSetFocus + CallAfter as a fallback for non-SetFocus paths
-    // (keyboard navigation, WM_SETFOCUS from the OS).
     virtual void SetFocus() override;
 
-    // Panel is a transparent wrapper; only the Flutter child accepts focus.
-    // Prevents wxWidgets from reclaiming focus via mouse-click auto-focus
-    // (MSWWindowProc calls SetFocus on WM_LBUTTONDOWN for IsFocusable windows).
     bool AcceptsFocus() const override { return false; }
 
-    // Attempt deferred embed if it hasn't happened yet.
     void tryEmbed();
 
 protected:
+    // Declaration order sets destruction order (reverse): m_channel dies AFTER m_view.
+    std::unique_ptr<FlutterChannel>  m_channel;
     std::unique_ptr<FlutterViewHost> m_view;
-    bool m_embedded = false;   // true after the first successful embedInto
+    bool m_embedded = false;
 
 #ifdef __WXMSW__
     virtual WXHWND MSWGetFocusHWND() const override;

--- a/src/slic3r/GUI/Flutter/flutter_host.h
+++ b/src/slic3r/GUI/Flutter/flutter_host.h
@@ -5,8 +5,10 @@
 
 // =========================================================================
 // Two-layer architecture:
-//   FlutterEngineHost — one per process, owns the FlutterEngine lifecycle
-//   FlutterViewHost   — one per panel, owns a ViewController + MethodChannel
+//   FlutterEngineHost — creates FlutterViewHost instances.  On macOS the
+//       host retains engine references centrally; on Windows/Linux it is a
+//       stateless factory and each view owns its own engine.
+//   FlutterViewHost   — one per panel, owns the native view + engine.
 // =========================================================================
 
 // ── View layer (one per visible panel) ─────────────────────────────────

--- a/tests/libslic3r/test_flutter.cpp
+++ b/tests/libslic3r/test_flutter.cpp
@@ -261,7 +261,116 @@ TEST_CASE("Namespace on() guards against duplicate method names", "[FlutterChann
 {
     FlutterChannel channel("test");
     channel.on("getVersion", [](const auto&, auto r) { r("v1"); });
-    // ns adds prefix, so "device.getVersion" != "getVersion"
     REQUIRE_NOTHROW(channel.ns("device").on("getVersion",
         [](const auto&, auto r) { r("v2"); }));
+}
+
+// ── Integration: handler + mock view ──────────────────────────────
+
+class IntegrationMockView : public FlutterViewHost {
+public:
+    MethodCallHandler m_handler;
+    std::vector<std::string> sent;
+    void* nativeHandle() const override { return nullptr; }
+    void embedInto(void*) override {}
+    void resize(int, int) override {}
+    void focus() override {}
+    void setMethodCallHandler(MethodCallHandler h) override { m_handler = std::move(h); }
+    void invokeMethod(const std::string& m, const std::string& a) override { sent.push_back(m + ":" + a); }
+};
+
+TEST_CASE("Multiple handler invocations each get independent reply", "[FlutterChannel][integration]")
+{
+    FlutterChannel channel("test");
+    channel.on("getVersion", [](auto, auto r) { r("v1"); })
+           .on("getStatus",  [](auto, auto r) { r("idle"); });
+
+    IntegrationMockView view;
+    auto handler = channel.handler(&view);
+
+    std::string r1, r2, r3;
+    handler("getVersion", "", [&](auto s) { r1 = s; });
+    handler("getStatus",  "", [&](auto s) { r2 = s; });
+    handler("getVersion", "", [&](auto s) { r3 = s; });
+
+    REQUIRE(r1 == "v1");
+    REQUIRE(r2 == "idle");
+    REQUIRE(r3 == "v1");
+}
+
+TEST_CASE("Reply from handler reaches outer callback", "[FlutterChannel][integration]")
+{
+    FlutterChannel channel("test");
+    int n = 0;
+    channel.on("ping", [&](auto, auto r) { n++; r("pong"); });
+
+    IntegrationMockView view;
+    auto handler = channel.handler(&view);
+
+    handler("ping", "", [&](auto) { n++; });
+    handler("ping", "", [&](auto) { n++; });
+    handler("ping", "", [&](auto) { n++; });
+
+    REQUIRE(n == 6); // 3 handlers + 3 reply callbacks
+}
+
+TEST_CASE("system.ready drains queued messages in FIFO order", "[FlutterChannel][integration]")
+{
+    FlutterChannel channel("test");
+    IntegrationMockView view;
+    channel.handler(&view);
+
+    channel.invoke("a", "1");
+    channel.invoke("b", "2");
+    REQUIRE(view.sent.empty());
+
+    view.m_handler("system.ready", "", [](auto) {});
+
+    REQUIRE(view.sent.size() == 2);
+    REQUIRE(view.sent[0] == "a:1");
+    REQUIRE(view.sent[1] == "b:2");
+}
+
+TEST_CASE("on() after handler() is ignored", "[FlutterChannel][integration]")
+{
+    FlutterChannel channel("test");
+    channel.on("getVersion", [](auto, auto r) { r("v1"); });
+
+    IntegrationMockView view;
+    channel.handler(&view);
+
+    REQUIRE_NOTHROW(channel.on("late", [](auto, auto r) { r("late"); }));
+
+    std::string result = "not-called";
+    view.m_handler("late", "", [&](auto s) { result = s; });
+    REQUIRE(result.empty());
+}
+
+TEST_CASE("Unregistered method returns empty reply", "[FlutterChannel][integration]")
+{
+    FlutterChannel channel("test");
+    channel.on("getVersion", [](auto, auto r) { r("v1"); });
+
+    IntegrationMockView view;
+    auto handler = channel.handler(&view);
+
+    std::string result = "not-called";
+    handler("unknown", "{}", [&](auto s) { result = s; });
+    REQUIRE(result.empty());
+}
+
+TEST_CASE("Namespace routes work through frozen handler", "[FlutterChannel][integration]")
+{
+    FlutterChannel channel("test");
+    channel.ns("device").on("connect", [](auto, auto r) { r("ok"); });
+    channel.ns("device").on("scan",    [](auto, auto r) { r("[]"); });
+
+    IntegrationMockView view;
+    auto handler = channel.handler(&view);
+
+    std::string r1, r2;
+    handler("device.connect", "{}", [&](auto s) { r1 = s; });
+    handler("device.scan",    "{}", [&](auto s) { r2 = s; });
+    REQUIRE(r1 == "ok");
+    REQUIRE(r2 == "[]");
 }


### PR DESCRIPTION
## Summary
- Embed FlutterChannel as mandatory comm layer in FlutterPanel: hide FlutterViewHost* behind channel() accessor, remove view() and setHandler() public methods
- Remove deprecated Dispatcher class, migrate MainFrame to FlutterChannel
- Remove redundant inner reply guard in FlutterChannel::handler()
- Fix FlutterChannel::handler() replied flag lifetime from per-handler to per-invocation
- Add system.ready notification in Dart initState
- Update flutter_host.h comments