### PR TITLE
fix: first-layer honeycomb sparse infill alignment

### DIFF
--- a/installer.nsi
+++ b/installer.nsi
@@ -11,7 +11,7 @@
 !define PRODUCT_INSTALL_KEY "Software\${PRODUCT_PUBLISHER}\${PRODUCT_NAME}"
 
 !ifndef VERSION
-    !define VERSION "2.3.3"
+    !define VERSION "2.3.4"
 !endif
 
 !ifndef SOURCE_DIR

--- a/scripts/flatpak/io.github.Snapmaker.Snapmaker_Orca.metainfo.xml
+++ b/scripts/flatpak/io.github.Snapmaker.Snapmaker_Orca.metainfo.xml
@@ -38,9 +38,9 @@
 	  <color type="primary" scheme_preference="light">#009688</color>
 	</branding>
     <releases>
-	    <release version="2.3.3" date="2026-5-27">
+	    <release version="2.3.4" date="2026-6-09">
             <description>
-                <p>Version 2.3.3 release with improvements and bug fixes.</p>
+                <p>Version 2.3.4 release with improvements and bug fixes.</p>
             </description>
         </release>
     </releases>

--- a/src/common_func/common_func.hpp
+++ b/src/common_func/common_func.hpp
@@ -6,12 +6,12 @@
 #define SLIC3R_APP_NAME "Snapmaker Orca"
 #define SLIC3R_APP_KEY "Snapmaker_Orca"
 #define SLIC3R_VERSION "01.10.01.50"
-#define Snapmaker_VERSION "2.3.3"
+#define Snapmaker_VERSION "2.3.4"
 #define MIN_FIRM_VER "1.0.0"
 #ifndef GIT_COMMIT_HASH
 #define GIT_COMMIT_HASH "0000000" // 0000000 means uninitialized
 #endif
-#define SLIC3R_BUILD_ID "2.3.3"
+#define SLIC3R_BUILD_ID "2.3.4"
 // #define SLIC3R_RC_VERSION "01.10.01.50"
 #define BBL_RELEASE_TO_PUBLIC 1
 #define BBL_INTERNAL_TESTING 0

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -938,9 +938,9 @@ std::vector<SurfaceFill> group_fills(const Layer &layer, LockRegionParam &lock_p
 		            params.anchor_length = 1000.f;
 					params.anchor_length_max = 1000.f;
 		        } else {
-					// Internal infill. Calculating infill line spacing independent of the current layer height and 1st layer status,
-					// so that internall infill will be aligned over all layers of the current region.
-		            params.spacing = layerm.flow(frInfill, layer.object()->config().layer_height).spacing();
+					// Internal infill pattern spacing must stay independent of the current layer height and first-layer line width,
+					// so sparse infill stays aligned over all layers of the current region.
+		            params.spacing = layerm.flow(frInfill, layer.object()->config().layer_height, false).spacing();
 		            // Anchor a sparse infill to inner perimeters with the following anchor length:
 		        	params.anchor_length = float(region_config.infill_anchor);
 					if (region_config.infill_anchor.percent)

--- a/src/libslic3r/Layer.hpp
+++ b/src/libslic3r/Layer.hpp
@@ -74,6 +74,7 @@ public:
     unsigned int extruder(FlowRole role) const;
     Flow    flow(FlowRole role) const;
     Flow    flow(FlowRole role, double layer_height) const;
+    Flow    flow(FlowRole role, double layer_height, bool use_initial_layer_width) const;
     Flow    bridging_flow(FlowRole role, bool thick_bridge = false) const;
 
     void    slices_to_fill_surfaces_clipped();

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -106,9 +106,14 @@ Flow LayerRegion::flow(FlowRole role) const
 
 Flow LayerRegion::flow(FlowRole role, double layer_height) const
 {
+    return this->flow(role, layer_height, m_layer->id() == 0);
+}
+
+Flow LayerRegion::flow(FlowRole role, double layer_height, bool use_initial_layer_width) const
+{
     const PrintConfig          &print_config = m_layer->object()->print()->config();
     ConfigOptionFloatOrPercent config_width;
-    if (m_layer->id() == 0 && print_config.initial_layer_line_width.value > 0) {
+    if (use_initial_layer_width && print_config.initial_layer_line_width.value > 0) {
         config_width = print_config.initial_layer_line_width;
     } else if (role == frExternalPerimeter) {
         config_width = m_region->config().outer_wall_line_width;

--- a/version.inc
+++ b/version.inc
@@ -10,7 +10,7 @@ endif()
 if(NOT DEFINED BBL_INTERNAL_TESTING)
 set(BBL_INTERNAL_TESTING "0")
 endif()
-set(Snapmaker_VERSION "2.3.3")
+set(Snapmaker_VERSION "2.3.4")
 set(MIN_FIRM_VER "1.0.0")
 string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)"
        Snapmaker_VERSION_MATCH ${Snapmaker_VERSION})


### PR DESCRIPTION
## Summary
- Restores normal-layer sparse infill spacing when generating sparse infill patterns.
- Adds a `LayerRegion::flow(..., use_initial_layer_width)` overload so callers can opt out of first-layer line width.
- Fixes honeycomb infill deformation/shift on layer 1 when `bottom_shell_layers = 0`.

## Cause
The FullSpectrum merge changed sparse infill spacing to use `LayerRegion::flow()`, which applies `initial_layer_line_width` on layer 0. That changed the honeycomb grid pitch only on the first sparse layer, causing the exposed honeycomb to appear shifted/deformed.