### PR TITLE
Keep Local-Z whole-object masks scoped to mixed rows

### DIFF
--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -2860,13 +2860,14 @@ static std::vector<std::vector<ExPolygons>> local_z_planner_segmentation_with_wh
                 continue;
 
             const unsigned int state_id = segmentation_channel_filament_id(channel_idx);
+            if (!mixed_mgr.is_mixed(state_id, num_physical))
+                continue;
             if (channel_idx >= augmented[layer_id].size())
                 augmented[layer_id].resize(channel_idx + 1);
 
             append(augmented[layer_id][channel_idx], state_masks);
             layer_has_overlay = true;
-            if (mixed_mgr.is_mixed(state_id, num_physical))
-                ++overlay_mixed_channels;
+            ++overlay_mixed_channels;
         }
 
         for (size_t channel_idx = num_physical + 1; channel_idx < augmented[layer_id].size(); ++channel_idx) {
@@ -3159,9 +3160,9 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
     // Multi-color layer-cycle rows choose a pair once per nominal layer/zone
     // and rotate that pair independently from per-subpass A/B cadence.
     std::vector<int> row_layer_cycle_index(mixed_rows.size(), 0);
-    // Painted-only Local-Z keeps cadence isolated per zone. Whole-object Local-Z
-    // instead syncs newly introduced painted rows to the dominant mixed cadence
-    // so painted islands do not restart their phase at the boundary.
+    // Keep Local-Z cadence isolated per mixed row. Different mixed rows may
+    // share a component filament, but their ratios and phase must not bleed
+    // into one another.
     std::vector<uint8_t> row_active_prev_layer(mixed_rows.size(), uint8_t(0));
 
     std::vector<std::vector<int>> per_row_gradient_layers(mixed_rows.size());
@@ -3270,18 +3271,8 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
                     row_direct_component_error_mm[row_idx].size() == row_direct_component_ids[row_idx].size()) {
                     std::fill(row_direct_component_error_mm[row_idx].begin(), row_direct_component_error_mm[row_idx].end(), 0.0);
                 }
-                const bool can_sync_to_dominant =
-                    local_z_whole_objects &&
-                    dominant_mixed_idx < mixed_rows.size() &&
-                    dominant_mixed_idx != row_idx &&
-                    row_active_this_layer[dominant_mixed_idx] != 0;
-                if (can_sync_to_dominant) {
-                    row_cadence_index[row_idx]     = row_cadence_index[dominant_mixed_idx];
-                    row_layer_cycle_index[row_idx] = row_layer_cycle_index[dominant_mixed_idx];
-                } else {
-                    row_cadence_index[row_idx]     = 0;
-                    row_layer_cycle_index[row_idx] = 0;
-                }
+                row_cadence_index[row_idx]     = 0;
+                row_layer_cycle_index[row_idx] = 0;
             }
         }
         std::vector<LocalZActivePair> row_active_pairs(mixed_rows.size());
@@ -3336,7 +3327,10 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
                 continue;
             const unsigned int state_id = segmentation_channel_filament_id(channel_idx);
             if (state_id >= 1 && state_id <= num_physical) {
-                if (!dominant_is_gradient)
+                // Whole-object Local-Z uses physical paint only as a blocker
+                // when building augmented mixed masks. Do not put ordinary
+                // filaments into the Local-Z split domain.
+                if (!local_z_whole_objects && !dominant_is_gradient)
                     append(fixed_state_masks_by_extruder[state_id - 1], state_masks);
                 continue;
             }
@@ -3420,17 +3414,20 @@ static void build_local_z_plan(PrintObject &print_object, const std::vector<std:
 
         std::vector<std::vector<double>> isolated_row_pass_heights(mixed_rows.size());
         bool isolated_multi_row_mode = false;
-        if (interval.has_mixed_paint &&
-            preferred_a <= EPSILON &&
-            preferred_b <= EPSILON &&
-            active_mixed_rows > 1) {
+        if (interval.has_mixed_paint && active_mixed_rows > 1) {
             size_t isolated_rows_with_split = 0;
             for (size_t row_idx = 0; row_idx < row_active_this_layer.size(); ++row_idx) {
                 if (row_active_this_layer[row_idx] == 0)
                     continue;
 
                 std::vector<double> row_passes;
-                if (row_uses_direct_multicolor_solver[row_idx] != 0) {
+                if (preferred_a > EPSILON || preferred_b > EPSILON) {
+                    row_passes = build_local_z_pass_heights(interval.base_height,
+                                                            mixed_lower,
+                                                            mixed_upper,
+                                                            preferred_a,
+                                                            preferred_b);
+                } else if (row_uses_direct_multicolor_solver[row_idx] != 0) {
                     row_passes = build_local_z_direct_multicolor_pass_heights(mixed_rows[row_idx],
                                                                              row_direct_component_weights[row_idx],
                                                                              interval.base_height,


### PR DESCRIPTION
## Summary
- Prevent whole-object Local-Z from adding ordinary single-color filament regions to the Local-Z split domain.
- Overlay only mixed paint states when building whole-object Local-Z masks.
- Keep Local-Z cadence isolated per mixed row so separate mixed pairs do not influence each other.

Fixes 126.