### PR TITLE
fix: avoid Plater access when clearing GLCanvas3D during destruction

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1203,7 +1203,7 @@ GLCanvas3D::GLCanvas3D(wxGLCanvas* canvas, Bed3D &bed)
 
 GLCanvas3D::~GLCanvas3D()
 {
-    reset_volumes();
+    reset_volumes(ResetVolumesMode::CanvasDestruction);
 
     m_sel_plate_toolbar.del_all_item();
     m_sel_plate_toolbar.del_stats_item();
@@ -1340,7 +1340,7 @@ unsigned int GLCanvas3D::get_volumes_count() const
     return (unsigned int)m_volumes.volumes.size();
 }
 
-void GLCanvas3D::reset_volumes()
+void GLCanvas3D::reset_volumes(ResetVolumesMode mode)
 {
     if (!m_initialized)
         return;
@@ -1350,9 +1350,12 @@ void GLCanvas3D::reset_volumes()
 
     _set_current();
 
-    m_selection.clear();
+    m_selection.clear(mode == ResetVolumesMode::Normal);
     m_volumes.clear();
     m_dirty = true;
+
+    if (mode == ResetVolumesMode::CanvasDestruction)
+        return;
 
     auto pLater = wxGetApp().plater();
     if (pLater) {

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -754,7 +754,11 @@ public:
 
     unsigned int get_volumes_count() const;
     const GLVolumeCollection& get_volumes() const { return m_volumes; }
-    void reset_volumes();
+    enum class ResetVolumesMode {
+        Normal,
+        CanvasDestruction
+    };
+    void reset_volumes(ResetVolumesMode mode = ResetVolumesMode::Normal);
     ModelInstanceEPrintVolumeState check_volumes_outside_state() const;
     bool is_all_plates_selected() { return m_sel_plate_toolbar.m_all_plates_stats_item && m_sel_plate_toolbar.m_all_plates_stats_item->selected; }
     const float get_scale() const;

--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -638,7 +638,7 @@ void Selection::set_deserialized(EMode mode, const std::vector<std::pair<size_t,
     set_bounding_boxes_dirty();
 }
 
-void Selection::clear()
+void Selection::clear(bool notify_sidebar)
 {
     if (!m_valid)
         return;
@@ -682,7 +682,8 @@ void Selection::clear()
 #endif
 
     // #et_FIXME fake KillFocus from sidebar
-    wxGetApp().plater()->canvas3D()->handle_sidebar_focus_event("", false);
+    if (notify_sidebar)
+        wxGetApp().plater()->canvas3D()->handle_sidebar_focus_event("", false);
 }
 
 // Update the selection based on the new instance IDs.

--- a/src/slic3r/GUI/Selection.hpp
+++ b/src/slic3r/GUI/Selection.hpp
@@ -249,7 +249,7 @@ public:
     // Update the selection based on the map from old indices to new indices after m_volumes changed.
     // If the current selection is by instance, this call may select newly added volumes, if they belong to already selected instances.
     void volumes_changed(const std::vector<size_t> &map_volume_old_to_new);
-    void clear();
+    void clear(bool notify_sidebar = true);
 
     bool is_empty() const { return m_type == Empty; }
     bool is_wipe_tower() const { return m_type == WipeTower; }


### PR DESCRIPTION
## Summary

Fix a shutdown crash caused by `GLCanvas3D::~GLCanvas3D()` re-entering `Plater` while child windows are being destroyed.

During destruction, `reset_volumes()` clears the selection, and `Selection::clear()` normally notifies the sidebar through `Plater::canvas3D()`. In shutdown paths, `Plater` private state may already be partially destroyed, so this callback can dereference invalid state and crash.

## Changes

- Add a destruction-specific `GLCanvas3D::ResetVolumesMode`.
- Keep normal `reset_volumes()` behavior unchanged by default.
- Make `GLCanvas3D::~GLCanvas3D()` use `CanvasDestruction` mode.
- Allow `Selection::clear()` to skip sidebar focus notification only for the destruction path.
- Avoid changing `Plater` destruction order.

## Risk

Low. The behavior change is limited to `GLCanvas3D` destruction. Normal volume reset and normal selection clearing still use the existing sidebar notification path.

## Testing

Not run locally. Compile/runtime validation will be handled separately.