### PR TITLE
feat: pass-through sw_ControlPurifier params directly

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -3635,31 +3635,22 @@ void SSWCP_MachineOption_Instance::sw_BedMesh_AbortProbeMesh()
 
 void SSWCP_MachineOption_Instance::sw_ControlPurifier()
 {
-    try {
+    std::shared_ptr<PrintHost> host = nullptr;
+    wxGetApp().get_connect_host(host);
 
-        int fan_speed = m_param_data.count("fan_speed") ? m_param_data["fan_speed"].get<int>() : -1;
-        int delay_time = m_param_data.count("delay_time") ? m_param_data["delay_time"].get<int>() : -1;
-        int work_time  = m_param_data.count("work_time") ? m_param_data["work_time"].get<int>() : -1;
-        
-
-        std::shared_ptr<PrintHost> host = nullptr;
-        wxGetApp().get_connect_host(host);
-
-        if (!host) {
-            handle_general_fail(-1, "Connection lost!");
-            return;
-        }
-
-        auto weak_self = std::weak_ptr<SSWCP_Instance>(shared_from_this());
-        host->async_controlPurifier(fan_speed, delay_time, work_time, [weak_self](const json& response) {
-            auto self = weak_self.lock();
-            if (self) {
-                SSWCP_Instance::on_mqtt_msg_arrived(self, response);
-            }
-        });
-    } catch (std::exception& e) {
-        handle_general_fail();
+    if (!host) {
+        BOOST_LOG_TRIVIAL(error) << "[WCP] sw_ControlPurifier: no active machine connected";
+        handle_general_fail(-1, "Connection lost!");
+        return;
     }
+
+    auto weak_self = std::weak_ptr<SSWCP_Instance>(shared_from_this());
+    host->async_controlPurifier(m_param_data, [weak_self](const json& response) {
+        auto self = weak_self.lock();
+        if (self) {
+            SSWCP_Instance::on_mqtt_msg_arrived(self, response);
+        }
+    });
 }
 
 void SSWCP_MachineOption_Instance::sw_ControlMainFan()

--- a/src/slic3r/Utils/MoonRaker.cpp
+++ b/src/slic3r/Utils/MoonRaker.cpp
@@ -2033,6 +2033,20 @@ void Moonraker_Mqtt::async_controlPurifier(int                                  
     }
 }
 
+void Moonraker_Mqtt::async_controlPurifier(const nlohmann::json& params,
+                                            std::function<void(const nlohmann::json& response)> callback)
+{
+    if (!send_to_request("printer.control.purifier", params, true, callback,
+                         [callback]() {
+                             json res;
+                             res["error"] = "timeout";
+                             callback(res);
+                         }) &&
+        callback) {
+        callback(json::value_t::null);
+    }
+}
+
 
 void Moonraker_Mqtt::async_control_main_fan(int speed, std::function<void(const nlohmann::json& response)> callback)
 {

--- a/src/slic3r/Utils/MoonRaker.hpp
+++ b/src/slic3r/Utils/MoonRaker.hpp
@@ -118,6 +118,7 @@ public:
     virtual void async_bedmesh_abort_probe_mesh(std::function<void(const nlohmann::json& response)>) {}
 
     virtual void async_controlPurifier(int fan_speed, int delay_time, int work_time, std::function<void(const nlohmann::json& response)>) {}
+    virtual void async_controlPurifier(const nlohmann::json& params, std::function<void(const nlohmann::json& response)> callback) {}
 
     virtual void async_control_main_fan(int speed, std::function<void(const nlohmann::json& response)>) {}
 
@@ -295,6 +296,7 @@ public:
     virtual void async_bedmesh_abort_probe_mesh(std::function<void(const nlohmann::json& response)>) override;
 
     virtual void async_controlPurifier(int fan_speed, int delay_time, int work_time, std::function<void(const nlohmann::json& response)>) override;
+    virtual void async_controlPurifier(const nlohmann::json& params, std::function<void(const nlohmann::json& response)> callback) override;
 
     virtual void async_control_main_fan(int speed, std::function<void(const nlohmann::json& response)>) override;
 

--- a/src/slic3r/Utils/PrintHost.hpp
+++ b/src/slic3r/Utils/PrintHost.hpp
@@ -150,6 +150,7 @@ public:
     virtual void async_bedmesh_abort_probe_mesh(std::function<void(const nlohmann::json& response)>) {}
 
     virtual void async_controlPurifier(int fan_speed, int delay_time, int work_time, std::function<void(const nlohmann::json& response)>) {}
+    virtual void async_controlPurifier(const nlohmann::json& params, std::function<void(const nlohmann::json& response)> callback) {}
 
     virtual void async_control_main_fan(int speed, std::function<void(const nlohmann::json& response)>) {}
 


### PR DESCRIPTION
## Summary

Remove parameter extraction in `sw_ControlPurifier`, pass all incoming params directly to `printer.control.purifier` without validation.

## Changes

- `src/slic3r/GUI/SSWCP.cpp` — `sw_ControlPurifier`: remove `fan_speed`/`delay_time`/`work_time` parsing, pass `m_param_data` directly
- `src/slic3r/Utils/PrintHost.hpp` — new `async_controlPurifier(const json&, callback)` virtual overload
- `src/slic3r/Utils/MoonRaker.hpp` — override declarations
- `src/slic3r/Utils/MoonRaker.cpp` — passthrough implementation: params sent as-is via `printer.control.purifier`

## Before / After

**Before**: `{"fan": "exhaust", "speed": 30}` → all parsed as `-1` → `{}` sent to device

**After**: `{"fan": "exhaust", "speed": 30}` → `{"fan": "exhaust", "speed": 30}` sent to device
