### PR TITLE
[Bugfix]: fix crash on delete partPlate frequency

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1544,7 +1544,7 @@ void GLCanvas3D::set_config(const DynamicPrintConfig* config)
     // Orca: Filament shrinkage compensation
     const Print *print = fff_print();
     if (print != nullptr)
-        m_layers_editing.set_shrinkage_compensation(fff_print()->shrinkage_compensation());
+        m_layers_editing.set_shrinkage_compensation(print->shrinkage_compensation());
 }
 
 void GLCanvas3D::set_process(BackgroundSlicingProcess *process)

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -21259,6 +21259,11 @@ int Plater::delete_plate(int plate_index)
         index = p->partplate_list.get_curr_plate_index();
 
     take_snapshot("delete partplate");
+
+    // CRASH FIX: Clear fff_print reference before PartPlateList::delete_plate destroys the Print,
+    // preventing dangling pointer access during subsequent update calls.
+    p->background_process.set_fff_print(nullptr);
+
     ret = p->partplate_list.delete_plate(index);
 
     //BBS: update the current print to the current plate


### PR DESCRIPTION
Description
Reuse the cached print pointer instead of calling fff_print() a second time:

Null out m_fff_print before PartPlateList::delete_plate destroys the Print, then restore it afterwards via update_slice_context_to_current_plate: