### PR TITLE
feat: add metadata field to sw_GetActiveFile response

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -5,6 +5,7 @@
 #include "DownloadManager.hpp"
 #include "nlohmann/json.hpp"
 #include "slic3r/GUI/Tab.hpp"
+#include "libslic3r/Model.hpp"
 #include "sentry_wrapper/SentryWrapper.hpp"
 #include <algorithm>
 #include <iterator>
@@ -688,78 +689,88 @@ void SSWCP_Instance::sw_Exit() {
 
 void SSWCP_Instance::sw_GetActiveFile()
 {
-    try {
-        std::string file_path = SSWCP::get_active_filename();
-        std::string file_name = SSWCP::get_display_filename();
-        if (file_path == "" || file_name == "") {
-            handle_general_fail();
-            return;
-        }
-        bool iszip = false;
-        if (m_param_data.count("is_zip")) {
-            iszip = m_param_data["is_zip"].get<bool>();
-        }
-
-        if (iszip) {
-            std::weak_ptr<SSWCP_Instance> weak_self = shared_from_this();
-
-            if (m_work_thread.joinable())
-                m_work_thread.join();
-
-            m_work_thread          = std::thread([file_path, file_name, weak_self]() {
-                auto        self       = weak_self.lock();
-                std::string zipname    = generate_zip_path(file_path, file_name);
-                json        res        = get_or_create_zip_json(file_path, file_name, zipname);
-                size_t      name_index = file_name.find_last_of(".");
-                size_t      path_index = file_path.find_last_of(".");
-                if (!(name_index == std::string::npos || path_index == std::string::npos)) {
-                    self->m_res_data["file_name"] = file_name.substr(0, name_index) + ".zip";
-                    self->m_res_data["file_path"] = wxString(zipname).ToUTF8();
-                    SSWCP::m_file_size_mutex.lock();
-                    self->m_res_data["origin_size"] = SSWCP::m_active_file_size;
-                    std::string url_zip_path = std::string(wxString(zipname).ToUTF8());
-                    std::replace(url_zip_path.begin(), url_zip_path.end(), '\\', '/');
-                    self->m_res_data["url"] = LOCALHOST_URL + std::to_string(wxGetApp().get_page_http_port()) + "/localfile/" + Http::url_encode(url_zip_path);
-                    SSWCP::m_file_size_mutex.unlock();
-
-                    // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
-                    self->m_res_data["checksum"] = calc_sha256_base64(file_path);
-
-                    wxGetApp().CallAfter([weak_self]() {
-                        if (weak_self.lock()) {
-                            weak_self.lock()->send_to_js();
-                            weak_self.lock()->finish_job();
-                        }
-                    });
-                } else {
-                    wxGetApp().CallAfter([weak_self]() {
-                        if (weak_self.lock()) {
-                            weak_self.lock()->handle_general_fail();
-                        }
-                    });
-                    return;
-                }
-            });
-            
-        } else {
-            m_res_data["file_name"] = file_name;
-            std::string url_path = file_path;
-            std::replace(url_path.begin(), url_path.end(), '\\', '/');
-            m_res_data["file_path"] = file_path;
-            m_res_data["origin_size"] = boost::filesystem::file_size(file_path);
-
-            // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
-            m_res_data["checksum"] = calc_sha256_base64(file_path);
-            m_res_data["url"]      = LOCALHOST_URL + std::to_string(wxGetApp().get_page_http_port()) + "/localfile/" + Http::url_encode(url_path);
-
-            send_to_js();
-            finish_job();
-        }
-
-    }
-    catch (std::exception& e) {
+    std::string file_path = SSWCP::get_active_filename();
+    std::string file_name = SSWCP::get_display_filename();
+    if (file_path == "" || file_name == "") {
         handle_general_fail();
+        return;
     }
+    bool iszip = false;
+    if (m_param_data.count("is_zip")) {
+        iszip = m_param_data["is_zip"].get<bool>();
+    }
+
+    json metadata_json = json::object();
+    if (wxGetApp().model().model_info) {
+        auto& items = wxGetApp().model().model_info->metadata_items;
+        auto lookup = [&](const std::string& key) {
+            auto it = items.find(key);
+            if (it != items.end())
+                metadata_json[key] = it->second;
+        };
+        // Currently only these three metadata fields are returned for business needs
+        lookup("DesignModelId");
+        lookup("DesignProfileId");
+        lookup("DesignRegion");
+    }
+    m_res_data["metadata"] = metadata_json;
+
+    if (iszip) {
+        std::weak_ptr<SSWCP_Instance> weak_self = shared_from_this();
+
+        if (m_work_thread.joinable())
+            m_work_thread.join();
+
+        m_work_thread          = std::thread([file_path, file_name, weak_self]() {
+            auto        self       = weak_self.lock();
+            std::string zipname    = generate_zip_path(file_path, file_name);
+            json        res        = get_or_create_zip_json(file_path, file_name, zipname);
+            size_t      name_index = file_name.find_last_of(".");
+            size_t      path_index = file_path.find_last_of(".");
+            if (!(name_index == std::string::npos || path_index == std::string::npos)) {
+                self->m_res_data["file_name"] = file_name.substr(0, name_index) + ".zip";
+                self->m_res_data["file_path"] = wxString(zipname).ToUTF8();
+                SSWCP::m_file_size_mutex.lock();
+                self->m_res_data["origin_size"] = SSWCP::m_active_file_size;
+                std::string url_zip_path = std::string(wxString(zipname).ToUTF8());
+                std::replace(url_zip_path.begin(), url_zip_path.end(), '\\', '/');
+                self->m_res_data["url"] = LOCALHOST_URL + std::to_string(wxGetApp().get_page_http_port()) + "/localfile/" + Http::url_encode(url_zip_path);
+                SSWCP::m_file_size_mutex.unlock();
+
+                // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
+                self->m_res_data["checksum"] = calc_sha256_base64(file_path);
+
+                wxGetApp().CallAfter([weak_self]() {
+                    if (weak_self.lock()) {
+                        weak_self.lock()->send_to_js();
+                        weak_self.lock()->finish_job();
+                    }
+                });
+            } else {
+                wxGetApp().CallAfter([weak_self]() {
+                    if (weak_self.lock()) {
+                        weak_self.lock()->handle_general_fail();
+                    }
+                });
+                return;
+            }
+        });
+
+    } else {
+        m_res_data["file_name"] = file_name;
+        std::string url_path = file_path;
+        std::replace(url_path.begin(), url_path.end(), '\\', '/');
+        m_res_data["file_path"] = file_path;
+        m_res_data["origin_size"] = boost::filesystem::file_size(file_path);
+
+        // checksum: SHA-256 digest as standard Base64, for Flutter-side integrity verification
+        m_res_data["checksum"] = calc_sha256_base64(file_path);
+        m_res_data["url"]      = LOCALHOST_URL + std::to_string(wxGetApp().get_page_http_port()) + "/localfile/" + Http::url_encode(url_path);
+
+        send_to_js();
+        finish_job();
+    }
+
 }
 
 void SSWCP_Instance::sw_LaunchConsole() {


### PR DESCRIPTION
## Summary

- Add `metadata` field to `sw_GetActiveFile` response, returning `DesignModelId`, `DesignProfileId`, and `DesignRegion` parsed from 3MF file metadata
- Remove unnecessary try-catch wrapper in `sw_GetActiveFile`
- Add `#include "libslic3r/Model.hpp"` to access `ModelInfo::metadata_items`

## Response example

```json
{
    "file_name": "xxx.gcode",
    "file_path": "xxx/xxx/xxx.gcode",
    "url": "http://127.0.0.1:13619/...",
    "origin_size": 14236644,
    "checksum": "sOSr0V/NLoZR3vDOCww/MmjH22N3fO0GP+TbBqYy124=",
    "metadata": {
        "DesignModelId": "CNc4531558b00d1b",
        "DesignProfileId": "49885620",
        "DesignRegion": "CN"
    }
}
