### PR TITLE
Enable "Exclude objects" by default for Snapmaker printers

### DIFF
--- a/resources/profiles/Snapmaker/process/fdm_process_common.json
+++ b/resources/profiles/Snapmaker/process/fdm_process_common.json
@@ -185,7 +185,7 @@
   "filename_format": "{input_filename_base}_{layer_height}mm_{print_time}.gcode",
   "post_process": "",
   "enforce_support_layers": "0",
-  "exclude_object": "0",
+  "exclude_object": "1",
   "timelapse_type": "0",
   "gap_fill_enabled": "0",
   "single_extruder_multi_material_priming": "0"


### PR DESCRIPTION
Sets `exclude_object` to `"1"` in the common Snapmaker process profile (`resources/profiles/Snapmaker/process/fdm_process_common.json`), so per-object cancellation markers are emitted by default across all Snapmaker process profiles that inherit it.

### Why
With multiple parts on one plate, a single failed object can be cancelled mid-print without aborting the whole job — the common multi-object workflow. Object exclusion is already enabled per-profile for the U1 (#12869); this promotes it to the shared Snapmaker process base.

### Scope
- Single profile value change, no code changes.
- Profiles that explicitly override `exclude_object` are unaffected.