### PR TITLE
fix: filament temp mixing enhancements, slice-all plate skip, and wxEntry encoding

### DIFF
--- a/localization/i18n/Snapmaker_Orca.pot
+++ b/localization/i18n/Snapmaker_Orca.pot
@@ -2850,6 +2850,12 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
+msgid "Confirm slicing"
+msgstr ""
+
+msgid "This material combination may cause risks. Do you want to continue?"
+msgstr ""
+
 msgid "Close"
 msgstr ""
 

--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -2826,6 +2826,9 @@ msgstr "AMS 材料设置"
 msgid "Confirm"
 msgstr "确定"
 
+msgid "Confirm slicing"
+msgstr "请确认是否切片"
+
 msgid "Close"
 msgstr "关闭"
 
@@ -15267,6 +15270,9 @@ msgstr "检测到高温材料与低温材料同时使用。混合打印可能导
 
 msgid "Detected both high and low temperature materials. Mixed printing may result in extruder clogging, nozzle damage, or layer adhesion issues. To continue printing, enable \"Allow mixed printing of high and low temperature materials\" in Preferences."
 msgstr "检测到高温材料与低温材料同时使用。混合打印可能导致挤出机堵塞、喷嘴损坏或层间粘附问题。如需继续打印，请在「偏好设置」中开启 \"允许高/低温材料混合打印\"。"
+
+msgid "This material combination may cause risks. Do you want to continue?"
+msgstr "此材料组合可能存在风险，是否继续？"
 
 msgid "Allow high/low temperature filament mixing"
 msgstr "允许高/低温材料混合打印"

--- a/src/Snapmaker_Orca.cpp
+++ b/src/Snapmaker_Orca.cpp
@@ -4991,6 +4991,27 @@ int CLI::run(int argc, char **argv)
                         print->apply(model, new_print_config);
                         BOOST_LOG_TRIVIAL(info) << boost::format("set no_check to %1%:")%no_check;
                         print->set_no_check_flag(no_check);//BBS
+                        // CLI guard: check high/low temp filament mixing.
+                        // The GUI has Plater::sync_filament_temp_mixing_notification()
+                        // which respects user preferences. For CLI we always block.
+                        if (print_fff) {
+                            const auto& pcfg = print_fff->config();
+                            const auto& extruders = print_fff->extruders();
+                            std::vector<std::string> ftypes;
+                            ftypes.reserve(extruders.size());
+                            for (unsigned int eid : extruders)
+                                ftypes.push_back(pcfg.filament_type.get_at(eid));
+                            if (!Print::check_multi_filaments_compatibility(ftypes)) {
+                                boost::nowide::cerr
+                                    << "Cannot print multiple filaments which have "
+                                       "large difference of temperature together."
+                                    << std::endl;
+                                record_exit_reson(outfile_dir, CLI_FILAMENTS_DIFFERENT_TEMP,
+                                                  index + 1, cli_errors[CLI_FILAMENTS_DIFFERENT_TEMP],
+                                                  sliced_info);
+                                flush_and_exit(CLI_FILAMENTS_DIFFERENT_TEMP);
+                            }
+                        }
                         StringObjectException warning;
                         auto err = print->validate(&warning);
                         if (!err.string.empty()) {

--- a/src/Snapmaker_Orca.cpp
+++ b/src/Snapmaker_Orca.cpp
@@ -4994,7 +4994,8 @@ int CLI::run(int argc, char **argv)
                         // CLI guard: check high/low temp filament mixing.
                         // The GUI has Plater::sync_filament_temp_mixing_notification()
                         // which respects user preferences. For CLI we always block.
-                        if (print_fff) {
+                        if (print_fff)
+                        {
                             const auto& pcfg = print_fff->config();
                             const auto& extruders = print_fff->extruders();
                             std::vector<std::string> ftypes;

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1556,15 +1556,6 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
     if (extruders.empty())
         return { L("No extrusions under current settings.") };
 
-    // Check for high/low temperature filament mixing.
-    if (extruders.size() > 1) {
-        auto ret = check_multi_filament_valid(*this);
-        if (!ret.string.empty()) {
-            ret.type = STRING_EXCEPT_FILAMENTS_DIFFERENT_TEMP;
-            return ret;
-        }
-    }
-
     if (m_config.print_sequence == PrintSequence::ByObject) {
         if (m_config.timelapse_type == TimelapseType::tlSmooth)
             return {L("Smooth mode of timelapse is not supported when \"by object\" sequence is enabled.")};

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1556,17 +1556,6 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
     if (extruders.empty())
         return { L("No extrusions under current settings.") };
 
-    // Check for high/low temperature filament mixing. The check uses
-    // filament_is_high_temperature from each filament preset. This guard
-    // works for both single-nozzle and multi-nozzle printers.
-    if (extruders.size() > 1) {
-        auto ret = check_multi_filament_valid(*this);
-        if (!ret.string.empty()) {
-            ret.type = STRING_EXCEPT_FILAMENTS_DIFFERENT_TEMP;
-            return ret;
-        }
-    }
-
     if (m_config.print_sequence == PrintSequence::ByObject) {
         if (m_config.timelapse_type == TimelapseType::tlSmooth)
             return {L("Smooth mode of timelapse is not supported when \"by object\" sequence is enabled.")};

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1556,6 +1556,15 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
     if (extruders.empty())
         return { L("No extrusions under current settings.") };
 
+    // Check for high/low temperature filament mixing.
+    if (extruders.size() > 1) {
+        auto ret = check_multi_filament_valid(*this);
+        if (!ret.string.empty()) {
+            ret.type = STRING_EXCEPT_FILAMENTS_DIFFERENT_TEMP;
+            return ret;
+        }
+    }
+
     if (m_config.print_sequence == PrintSequence::ByObject) {
         if (m_config.timelapse_type == TimelapseType::tlSmooth)
             return {L("Smooth mode of timelapse is not supported when \"by object\" sequence is enabled.")};

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -4049,10 +4049,10 @@ void GCodeViewer::render_shells(int canvas_width, int canvas_height)
 
 //BBS
 void GCodeViewer::render_all_plates_stats(const std::vector<const GCodeProcessorResult*>& gcode_result_list, bool show /*= true*/) const {
-    if (!show)
+    if (!show || gcode_result_list.empty())
         return;
-    for (auto gcode_result : gcode_result_list) {
-        if (gcode_result->moves.size() == 0)
+    for (const GCodeProcessorResult* gcode_result : gcode_result_list) {
+        if (gcode_result == nullptr || gcode_result->moves.empty())
             return;
     }
     ImGuiWrapper& imgui = *wxGetApp().imgui();
@@ -4076,7 +4076,7 @@ void GCodeViewer::render_all_plates_stats(const std::vector<const GCodeProcessor
     std::vector<ColorRGBA> filament_colors;
     decode_colors(wxGetApp().plater()->get_extruder_colors_from_plater_config(gcode_result_list.back()), filament_colors);
 
-    for (int i = 0; i < filament_colors.size(); i++) { 
+    for (size_t i = 0; i < filament_colors.size(); i++) {
         filament_colors[i] = adjust_color_for_rendering(filament_colors[i]);
     }
 
@@ -4170,6 +4170,10 @@ void GCodeViewer::render_all_plates_stats(const std::vector<const GCodeProcessor
         ImGui::Separator();
     };
     auto get_used_filament_from_volume = [this, imperial_units, &filament_diameters, &filament_densities](double volume, int extruder_id) {
+        if (extruder_id < 0 || static_cast<size_t>(extruder_id) >= filament_diameters.size() ||
+            static_cast<size_t>(extruder_id) >= filament_densities.size())
+            return std::pair<double, double>{ 0.0, 0.0 };
+
         double koef = imperial_units ? 1.0 / GizmoObjectManipulation::in_to_mm : 0.001;
         std::pair<double, double> ret = { koef * volume / (PI * sqr(0.5 * filament_diameters[extruder_id])),
                                             volume * filament_densities[extruder_id] * 0.001 };
@@ -4183,6 +4187,9 @@ void GCodeViewer::render_all_plates_stats(const std::vector<const GCodeProcessor
         PartPlateList& plate_list = wxGetApp().plater()->get_partplate_list();
         for (auto plate : plate_list.get_nonempty_plate_list())
         {
+            if (plate == nullptr || plate->get_slice_result() == nullptr)
+                continue;
+
             auto plate_print_statistics = plate->get_slice_result()->print_statistics;
             for (const auto& [extruder_id, model_volume] : plate_print_statistics.model_volumes_per_extruder) {
                 model_volume_of_extruders_all_plates[extruder_id] += model_volume;
@@ -4201,7 +4208,8 @@ void GCodeViewer::render_all_plates_stats(const std::vector<const GCodeProcessor
             
             Print     *print;
             plate->get_print((PrintBase **) &print, nullptr, nullptr);
-            total_cost_all_plates += print->print_statistics().total_cost;
+            if (print != nullptr)
+                total_cost_all_plates += print->print_statistics().total_cost;
         }
        
         for (auto it = model_volume_of_extruders_all_plates.begin(); it != model_volume_of_extruders_all_plates.end(); it++)

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4823,7 +4823,7 @@ void GLCanvas3D::do_move(const std::string& snapshot_type)
 
     reset_sequential_print_clearance();
 
-    wxGetApp().plater()->sync_filament_temp_mixing_notification();
+    wxGetApp().plater()->notify_filament_usage_changed();
 
     m_dirty = true;
 }

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -7931,16 +7931,19 @@ void GLCanvas3D::_render_imgui_select_plate_toolbar()
     }
     if (m_sel_plate_toolbar.show_stats_item) {
         all_plates_stats_item->percent = 0.0f;
+        const std::vector<PartPlate*> nonempty_plate_list = plate_list.get_nonempty_plate_list();
+        const std::vector<const GCodeProcessorResult*> nonempty_plate_results = plate_list.get_nonempty_plates_slice_results();
 
-        for (auto plate : plate_list.get_nonempty_plate_list()) {
+        for (PartPlate* plate : nonempty_plate_list) {
             if (plate->is_slice_result_valid() && plate->is_slice_result_ready_for_print())
                 sliced_plates_cnt++;
         }
-        all_plates_stats_item->percent = (float)(sliced_plates_cnt) / (float)(plate_list.get_nonempty_plate_list().size()) * 100.0f;
+        if (!nonempty_plate_list.empty())
+            all_plates_stats_item->percent = static_cast<float>(sliced_plates_cnt) / static_cast<float>(nonempty_plate_list.size()) * 100.0f;
 
         if (all_plates_stats_item->percent == 0.0f)
             all_plates_stats_item->slice_state = IMToolbarItem::SliceState::UNSLICED;
-        else if (sliced_plates_cnt == plate_list.get_nonempty_plate_list().size())
+        else if (sliced_plates_cnt == nonempty_plate_list.size())
             all_plates_stats_item->slice_state = IMToolbarItem::SliceState::SLICED;
         else if (all_plates_stats_item->percent < 100.0f)
             all_plates_stats_item->slice_state = IMToolbarItem::SliceState::SLICING;
@@ -7955,17 +7958,18 @@ void GLCanvas3D::_render_imgui_select_plate_toolbar()
 
         // Changing parameters does not invalid all plates, need extra logic to validate
         bool gcode_result_valid = true;
-        for (auto gcode_result : plate_list.get_nonempty_plates_slice_results()) {
-            if (gcode_result->moves.size() == 0) {
+        for (const GCodeProcessorResult* gcode_result : nonempty_plate_results) {
+            if (gcode_result == nullptr || gcode_result->moves.empty()) {
                 gcode_result_valid = false;
+                break;
             }
         }
         if (all_plates_stats_item->selected && all_plates_stats_item->slice_state == IMToolbarItem::SliceState::SLICED && gcode_result_valid) {
-            m_gcode_viewer.render_all_plates_stats(plate_list.get_nonempty_plates_slice_results());
+            m_gcode_viewer.render_all_plates_stats(nonempty_plate_results);
             m_render_preview = false;
         }
         else{
-            m_gcode_viewer.render_all_plates_stats(plate_list.get_nonempty_plates_slice_results(), false);
+            m_gcode_viewer.render_all_plates_stats(nonempty_plate_results, false);
             m_render_preview = true;
         }
     }else

--- a/src/slic3r/GUI/GUI_Init.cpp
+++ b/src/slic3r/GUI/GUI_Init.cpp
@@ -68,16 +68,23 @@ int GUI_Run(GUI_InitParams &params)
             wchar_t module_path[MAX_PATH + 1] = {0};
             GetModuleFileNameW(nullptr, module_path, MAX_PATH);
             char module_ansi[MAX_PATH * 2 + 1] = {0};
-            WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS,
-                                module_path, -1, module_ansi,
-                                sizeof(module_ansi), nullptr, nullptr);
-            if (module_ansi[0] == '\0') {
+            const int converted = WideCharToMultiByte(
+                CP_ACP, WC_NO_BEST_FIT_CHARS,
+                module_path, -1, module_ansi,
+                sizeof(module_ansi), nullptr, nullptr);
+            if (converted == 0)
+            {
                 // Fallback: conversion failed, use ASCII-safe short path
                 wchar_t short_path[MAX_PATH + 1] = {0};
                 GetShortPathNameW(module_path, short_path, MAX_PATH);
-                WideCharToMultiByte(CP_ACP, 0, short_path, -1,
-                                    module_ansi, sizeof(module_ansi),
-                                    nullptr, nullptr);
+                if (GetLastError() == ERROR_INSUFFICIENT_BUFFER ||
+                    WideCharToMultiByte(CP_ACP, 0, short_path, -1,
+                                        module_ansi, sizeof(module_ansi),
+                                        nullptr, nullptr) == 0)
+                {
+                    // Both primary and fallback failed; keep empty string,
+                    // wxEntry will use its own default behavior.
+                }
             }
             int   safe_argc = 1;
             char* safe_argv[] = { const_cast<char*>(module_ansi), nullptr };

--- a/src/slic3r/GUI/GUI_Init.cpp
+++ b/src/slic3r/GUI/GUI_Init.cpp
@@ -16,6 +16,11 @@
 #include <boost/nowide/iostream.hpp>
 #include <boost/nowide/convert.hpp>
 
+#ifdef _WIN32
+    #include <Windows.h>
+    #include <boost/nowide/stackstring.hpp>
+#endif
+
 #if __APPLE__
     #include <signal.h>
 #endif // __APPLE__
@@ -53,6 +58,32 @@ int GUI_Run(GUI_InitParams &params)
         GUI::GUI_App::SetInstance(gui);
         gui->init_params = &params;
 
+#ifdef _WIN32
+        // argv[0] from boost::nowide::narrow() is UTF-8, but wxEntry expects
+        // the system ANSI codepage (CP_ACP). When the executable path contains
+        // non-ASCII characters, the encoding mismatch causes wxWidgets to
+        // show: "Command line argument 0 couldn't be converted to Unicode".
+        // Rebuild argv[0] from the real module path using the proper codepage.
+        {
+            wchar_t module_path[MAX_PATH + 1] = {0};
+            GetModuleFileNameW(nullptr, module_path, MAX_PATH);
+            char module_ansi[MAX_PATH * 2 + 1] = {0};
+            WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS,
+                                module_path, -1, module_ansi,
+                                sizeof(module_ansi), nullptr, nullptr);
+            if (module_ansi[0] == '\0') {
+                // Fallback: conversion failed, use ASCII-safe short path
+                wchar_t short_path[MAX_PATH + 1] = {0};
+                GetShortPathNameW(module_path, short_path, MAX_PATH);
+                WideCharToMultiByte(CP_ACP, 0, short_path, -1,
+                                    module_ansi, sizeof(module_ansi),
+                                    nullptr, nullptr);
+            }
+            int   safe_argc = 1;
+            char* safe_argv[] = { const_cast<char*>(module_ansi), nullptr };
+            return wxEntry(safe_argc, safe_argv);
+        }
+#else
         if (params.argc > 1) {
             // STUDIO-273 wxWidgets report error when opening some files with specific names
             // wxWidgets does not handle parameters, so intercept parameters here, only keep the app name
@@ -63,6 +94,7 @@ int GUI_Run(GUI_InitParams &params)
         } else {
             return wxEntry(params.argc, params.argv);
         }
+#endif
     } catch (const Slic3r::Exception &ex) {
         BOOST_LOG_TRIVIAL(error) << ex.what() << std::endl;
         wxMessageBox(boost::nowide::widen(ex.what()), _L("Snapmaker Orca GUI initialization failed"), wxICON_STOP);

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -1100,7 +1100,7 @@ void ObjectList::update_filament_in_config(const wxDataViewItem& item)
 
     // update scene
     wxGetApp().plater()->update();
-    wxGetApp().plater()->sync_filament_temp_mixing_notification();
+    wxGetApp().plater()->notify_filament_usage_changed();
 }
 
 void ObjectList::update_name_in_model(const wxDataViewItem& item) const
@@ -5923,7 +5923,7 @@ void ObjectList::set_extruder_for_selected_items(const int extruder)
 
     // update scene
     wxGetApp().plater()->update();
-    wxGetApp().plater()->sync_filament_temp_mixing_notification();
+    wxGetApp().plater()->notify_filament_usage_changed();
 
     // BBS: update extruder/filament column
     Refresh();
@@ -5983,7 +5983,7 @@ void ObjectList::reload_all_plates(bool notify_partplate)
     wxGetApp().plater()->update();
     // update printable states on canvas
     wxGetApp().plater()->get_view3D_canvas3D()->update_instance_printable_state_for_objects(obj_idxs);
-    wxGetApp().plater()->sync_filament_temp_mixing_notification();
+    wxGetApp().plater()->notify_filament_usage_changed();
 }
 
 void ObjectList::on_plate_selected(int plate_index)

--- a/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoMmuSegmentation.cpp
@@ -1000,7 +1000,7 @@ void GLGizmoMmuSegmentation::update_model_object()
         wxGetApp().obj_list()->update_info_items(obj_idx);
         wxGetApp().plater()->get_partplate_list().notify_instance_update(obj_idx, 0);
         m_parent.post_event(SimpleEvent(EVT_GLCANVAS_SCHEDULE_BACKGROUND_PROCESS));
-        wxGetApp().plater()->sync_filament_temp_mixing_notification();
+        wxGetApp().plater()->notify_filament_usage_changed();
     }
 }
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -565,7 +565,7 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             }
             return;}
 #endif
-        if (evt.CmdDown() && evt.GetKeyCode() == 'R') { if (m_slice_enable) { wxGetApp().plater()->update(true, true); wxPostEvent(m_plater, SimpleEvent(EVT_GLTOOLBAR_SLICE_PLATE)); this->m_tabpanel->SetSelection(tpPreview); } return; }
+        if (evt.CmdDown() && evt.GetKeyCode() == 'R') { if (m_slice_enable) { wxGetApp().plater()->update(true, true); wxPostEvent(m_plater, SimpleEvent(EVT_GLTOOLBAR_SLICE_PLATE)); } return; }
         if (evt.CmdDown() && evt.ShiftDown() && evt.GetKeyCode() == 'G') {
             m_plater->apply_background_progress();
             m_print_enable = get_enable_print_status();
@@ -1659,7 +1659,6 @@ wxBoxSizer* MainFrame::create_side_tools()
             else
                 wxPostEvent(m_plater, SimpleEvent(EVT_GLTOOLBAR_SLICE_PLATE));
 
-            this->m_tabpanel->SetSelection(tpPreview);
         });
 
     m_print_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent& event)
@@ -2054,11 +2053,11 @@ void MainFrame::update_slice_print_status(SlicePrintEventType event, bool can_sl
 {
     bool enable_print = true, enable_slice = true;
 
-    if (!can_slice)
-    {
-        if (m_slice_select == eSlicePlate)
-            enable_slice = false;
-    }
+    if (event == eEventPlateUpdate)
+        enable_slice = get_enable_slice_status();
+    else if (!can_slice)
+        enable_slice = false;
+
     if (!can_print)
         enable_print = false;
 
@@ -2070,7 +2069,7 @@ void MainFrame::update_slice_print_status(SlicePrintEventType event, bool can_sl
     }
 
     //process slice logic
-    if (enable_slice)
+    if (event != eEventPlateUpdate && enable_slice)
     {
         enable_slice = get_enable_slice_status();
     }

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1043,11 +1043,13 @@ void MainFrame::init_tabpanel() {
         m_last_selected_tab = m_tabpanel->GetSelection();
         if (panel == m_plater) {
             if (sel == tp3DEditor) {
-                wxPostEvent(m_plater, SimpleEvent(EVT_GLVIEWTOOLBAR_3D));
+                if (!m_plater || !m_plater->is_view3D_shown())
+                    wxPostEvent(m_plater, SimpleEvent(EVT_GLVIEWTOOLBAR_3D));
                 m_param_panel->OnActivate();
             }
             else if (sel == tpPreview) {
-                wxPostEvent(m_plater, SimpleEvent(EVT_GLVIEWTOOLBAR_PREVIEW));
+                if (!m_plater || m_plater->is_view3D_shown())
+                    wxPostEvent(m_plater, SimpleEvent(EVT_GLVIEWTOOLBAR_PREVIEW));
                 m_param_panel->OnActivate();
             }
         }

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1891,8 +1891,7 @@ bool MainFrame::get_enable_slice_status()
         {
             enable = false;
         }*/
-        //always enable slice_all button
-        enable = true;
+        enable = m_plater->has_sliceable_plate_for_slice_all();
     }
     else if (m_slice_select == eSlicePlate)
     {
@@ -1901,6 +1900,10 @@ bool MainFrame::get_enable_slice_status()
             enable = false;
         }
         else if (!current_plate->can_slice())
+        {
+            enable = false;
+        }
+        else if (m_plater->is_plate_blocked_by_filament_temp_mixing(part_plate_list.get_curr_plate_index()))
         {
             enable = false;
         }

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2058,7 +2058,10 @@ void MainFrame::update_slice_print_status(SlicePrintEventType event, bool can_sl
     if (event == eEventPlateUpdate)
         enable_slice = get_enable_slice_status();
     else if (!can_slice)
-        enable_slice = false;
+        // Don't hard-disable the slice button; let get_enable_slice_status()
+        // decide. In eSliceAll mode other plates may still be sliceable even
+        // if the caller thinks the current plate isn't.
+        enable_slice = get_enable_slice_status();
 
     if (!can_print)
         enable_print = false;

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -1836,6 +1836,16 @@ void NotificationManager::push_validate_error_notification(StringObjectException
 	set_slicing_progress_hidden();
 }
 
+void NotificationManager::close_validate_error_notification(const std::string& text)
+{
+    close_notification_of_type_and_text(NotificationType::ValidateError, _u8L("Error:") + "\n" + text);
+}
+
+void NotificationManager::close_validate_warning_notification(const std::string& text)
+{
+    close_notification_of_type_and_text(NotificationType::ValidateWarning, _u8L("WARNING:") + "\n" + text);
+}
+
 void NotificationManager::push_slicing_error_notification(const std::string &text, std::vector<ModelObject const *> objs)
 {
     std::vector<ObjectID> ids;
@@ -2003,6 +2013,15 @@ void NotificationManager::close_notification_of_type(const NotificationType type
 		}
 	}
 }
+
+void NotificationManager::close_notification_of_type_and_text(const NotificationType type, const std::string& text)
+{
+    for (std::unique_ptr<PopNotification>& notification : m_pop_notifications) {
+        if (notification->get_type() == type && notification->compare_text(text))
+            notification->close();
+    }
+}
+
 void NotificationManager::remove_slicing_warnings_of_released_objects(const std::vector<ObjectID>& living_oids)
 {
 	for (std::unique_ptr<PopNotification> &notification : m_pop_notifications)

--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -2016,7 +2016,8 @@ void NotificationManager::close_notification_of_type(const NotificationType type
 
 void NotificationManager::close_notification_of_type_and_text(const NotificationType type, const std::string& text)
 {
-    for (std::unique_ptr<PopNotification>& notification : m_pop_notifications) {
+    for (std::unique_ptr<PopNotification>& notification : m_pop_notifications)
+    {
         if (notification->get_type() == type && notification->compare_text(text))
             notification->close();
     }

--- a/src/slic3r/GUI/NotificationManager.hpp
+++ b/src/slic3r/GUI/NotificationManager.hpp
@@ -199,6 +199,8 @@ public:
 	void stop_delayed_notifications_of_type(const NotificationType type);
 	// Creates Validate Error notification with a custom text and no fade out.
 	void push_validate_error_notification(StringObjectException const & error);
+	void close_validate_error_notification(const std::string& text);
+	void close_validate_warning_notification(const std::string& text);
 		// print host upload
 	void push_upload_job_notification(int id, float filesize, const std::string& filename, const std::string& host, float percentage = 0);
 	void set_upload_job_notification_percentage(int id, const std::string& filename, const std::string& host, float percentage);
@@ -844,6 +846,7 @@ private:
 	//can be used to create custom notification
 	bool push_notification_data(const NotificationData& notification_data, int timestamp);
 	bool push_notification_data(std::unique_ptr<NotificationManager::PopNotification> notification, int timestamp);
+	void close_notification_of_type_and_text(const NotificationType type, const std::string& text);
 	// Delayed notifications goes first to the m_waiting_notifications vector and only after remaining time is <= 0
 	// and condition callback is success, notification is regular pushed from update function.
 	// Otherwise another delay interval waiting. Timestamp is 0.
@@ -898,6 +901,8 @@ private:
 		NotificationType::PlaterWarning,
 		NotificationType::ProgressBar,
 		NotificationType::PrintHostUpload,
+        NotificationType::ValidateError,
+        NotificationType::ValidateWarning,
         NotificationType::SimplifySuggestion
 	};
 	//prepared (basic) notifications

--- a/src/slic3r/GUI/NotificationManager.hpp
+++ b/src/slic3r/GUI/NotificationManager.hpp
@@ -901,9 +901,9 @@ private:
 		NotificationType::PlaterWarning,
 		NotificationType::ProgressBar,
 		NotificationType::PrintHostUpload,
-        NotificationType::ValidateError,
-        NotificationType::ValidateWarning,
-        NotificationType::SimplifySuggestion
+		NotificationType::ValidateError,
+		NotificationType::ValidateWarning,
+		NotificationType::SimplifySuggestion
 	};
 	//prepared (basic) notifications
 	// non-static so its not loaded too early. If static, the translations wont load correctly.

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -4527,7 +4527,7 @@ int PartPlateList::add_to_plate(int obj_id, int instance_id, int plate_id)
 	}
 	ret = plate->add_instance(obj_id, instance_id, true);
 
-	wxGetApp().plater()->sync_filament_temp_mixing_notification();
+	wxGetApp().plater()->notify_filament_usage_changed();
 
 	return ret;
 }

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -4039,6 +4039,8 @@ int PartPlateList::select_plate(int index)
 		return -1;
 	}
 
+	const int old_plate_index = m_current_plate;
+
 	// BBS: erase unnecessary snapshot
 	if (get_curr_plate_index() != index && m_intialized) {
 		if (m_plater)
@@ -4052,6 +4054,8 @@ int PartPlateList::select_plate(int index)
 
 	m_current_plate = index;
 	m_plate_list[m_current_plate]->set_selected();
+	if (old_plate_index != m_current_plate && wxGetApp().plater())
+		wxGetApp().plater()->notify_filament_usage_changed();
 
 	//BBS
 	if(m_model)

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -201,6 +201,16 @@ static const std::pair<unsigned int, unsigned int> THUMBNAIL_SIZE_3MF = { 512, 5
 namespace Slic3r {
 namespace GUI {
 
+static std::string filament_temp_mixing_warning_text()
+{
+    return _u8L("Detected both high and low temperature materials. Mixed printing may result in extruder clogging, nozzle damage, or layer adhesion issues.");
+}
+
+static std::string filament_temp_mixing_error_text()
+{
+    return _u8L("Detected both high and low temperature materials. Mixed printing may result in extruder clogging, nozzle damage, or layer adhesion issues. To continue printing, enable \"Allow mixed printing of high and low temperature materials\" in Preferences.");
+}
+
 wxDEFINE_EVENT(EVT_SCHEDULE_BACKGROUND_PROCESS,     SimpleEvent);
 wxDEFINE_EVENT(EVT_SLICING_UPDATE,                  SlicingStatusEvent);
 wxDEFINE_EVENT(EVT_SLICING_COMPLETED,               wxCommandEvent);
@@ -231,6 +241,7 @@ wxDEFINE_EVENT(EVT_PRINT_FROM_SDCARD_VIEW,          SimpleEvent);
 
 wxDEFINE_EVENT(EVT_CREATE_FILAMENT, SimpleEvent);
 wxDEFINE_EVENT(EVT_MODIFY_FILAMENT, SimpleEvent);
+wxDEFINE_EVENT(EVT_FILAMENT_USAGE_CHANGED, SimpleEvent);
 wxDEFINE_EVENT(EVT_ADD_FILAMENT, SimpleEvent);
 wxDEFINE_EVENT(EVT_DEL_FILAMENT, SimpleEvent);
 wxDEFINE_EVENT(EVT_ADD_CUSTOM_FILAMENT, ColorEvent);
@@ -2869,8 +2880,7 @@ void Sidebar::update_presets(Preset::Type preset_type)
 
         update_dynamic_filament_list();
 
-        // Real-time high/low temperature filament mixing check after filament preset change
-        p->plater->sync_filament_temp_mixing_notification();
+        p->plater->notify_filament_usage_changed();
 
         break;
     }
@@ -8409,6 +8419,7 @@ struct Plater::priv
     // PIMPL back pointer ("Q-Pointer")
     Plater *q;
     MainFrame *main_frame;
+    bool filament_usage_sync_pending = false;
 
     MenuFactory menus;
 
@@ -9057,6 +9068,10 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
     this->q->Bind(EVT_CREATE_FILAMENT, &priv::on_create_filament, this);
     this->q->Bind(EVT_MODIFY_FILAMENT, &priv::on_modify_filament, this);
     this->q->Bind(EVT_ADD_CUSTOM_FILAMENT, &priv::on_add_custom_filament, this);
+    this->q->Bind(EVT_FILAMENT_USAGE_CHANGED, [this](SimpleEvent&) {
+        filament_usage_sync_pending = false;
+        this->q->sync_filament_temp_mixing_notification();
+    });
     main_frame->m_tabpanel->Bind(wxEVT_NOTEBOOK_PAGE_CHANGING, &priv::on_tab_selection_changing, this);
 
     auto* panel_3d = new wxPanel(q);
@@ -11250,7 +11265,7 @@ void Plater::priv::remove_curr_plate_all()
     view3D->remove_curr_plate_all();
     this->sidebar->obj_list()->update_selections();
 
-    q->sync_filament_temp_mixing_notification();
+    q->notify_filament_usage_changed();
 }
 
 void Plater::priv::select_all()
@@ -11282,6 +11297,7 @@ void Plater::priv::remove(size_t obj_idx)
     // Delete object from Sidebar list. Do it after update, so that the GLScene selection is updated with the modified model.
     sidebar->obj_list()->delete_object_from_list(obj_idx);
     object_list_changed();
+    q->notify_filament_usage_changed();
 }
 
 
@@ -11320,6 +11336,8 @@ bool Plater::priv::delete_object_from_model(size_t obj_idx, bool refresh_immedia
         object_list_changed();
     }
 
+    q->notify_filament_usage_changed();
+
     return true;
 }
 
@@ -11352,6 +11370,7 @@ void Plater::priv::delete_all_objects_from_model()
     //BBS
     model.calib_pa_pattern.reset();
     model.plates_custom_gcodes.clear();
+    q->notify_filament_usage_changed();
 }
 
 void Plater::priv::reset(bool apply_presets_change)
@@ -11731,6 +11750,10 @@ unsigned int Plater::priv::update_background_process(bool force_validation, bool
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": validate err=%1%, warning=%2%")%err.string%warning.string;
 
         if (err.string.empty()) {
+            // Pass a warning from validation and either show a notification,
+            // or hide the old one.
+            process_validation_warning(warning);
+
             // Validate passed, but also check filament temp mixing as a final
             // guard. check_filament_temp_mixing() reads directly from preset
             // configs and catches cases that Print::validate() may miss (e.g.
@@ -11744,9 +11767,6 @@ unsigned int Plater::priv::update_background_process(bool force_validation, bool
             if (invalidated != Print::APPLY_STATUS_UNCHANGED && background_processing_enabled())
                 return_state |= UPDATE_BACKGROUND_PROCESS_RESTART;
 
-            // Pass a warning from validation and either show a notification,
-            // or hide the old one.
-            process_validation_warning(warning);
             if (printer_technology == ptFFF) {
                 view3D->get_canvas3d()->reset_sequential_print_clearance();
                 view3D->get_canvas3d()->set_as_dirty();
@@ -13656,14 +13676,8 @@ void Plater::priv::on_action_slice_plate(SimpleEvent&)
         Model::setPrintSpeedTable(config, print_config);
         m_slice_all = false;
 
-        // Pre-slice confirmation for high/low temp filament mixing
-        if (wxGetApp().app_config->get_bool("allow_filament_temp_mixing")
-            && !q->check_filament_temp_mixing()) {
-            wxMessageDialog dlg(q, _L("该组合可能导致风险，是否继续"),
-                                _L("确认"), wxYES_NO | wxICON_WARNING);
-            if (dlg.ShowModal() != wxID_YES)
-                return;
-        }
+        if (!q->confirm_filament_temp_mixing_before_slice())
+            return;
 
         q->reslice();
         q->select_view_3D("Preview");
@@ -13684,14 +13698,8 @@ void Plater::priv::on_action_slice_all(SimpleEvent&)
         Model::setExtruderParams(config, numExtruders);
         Model::setPrintSpeedTable(config, print_config);
 
-        // Pre-slice confirmation for high/low temp filament mixing
-        if (wxGetApp().app_config->get_bool("allow_filament_temp_mixing")
-            && !q->check_filament_temp_mixing()) {
-            wxMessageDialog dlg(q, _L("该组合可能导致风险，是否继续"),
-                                _L("确认"), wxYES_NO | wxICON_WARNING);
-            if (dlg.ShowModal() != wxID_YES)
-                return;
-        }
+        if (!q->confirm_filament_temp_mixing_before_slice())
+            return;
 
         m_slice_all = true;
         m_slice_all_only_has_gcode = true;
@@ -17152,7 +17160,10 @@ std::vector<size_t> Plater::load_files(const std::vector<fs::path>& input_files,
     p->m_slice_all_only_has_gcode = false;
     //BBS: wish to reset all plates stats item selected state when load a new file
     p->preview->get_canvas3d()->reset_select_plate_toolbar_selection();
-    return p->load_files(input_files, strategy, ask_multi);
+    std::vector<size_t> loaded = p->load_files(input_files, strategy, ask_multi);
+    if (!loaded.empty())
+        notify_filament_usage_changed();
+    return loaded;
 }
 
 // To be called when providing a list of files to the GUI slic3r on command line.
@@ -17162,7 +17173,7 @@ std::vector<size_t> Plater::load_files(const std::vector<std::string>& input_fil
     paths.reserve(input_files.size());
     for (const std::string& path : input_files)
         paths.emplace_back(path);
-    return p->load_files(paths, strategy, ask_multi);
+    return load_files(paths, strategy, ask_multi);
 }
 
 bool Plater::preview_zip_archive(const boost::filesystem::path& archive_path)
@@ -18049,8 +18060,10 @@ void Plater::remove_selected()
     //BBS delete current selected
     // p->view3D->delete_selected();
     GLCanvas3D* canvas = p->get_current_canvas3D();
-    if (canvas)
+    if (canvas) {
         canvas->delete_selected();
+        notify_filament_usage_changed();
+    }
 }
 
 void Plater::increase_instances(size_t num)
@@ -20100,6 +20113,27 @@ bool Plater::check_filament_temp_mixing()
     int num_filaments = (int)ft_opt->values.size();
     std::set<int> used_slots;
 
+    PartPlate* curr_plate = p->partplate_list.get_curr_plate();
+    auto object_is_on_curr_plate = [curr_plate](size_t obj_idx, const ModelObject* mo) {
+        if (!curr_plate)
+            return true;
+        for (int inst_idx = 0; inst_idx < (int)mo->instances.size(); ++inst_idx) {
+            if (curr_plate->contain_instance((int)obj_idx, inst_idx))
+                return true;
+        }
+        return false;
+    };
+
+    bool has_object_on_curr_plate = false;
+    for (size_t obj_idx = 0; obj_idx < wxGetApp().model().objects.size(); ++obj_idx) {
+        if (object_is_on_curr_plate(obj_idx, wxGetApp().model().objects[obj_idx])) {
+            has_object_on_curr_plate = true;
+            break;
+        }
+    }
+    if (!has_object_on_curr_plate)
+        return true;
+
     auto collect_from_cfg = [&](const DynamicPrintConfig& cfg) {
         static const char* keys_1based[] = {"wall_filament", "solid_infill_filament"};
         for (auto key : keys_1based) {
@@ -20120,23 +20154,13 @@ bool Plater::check_filament_temp_mixing()
     collect_from_cfg(*this->config());
 
     // Also collect from current plate's config for any plate-level overrides
-    PartPlate* curr_plate = p->partplate_list.get_curr_plate();
     if (curr_plate)
         collect_from_cfg(*curr_plate->config());
 
     // Collect from ModelVolume painting extruders for objects on the current plate
     for (size_t obj_idx = 0; obj_idx < wxGetApp().model().objects.size(); ++obj_idx) {
         const ModelObject* mo = wxGetApp().model().objects[obj_idx];
-        bool on_curr_plate = false;
-        if (curr_plate) {
-            for (int inst_idx = 0; inst_idx < (int)mo->instances.size(); ++inst_idx) {
-                if (curr_plate->contain_instance((int)obj_idx, inst_idx)) {
-                    on_curr_plate = true;
-                    break;
-                }
-            }
-        }
-        if (!on_curr_plate)
+        if (!object_is_on_curr_plate(obj_idx, mo))
             continue;
         for (const ModelVolume* mv : mo->volumes) {
             for (int eid : mv->get_extruders()) {
@@ -20174,30 +20198,62 @@ bool Plater::check_filament_temp_mixing()
     return compatible;
 }
 
+Plater::FilamentTempMixingState Plater::get_filament_temp_mixing_state()
+{
+    if (check_filament_temp_mixing())
+        return FilamentTempMixingState::Compatible;
+
+    return wxGetApp().app_config->get_bool("allow_filament_temp_mixing") ?
+        FilamentTempMixingState::AllowedWarning :
+        FilamentTempMixingState::BlockedError;
+}
+
 bool Plater::sync_filament_temp_mixing_notification()
 {
-    if (check_filament_temp_mixing()) {
-        get_notification_manager()->close_notification_of_type(NotificationType::ValidateError);
-        get_notification_manager()->close_notification_of_type(NotificationType::ValidateWarning);
+    switch (get_filament_temp_mixing_state()) {
+    case FilamentTempMixingState::Compatible:
+        get_notification_manager()->close_validate_error_notification(filament_temp_mixing_error_text());
+        get_notification_manager()->close_validate_warning_notification(filament_temp_mixing_warning_text());
         get_partplate_list().get_curr_plate()->update_apply_result_invalid(false);
         return true;
-    }
-
-    StringObjectException err;
-    err.type   = STRING_EXCEPT_FILAMENTS_DIFFERENT_TEMP;
-
-    if (wxGetApp().app_config->get_bool("allow_filament_temp_mixing")) {
+    case FilamentTempMixingState::AllowedWarning:
+        get_notification_manager()->close_validate_error_notification(filament_temp_mixing_error_text());
+        get_partplate_list().get_curr_plate()->update_apply_result_invalid(false);
         get_notification_manager()->push_notification(
             NotificationType::ValidateWarning,
             NotificationManager::NotificationLevel::WarningNotificationLevel,
-            _u8L("WARNING:") + "\n" +
-            _u8L("Detected both high and low temperature materials. Mixed printing may result in extruder clogging, nozzle damage, or layer adhesion issues."));
-    } else {
-        err.string = _u8L("Detected both high and low temperature materials. Mixed printing may result in extruder clogging, nozzle damage, or layer adhesion issues. To continue printing, enable \"Allow mixed printing of high and low temperature materials\" in Preferences.");
+            _u8L("WARNING:") + "\n" + filament_temp_mixing_warning_text());
+        return true;
+    case FilamentTempMixingState::BlockedError: {
+        StringObjectException err;
+        err.type   = STRING_EXCEPT_FILAMENTS_DIFFERENT_TEMP;
+        err.string = filament_temp_mixing_error_text();
+        get_notification_manager()->close_validate_warning_notification(filament_temp_mixing_warning_text());
         get_notification_manager()->push_validate_error_notification(err);
         get_partplate_list().get_curr_plate()->update_apply_result_invalid(true);
+        return false;
     }
-    return false;
+    }
+
+    return true;
+}
+
+bool Plater::confirm_filament_temp_mixing_before_slice()
+{
+    if (get_filament_temp_mixing_state() != FilamentTempMixingState::AllowedWarning)
+        return true;
+
+    wxMessageDialog dlg(this, _L("该组合可能导致风险，是否继续"), _L("确认"), wxYES_NO | wxICON_WARNING);
+    return dlg.ShowModal() == wxID_YES;
+}
+
+void Plater::notify_filament_usage_changed()
+{
+    if (p->filament_usage_sync_pending)
+        return;
+
+    p->filament_usage_sync_pending = true;
+    wxQueueEvent(this, new SimpleEvent(EVT_FILAMENT_USAGE_CHANGED, this));
 }
 
 void Plater::on_config_change(const DynamicPrintConfig &config)
@@ -20289,7 +20345,7 @@ void Plater::on_config_change(const DynamicPrintConfig &config)
         update_title_dirty_status();
     }
 
-    sync_filament_temp_mixing_notification();
+    notify_filament_usage_changed();
 }
 
 void Plater::set_bed_shape() const

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -14,6 +14,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <numeric>
 #include <memory>
@@ -8511,7 +8512,7 @@ struct Plater::priv
     // PIMPL back pointer ("Q-Pointer")
     Plater *q;
     MainFrame *main_frame;
-    bool filament_usage_sync_pending = false;
+    std::atomic<bool> filament_usage_sync_pending{false};
     bool filament_temp_mixing_notification_initialized = false;
     int filament_temp_mixing_notification_plate = -1;
     FilamentTempMixingState filament_temp_mixing_notification_state = FilamentTempMixingState::Compatible;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -20239,10 +20239,6 @@ bool Plater::check_filament_temp_mixing(int plate_index)
     if (!has_object_on_plate)
         return true;
 
-    // Collect from the Plater's working config for global Process settings.
-    // Defaults are 0 (skipped by the >= 1 check).
-    collect_filament_slots_from_config(*this->config(), num_filaments, used_slots);
-
     // Also collect from current plate's config for any plate-level overrides
     if (plate)
         collect_filament_slots_from_config(*plate->config(), num_filaments, used_slots);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17258,8 +17258,24 @@ std::vector<size_t> Plater::load_files(const std::vector<fs::path>& input_files,
     //BBS: wish to reset all plates stats item selected state when load a new file
     p->preview->get_canvas3d()->reset_select_plate_toolbar_selection();
     std::vector<size_t> loaded = p->load_files(input_files, strategy, ask_multi);
-    if (!loaded.empty())
+    if (!loaded.empty()) {
+        // After loading a project, initialize the filament temp mixing state
+        // for ALL plates, not just the current one. This ensures each plate's
+        // m_apply_invalid flag is correct so that "Slice All" mode correctly
+        // detects which plates are sliceable.
+        PartPlateList& plate_list = get_partplate_list();
+        for (int i = 0; i < plate_list.get_plate_count(); ++i) {
+            FilamentTempMixingState state = get_filament_temp_mixing_state(i);
+            PartPlate* plate = plate_list.get_plate(i);
+            if (plate) {
+                plate->update_apply_result_invalid(
+                    state == FilamentTempMixingState::BlockedError);
+            }
+        }
         notify_filament_usage_changed();
+        // Force a sync for the current plate's notification display
+        sync_filament_temp_mixing_notification();
+    }
     return loaded;
 }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -264,6 +264,19 @@ static void collect_filament_slots_from_config(
         used_slots.insert(extruder_option->value - 1);
 }
 
+static void collect_filament_slots_from_model_config(
+    const ModelConfigObject& config,
+    int num_filaments,
+    std::set<int>& used_slots)
+{
+    if (!config.has("extruder"))
+        return;
+
+    const int extruder_id = config.extruder();
+    if (extruder_id >= 1 && extruder_id <= num_filaments)
+        used_slots.insert(extruder_id - 1);
+}
+
 wxDEFINE_EVENT(EVT_SCHEDULE_BACKGROUND_PROCESS,     SimpleEvent);
 wxDEFINE_EVENT(EVT_SLICING_UPDATE,                  SlicingStatusEvent);
 wxDEFINE_EVENT(EVT_SLICING_COMPLETED,               wxCommandEvent);
@@ -8510,7 +8523,6 @@ struct Plater::priv
     PartPlateList partplate_list;
     //BBS: add a flag to ignore cancel event
     bool m_ignore_event{false};
-    bool m_in_select_view_3D{false};
     bool m_slice_all{false};
     bool m_is_slicing {false};
     bool m_is_publishing {false};
@@ -9394,8 +9406,8 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
                     return;
                 }
                 if (q->is_plate_blocked_by_filament_temp_mixing(q->get_partplate_list().get_curr_plate_index())) {
-                    wxGetApp().mainframe->select_tab(size_t(MainFrame::tp3DEditor));
                     q->sync_filament_temp_mixing_notification();
+                    q->select_view_3D("Preview", true);
                     return;
                 }
             }
@@ -9691,10 +9703,6 @@ void Plater::priv::apply_free_camera_correction(bool apply/* = true*/)
 //BBS: add no slice option
 void Plater::priv::select_view_3D(const std::string& name, bool no_slice)
 {
-    if (m_in_select_view_3D)
-        return;
-    m_in_select_view_3D = true;
-
     if (name == "3D") {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << __LINE__ << "select view3D";
         if (q->only_gcode_mode() || q->using_exported_file()) {
@@ -9727,7 +9735,6 @@ void Plater::priv::select_view_3D(const std::string& name, bool no_slice)
     selection_changed();
 
     apply_free_camera_correction(false);
-    m_in_select_view_3D = false;
 }
 
 void Plater::priv::select_next_view_3D()
@@ -20232,31 +20239,27 @@ bool Plater::check_filament_temp_mixing(int plate_index)
     if (!has_object_on_plate)
         return true;
 
+    // Collect from the Plater's working config for global Process settings.
+    // Defaults are 0 (skipped by the >= 1 check).
+    collect_filament_slots_from_config(*this->config(), num_filaments, used_slots);
+
     // Also collect from current plate's config for any plate-level overrides
     if (plate)
         collect_filament_slots_from_config(*plate->config(), num_filaments, used_slots);
 
-    // Collect from ModelVolume painting extruders and object configs for
-    // objects on the current plate. Track whether any object relies on the
-    // global default extruder so we can resolve it at the end.
+    // Collect from ModelVolume painting extruders for objects on the
+    // current plate. Also track whether any object relies on the global
+    // default extruder (extruder=0) so we can resolve it at the end.
     bool uses_default_extruder = false;
     for (size_t obj_idx = 0; obj_idx < wxGetApp().model().objects.size(); ++obj_idx) {
         const ModelObject* model_object = wxGetApp().model().objects[obj_idx];
         if (!model_object_is_on_plate(plate, obj_idx, model_object))
             continue;
-
-        const int obj_extruder = model_object->config.extruder();
-        if (obj_extruder >= 1 && obj_extruder <= num_filaments)
-            used_slots.insert(obj_extruder - 1);
-        else if (obj_extruder == 0)
+        collect_filament_slots_from_model_config(model_object->config, num_filaments, used_slots);
+        if (model_object->config.extruder() == 0)
             uses_default_extruder = true;
-
         for (const ModelVolume* model_volume : model_object->volumes) {
-            if (model_volume->config.has("extruder")) {
-                const int vol_extruder = model_volume->config.extruder();
-                if (vol_extruder >= 1 && vol_extruder <= num_filaments)
-                    used_slots.insert(vol_extruder - 1);
-            }
+            collect_filament_slots_from_model_config(model_volume->config, num_filaments, used_slots);
             for (int extruder_id : model_volume->get_extruders()) {
                 if (extruder_id >= 1 && extruder_id <= num_filaments)
                     used_slots.insert(extruder_id - 1);
@@ -20265,7 +20268,9 @@ bool Plater::check_filament_temp_mixing(int plate_index)
     }
 
     // Resolve the global default extruder if any object on this plate
-    // uses extruder=0 (meaning "inherit from global config").
+    // uses extruder=0. p->config does not include the "extruder" key
+    // (it is not in the initializer list at priv constructor), so we
+    // must read it from full_config() instead.
     if (uses_default_extruder) {
         const ConfigOptionInt* extruder_opt = full_cfg.option<ConfigOptionInt>("extruder");
         if (extruder_opt != nullptr && extruder_opt->value >= 1 && extruder_opt->value <= num_filaments)
@@ -20351,10 +20356,6 @@ bool Plater::sync_filament_temp_mixing_notification()
     const int curr_plate_index = get_partplate_list().get_curr_plate_index();
     PartPlate* curr_plate = get_partplate_list().get_curr_plate();
     const FilamentTempMixingState mixing_state = get_filament_temp_mixing_state(curr_plate_index);
-    const bool notification_state_changed =
-        !p->filament_temp_mixing_notification_initialized ||
-        p->filament_temp_mixing_notification_plate != curr_plate_index ||
-        p->filament_temp_mixing_notification_state != mixing_state;
     bool slicing_allowed = true;
 
     switch (mixing_state) {
@@ -20367,12 +20368,10 @@ bool Plater::sync_filament_temp_mixing_notification()
     case FilamentTempMixingState::AllowedWarning:
         get_notification_manager()->close_validate_error_notification(filament_temp_mixing_error_text());
         get_partplate_list().get_curr_plate()->update_apply_result_invalid(false);
-        if (notification_state_changed) {
-            get_notification_manager()->push_notification(
-                NotificationType::ValidateWarning,
-                NotificationManager::NotificationLevel::WarningNotificationLevel,
-                _u8L("WARNING:") + "\n" + filament_temp_mixing_warning_text());
-        }
+        get_notification_manager()->push_notification(
+            NotificationType::ValidateWarning,
+            NotificationManager::NotificationLevel::WarningNotificationLevel,
+            _u8L("WARNING:") + "\n" + filament_temp_mixing_warning_text());
         slicing_allowed = true;
         break;
     case FilamentTempMixingState::BlockedError: {
@@ -20380,8 +20379,7 @@ bool Plater::sync_filament_temp_mixing_notification()
         err.type   = STRING_EXCEPT_FILAMENTS_DIFFERENT_TEMP;
         err.string = filament_temp_mixing_error_text();
         get_notification_manager()->close_validate_warning_notification(filament_temp_mixing_warning_text());
-        if (notification_state_changed)
-            get_notification_manager()->push_validate_error_notification(err);
+        get_notification_manager()->push_validate_error_notification(err);
         get_partplate_list().get_curr_plate()->update_apply_result_invalid(true);
         slicing_allowed = false;
         break;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -20418,9 +20418,11 @@ bool Plater::confirm_filament_temp_mixing_before_slice()
         break;
     }
 
-    wxMessageDialog dlg(this, _L("This material combination may cause risks. Do you want to continue?"),
-                        _L("Confirm"), wxYES_NO | wxICON_WARNING);
-    return dlg.ShowModal() == wxID_YES;
+    MessageDialog dlg(this, _L("This material combination may cause risks. Do you want to continue?"),
+                      _L("Confirm slicing"), wxICON_WARNING | wxOK | wxCANCEL);
+    dlg.SetButtonLabel(wxID_OK, _L("Confirm"));
+    dlg.SetButtonLabel(wxID_CANCEL, _L("Cancel"));
+    return dlg.ShowModal() == wxID_OK;
 }
 
 bool Plater::confirm_filament_temp_mixing_before_slice_all()
@@ -20443,9 +20445,11 @@ bool Plater::confirm_filament_temp_mixing_before_slice_all()
     if (!has_allowed_warning)
         return true;
 
-    wxMessageDialog dlg(this, _L("This material combination may cause risks. Do you want to continue?"),
-                        _L("Confirm"), wxYES_NO | wxICON_WARNING);
-    return dlg.ShowModal() == wxID_YES;
+    MessageDialog dlg(this, _L("This material combination may cause risks. Do you want to continue?"),
+                      _L("Confirm slicing"), wxICON_WARNING | wxOK | wxCANCEL);
+    dlg.SetButtonLabel(wxID_OK, _L("Confirm"));
+    dlg.SetButtonLabel(wxID_CANCEL, _L("Cancel"));
+    return dlg.ShowModal() == wxID_OK;
 }
 
 void Plater::notify_filament_usage_changed()

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -275,12 +275,32 @@ static void collect_filament_slots_from_model_config(
     int num_filaments,
     std::set<int>& used_slots)
 {
-    if (!config.has("extruder"))
-        return;
+    if (config.has("extruder"))
+    {
+        const int extruder_id = config.extruder();
+        if (extruder_id >= 1 && extruder_id <= num_filaments)
+            used_slots.insert(extruder_id - 1);
+    }
 
-    const int extruder_id = config.extruder();
-    if (extruder_id >= 1 && extruder_id <= num_filaments)
-        used_slots.insert(extruder_id - 1);
+    // Per-object feature-specific keys (wall_filament, etc.) may be
+    // overridden independently of the object's primary extruder.
+    static const std::vector<const char*> feature_keys = {
+        "wall_filament",
+        "sparse_infill_filament",
+        "solid_infill_filament",
+        "support_filament",
+        "support_interface_filament",
+        "wipe_tower_filament"
+    };
+    for (const char* key : feature_keys)
+    {
+        if (config.has(key))
+        {
+            const int val = config.opt_int(key);
+            if (val >= 1 && val <= num_filaments)
+                used_slots.insert(val - 1);
+        }
+    }
 }
 
 wxDEFINE_EVENT(EVT_SCHEDULE_BACKGROUND_PROCESS,     SimpleEvent);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9069,7 +9069,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
         "extruder_colour", "filament_colour", "material_colour", "printable_height", "printer_model", "printer_technology",
         // These values are necessary to construct SlicingParameters by the Canvas3D variable layer height editor.
         "layer_height", "initial_layer_print_height", "min_layer_height", "max_layer_height",
-        "brim_width", "wall_loops", "wall_filament", "sparse_infill_density", "sparse_infill_filament", "top_shell_layers",
+        "brim_width", "wall_loops", "wall_filament", "sparse_infill_density", "sparse_infill_filament", "solid_infill_filament", "top_shell_layers",
         "enable_support", "support_filament", "support_interface_filament",
         "support_top_z_distance", "support_bottom_z_distance", "raft_layers",
         "wipe_tower_rotation_angle", "wipe_tower_cone_angle", "wipe_tower_extra_spacing", "wipe_tower_extra_flow", "local_z_wipe_tower_purge_lines", "wipe_tower_max_purge_speed",

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -20297,6 +20297,45 @@ bool Plater::check_filament_temp_mixing(int plate_index)
         }
     }
 
+    // Collect from the Plater working config. The approach balances
+    // sensitivity against false positives:
+    // - Global features (wipe tower, support) always apply → always collected.
+    // - Feature-specific keys (wall_filament, infill) depend on the global
+    //   process defaults. They are only collected when at least one object
+    //   on the plate uses the default extruder (e=0), which means those
+    //   defaults WILL affect the actual slicing output.
+    {
+        // Always collect: features that cannot be overridden per-object.
+        static const std::vector<const char*> always_collect = {
+            "wipe_tower_filament",
+            "support_filament",
+            "support_interface_filament"
+        };
+        for (const char* key : always_collect)
+        {
+            const ConfigOptionInt* option = this->config()->option<ConfigOptionInt>(key);
+            if (option != nullptr && option->value >= 1 && option->value <= num_filaments)
+                used_slots.insert(option->value - 1);
+        }
+
+        // If any object uses e=0, the global process defaults for
+        // wall / infill extruders apply and must be collected.
+        if (uses_default_extruder)
+        {
+            static const std::vector<const char*> default_keys = {
+                "wall_filament",
+                "sparse_infill_filament",
+                "solid_infill_filament"
+            };
+            for (const char* key : default_keys)
+            {
+                const ConfigOptionInt* option = this->config()->option<ConfigOptionInt>(key);
+                if (option != nullptr && option->value >= 1 && option->value <= num_filaments)
+                    used_slots.insert(option->value - 1);
+            }
+        }
+    }
+
     // Resolve the global default extruder if any object on this plate
     // uses extruder=0. p->config does not include the "extruder" key
     // (it is not in the initializer list at priv constructor), so we

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9398,7 +9398,21 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
         q->Bind(EVT_EXPORT_FINISHED, &priv::on_export_finished, this);
         q->Bind(EVT_GLVIEWTOOLBAR_3D, [q](SimpleEvent&) { q->select_view_3D("3D"); });
         //BBS: set on_slice to false
-        q->Bind(EVT_GLVIEWTOOLBAR_PREVIEW, [q](SimpleEvent&) { q->select_view_3D("Preview", false); });
+        q->Bind(EVT_GLVIEWTOOLBAR_PREVIEW, [q](SimpleEvent&) {
+            if (q->is_view3D_shown()) {
+                if (q->has_sliceable_plate_for_slice_all()) {
+                    wxGetApp().mainframe->select_tab(size_t(MainFrame::tp3DEditor));
+                    wxPostEvent(q, SimpleEvent(EVT_GLTOOLBAR_SLICE_ALL));
+                    return;
+                }
+                if (q->is_plate_blocked_by_filament_temp_mixing(q->get_partplate_list().get_curr_plate_index())) {
+                    wxGetApp().mainframe->select_tab(size_t(MainFrame::tp3DEditor));
+                    q->sync_filament_temp_mixing_notification();
+                    return;
+                }
+            }
+            q->select_view_3D("Preview", false);
+        });
         q->Bind(EVT_GLTOOLBAR_SLICE_PLATE, &priv::on_action_slice_plate, this);
         q->Bind(EVT_GLTOOLBAR_SLICE_ALL, &priv::on_action_slice_all, this);
         q->Bind(EVT_GLTOOLBAR_PRINT_PLATE, &priv::on_action_print_plate, this);
@@ -11833,7 +11847,10 @@ unsigned int Plater::priv::update_background_process(bool force_validation, bool
                 notification_manager->set_all_slicing_errors_gray(true);
                 notification_manager->close_notification_of_type(NotificationType::ValidateError);
             }
-            if (invalidated != Print::APPLY_STATUS_UNCHANGED && background_processing_enabled())
+            else {
+                return_state |= UPDATE_BACKGROUND_PROCESS_INVALID;
+            }
+            if (filament_ok && invalidated != Print::APPLY_STATUS_UNCHANGED && background_processing_enabled())
                 return_state |= UPDATE_BACKGROUND_PROCESS_RESTART;
 
             if (printer_technology == ptFFF) {
@@ -13749,7 +13766,7 @@ void Plater::priv::on_action_slice_plate(SimpleEvent&)
         Model::setPrintSpeedTable(config, print_config);
         m_slice_all = false;
 
-        if (!q->confirm_filament_temp_mixing_before_slice())
+        if (!q->guard_before_slice_plate())
             return;
 
         q->reslice();
@@ -13771,7 +13788,7 @@ void Plater::priv::on_action_slice_all(SimpleEvent&)
         Model::setExtruderParams(config, numExtruders);
         Model::setPrintSpeedTable(config, print_config);
 
-        if (!q->confirm_filament_temp_mixing_before_slice_all())
+        if (!q->guard_before_slice_all())
             return;
 
         m_slice_all = true;
@@ -19409,6 +19426,18 @@ int Plater::start_next_slice()
     // Stop arrange and (or) optimize rotation tasks.
     //this->stop_jobs();
 
+    if (is_plate_blocked_by_filament_temp_mixing(p->partplate_list.get_curr_plate_index())) {
+        sync_filament_temp_mixing_notification();
+        if (p->m_slice_all) {
+            SlicingProcessCompletedEvent evt(EVT_PROCESS_COMPLETED, 0,
+                    SlicingProcessCompletedEvent::Finished, nullptr);
+            wxQueueEvent(this, evt.Clone());
+            return 0;
+        }
+        p->process_completed_with_error = p->partplate_list.get_curr_plate_index();
+        return -1;
+    }
+
     //FIXME Don't reslice if export of G-code or sending to OctoPrint is running.
     // bitmask of UpdateBackgroundProcessReturnState
     unsigned int state = this->p->update_background_process(true, false, false);
@@ -20355,6 +20384,17 @@ bool Plater::sync_filament_temp_mixing_notification()
     return slicing_allowed;
 }
 
+bool Plater::guard_before_slice_plate()
+{
+    sync_filament_temp_mixing_notification();
+    return confirm_filament_temp_mixing_before_slice();
+}
+
+bool Plater::guard_before_slice_all()
+{
+    return confirm_filament_temp_mixing_before_slice_all();
+}
+
 bool Plater::confirm_filament_temp_mixing_before_slice()
 {
     switch (get_filament_temp_mixing_state()) {
@@ -20380,7 +20420,9 @@ bool Plater::confirm_filament_temp_mixing_before_slice_all()
     bool has_allowed_warning = false;
     for (int plate_index = 0; plate_index < p->partplate_list.get_plate_count(); ++plate_index)
     {
-        if (get_filament_temp_mixing_state(plate_index) == FilamentTempMixingState::AllowedWarning)
+        PartPlate* plate = p->partplate_list.get_plate(plate_index);
+        if (plate != nullptr && plate->can_slice() &&
+            get_filament_temp_mixing_state(plate_index) == FilamentTempMixingState::AllowedWarning)
         {
             has_allowed_warning = true;
             break;
@@ -21135,6 +21177,8 @@ int Plater::select_plate(int plate_index, bool need_slice)
                         p->process_completed_with_error = -1;
                         p->m_slice_all = false;
                         reset_gcode_toolpaths();
+                        if (!guard_before_slice_plate())
+                            return ret;
                         reslice();
                     }
                     else {
@@ -21189,8 +21233,11 @@ int Plater::select_plate(int plate_index, bool need_slice)
                     //p->process_completed_with_error = -1;
                     p->m_slice_all = false;
                     reset_gcode_toolpaths();
-                    if (model_fits && !validate_err)
+                    if (model_fits && !validate_err) {
+                        if (!guard_before_slice_plate())
+                            return ret;
                         reslice();
+                    }
                     else {
                         p->main_frame->update_slice_print_status(MainFrame::eEventPlateUpdate, false);
                         //sometimes the previous print's sliced result is still valid, but the newly added object is laid over the boundary
@@ -21235,6 +21282,7 @@ int Plater::select_plate(int plate_index, bool need_slice)
 
     SimpleEvent event(EVT_GLCANVAS_PLATE_SELECT);
     p->on_plate_selected(event);
+    sync_filament_temp_mixing_notification();
     notify_filament_usage_changed();
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(" %1%: plate %2%, return %3%")%__LINE__ %plate_index %ret;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -203,12 +203,18 @@ namespace GUI {
 
 static std::string filament_temp_mixing_warning_text()
 {
-    return _u8L("Detected both high and low temperature materials. Mixed printing may result in extruder clogging, nozzle damage, or layer adhesion issues.");
+    return _u8L("Detected both high and low temperature materials. "
+                "Mixed printing may result in extruder clogging, "
+                "nozzle damage, or layer adhesion issues.");
 }
 
 static std::string filament_temp_mixing_error_text()
 {
-    return _u8L("Detected both high and low temperature materials. Mixed printing may result in extruder clogging, nozzle damage, or layer adhesion issues. To continue printing, enable \"Allow mixed printing of high and low temperature materials\" in Preferences.");
+    return _u8L("Detected both high and low temperature materials. "
+                "Mixed printing may result in extruder clogging, "
+                "nozzle damage, or layer adhesion issues. "
+                "To continue printing, enable \"Allow mixed printing "
+                "of high and low temperature materials\" in Preferences.");
 }
 
 static bool model_object_is_on_plate(PartPlate* plate, size_t obj_idx, const ModelObject* model_object)
@@ -13684,7 +13690,8 @@ void Plater::priv::on_process_completed(SlicingProcessCompletedEvent &evt)
     {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(":slicing all, plate %1% finished, start next slice...")%m_cur_slice_plate;
         m_cur_slice_plate = q->find_next_sliceable_plate_for_slice_all(m_cur_slice_plate + 1);
-        if (m_cur_slice_plate < 0) {
+        if (m_cur_slice_plate < 0)
+        {
             m_is_slicing = false;
             return;
         }
@@ -13797,7 +13804,8 @@ void Plater::priv::on_action_slice_all(SimpleEvent&)
         m_slice_all = true;
         m_slice_all_only_has_gcode = true;
         m_cur_slice_plate = q->find_next_sliceable_plate_for_slice_all(0);
-        if (m_cur_slice_plate < 0) {
+        if (m_cur_slice_plate < 0)
+        {
             m_slice_all = false;
             return;
         }
@@ -17258,16 +17266,19 @@ std::vector<size_t> Plater::load_files(const std::vector<fs::path>& input_files,
     //BBS: wish to reset all plates stats item selected state when load a new file
     p->preview->get_canvas3d()->reset_select_plate_toolbar_selection();
     std::vector<size_t> loaded = p->load_files(input_files, strategy, ask_multi);
-    if (!loaded.empty()) {
+    if (!loaded.empty())
+    {
         // After loading a project, initialize the filament temp mixing state
         // for ALL plates, not just the current one. This ensures each plate's
         // m_apply_invalid flag is correct so that "Slice All" mode correctly
         // detects which plates are sliceable.
         PartPlateList& plate_list = get_partplate_list();
-        for (int i = 0; i < plate_list.get_plate_count(); ++i) {
-            FilamentTempMixingState state = get_filament_temp_mixing_state(i);
+        for (int i = 0; i < plate_list.get_plate_count(); ++i)
+        {
+            const FilamentTempMixingState state = get_filament_temp_mixing_state(i);
             PartPlate* plate = plate_list.get_plate(i);
-            if (plate) {
+            if (plate)
+            {
                 plate->update_apply_result_invalid(
                     state == FilamentTempMixingState::BlockedError);
             }
@@ -19445,9 +19456,11 @@ int Plater::start_next_slice()
     // Stop arrange and (or) optimize rotation tasks.
     //this->stop_jobs();
 
-    if (is_plate_blocked_by_filament_temp_mixing(p->partplate_list.get_curr_plate_index())) {
+    if (is_plate_blocked_by_filament_temp_mixing(p->partplate_list.get_curr_plate_index()))
+    {
         sync_filament_temp_mixing_notification();
-        if (p->m_slice_all) {
+        if (p->m_slice_all)
+        {
             SlicingProcessCompletedEvent evt(EVT_PROCESS_COMPLETED, 0,
                     SlicingProcessCompletedEvent::Finished, nullptr);
             wxQueueEvent(this, evt.Clone());
@@ -20245,9 +20258,11 @@ bool Plater::check_filament_temp_mixing(int plate_index)
     PartPlate* plate = p->partplate_list.get_plate(plate_index);
 
     bool has_object_on_plate = false;
-    for (size_t obj_idx = 0; obj_idx < wxGetApp().model().objects.size(); ++obj_idx) {
+    for (size_t obj_idx = 0; obj_idx < wxGetApp().model().objects.size(); ++obj_idx)
+    {
         const ModelObject* model_object = wxGetApp().model().objects[obj_idx];
-        if (model_object_is_on_plate(plate, obj_idx, model_object)) {
+        if (model_object_is_on_plate(plate, obj_idx, model_object))
+        {
             has_object_on_plate = true;
             break;
         }
@@ -20263,16 +20278,19 @@ bool Plater::check_filament_temp_mixing(int plate_index)
     // current plate. Also track whether any object relies on the global
     // default extruder (extruder=0) so we can resolve it at the end.
     bool uses_default_extruder = false;
-    for (size_t obj_idx = 0; obj_idx < wxGetApp().model().objects.size(); ++obj_idx) {
+    for (size_t obj_idx = 0; obj_idx < wxGetApp().model().objects.size(); ++obj_idx)
+    {
         const ModelObject* model_object = wxGetApp().model().objects[obj_idx];
         if (!model_object_is_on_plate(plate, obj_idx, model_object))
             continue;
         collect_filament_slots_from_model_config(model_object->config, num_filaments, used_slots);
         if (model_object->config.extruder() == 0)
             uses_default_extruder = true;
-        for (const ModelVolume* model_volume : model_object->volumes) {
+        for (const ModelVolume* model_volume : model_object->volumes)
+        {
             collect_filament_slots_from_model_config(model_volume->config, num_filaments, used_slots);
-            for (int extruder_id : model_volume->get_extruders()) {
+            for (int extruder_id : model_volume->get_extruders())
+            {
                 if (extruder_id >= 1 && extruder_id <= num_filaments)
                     used_slots.insert(extruder_id - 1);
             }
@@ -20283,7 +20301,8 @@ bool Plater::check_filament_temp_mixing(int plate_index)
     // uses extruder=0. p->config does not include the "extruder" key
     // (it is not in the initializer list at priv constructor), so we
     // must read it from full_config() instead.
-    if (uses_default_extruder) {
+    if (uses_default_extruder)
+    {
         const ConfigOptionInt* extruder_opt = full_cfg.option<ConfigOptionInt>("extruder");
         if (extruder_opt != nullptr && extruder_opt->value >= 1 && extruder_opt->value <= num_filaments)
             used_slots.insert(extruder_opt->value - 1);
@@ -20299,11 +20318,14 @@ bool Plater::check_filament_temp_mixing(int plate_index)
     PresetBundle* bundle = wxGetApp().preset_bundle;
     bool has_high = false, has_low = false;
 
-    for (int slot : used_slots) {
-        if (slot < static_cast<int>(bundle->filament_presets.size())) {
+    for (int slot : used_slots)
+    {
+        if (slot < static_cast<int>(bundle->filament_presets.size()))
+        {
             const Preset* preset = bundle->filaments.find_preset(
                 bundle->filament_presets[slot], true);
-            if (preset != nullptr) {
+            if (preset != nullptr)
+            {
                 const bool is_high = preset->config.opt_bool("filament_is_high_temperature", 0);
                 if (is_high)
                     has_high = true;
@@ -20370,7 +20392,8 @@ bool Plater::sync_filament_temp_mixing_notification()
     const FilamentTempMixingState mixing_state = get_filament_temp_mixing_state(curr_plate_index);
     bool slicing_allowed = true;
 
-    switch (mixing_state) {
+    switch (mixing_state)
+    {
     case FilamentTempMixingState::Compatible:
         get_notification_manager()->close_validate_error_notification(filament_temp_mixing_error_text());
         get_notification_manager()->close_validate_warning_notification(filament_temp_mixing_warning_text());
@@ -20420,7 +20443,8 @@ bool Plater::guard_before_slice_all()
 
 bool Plater::confirm_filament_temp_mixing_before_slice()
 {
-    switch (get_filament_temp_mixing_state()) {
+    switch (get_filament_temp_mixing_state())
+    {
     case FilamentTempMixingState::Compatible:
         return true;
     case FilamentTempMixingState::BlockedError:
@@ -21260,12 +21284,14 @@ int Plater::select_plate(int plate_index, bool need_slice)
                     //p->process_completed_with_error = -1;
                     p->m_slice_all = false;
                     reset_gcode_toolpaths();
-                    if (model_fits && !validate_err) {
+                    if (model_fits && !validate_err)
+                    {
                         if (!guard_before_slice_plate())
                             return ret;
                         reslice();
                     }
-                    else {
+                    else
+                    {
                         p->main_frame->update_slice_print_status(MainFrame::eEventPlateUpdate, false);
                         //sometimes the previous print's sliced result is still valid, but the newly added object is laid over the boundary
                         //then the print toolpath will be shown, so we should not refresh print here, only onload shell

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -211,6 +211,72 @@ static std::string filament_temp_mixing_error_text()
     return _u8L("Detected both high and low temperature materials. Mixed printing may result in extruder clogging, nozzle damage, or layer adhesion issues. To continue printing, enable \"Allow mixed printing of high and low temperature materials\" in Preferences.");
 }
 
+static bool model_object_is_on_plate(PartPlate* plate, size_t obj_idx, const ModelObject* model_object)
+{
+    if (model_object == nullptr)
+        return false;
+
+    if (plate == nullptr)
+        return true;
+
+    const int object_index = static_cast<int>(obj_idx);
+    const int instance_count = static_cast<int>(model_object->instances.size());
+    for (int instance_index = 0; instance_index < instance_count; ++instance_index)
+    {
+        if (plate->contain_instance(object_index, instance_index))
+            return true;
+    }
+
+    return false;
+}
+
+static void collect_filament_slots_from_config(
+    const DynamicPrintConfig& config,
+    int num_filaments,
+    std::set<int>& used_slots)
+{
+    static const std::vector<const char*> keys_1based = {
+        "wall_filament",
+        "sparse_infill_filament",
+        "solid_infill_filament"
+    };
+    for (const char* key : keys_1based)
+    {
+        const ConfigOptionInt* option = config.option<ConfigOptionInt>(key);
+        if (option != nullptr && option->value >= 1 && option->value <= num_filaments)
+            used_slots.insert(option->value - 1);
+    }
+
+    static const std::vector<const char*> keys_0based = {
+        "support_filament",
+        "support_interface_filament",
+        "wipe_tower_filament"
+    };
+    for (const char* key : keys_0based)
+    {
+        const ConfigOptionInt* option = config.option<ConfigOptionInt>(key);
+        if (option != nullptr && option->value >= 1 && option->value <= num_filaments)
+            used_slots.insert(option->value - 1);
+    }
+
+    const ConfigOptionInt* extruder_option = config.option<ConfigOptionInt>("extruder");
+    if (extruder_option != nullptr && extruder_option->value >= 1 && extruder_option->value <= num_filaments)
+        used_slots.insert(extruder_option->value - 1);
+}
+
+static void collect_filament_slots_from_model_config(
+    const ModelConfigObject& config,
+    int num_filaments,
+    std::set<int>& used_slots)
+{
+    if (!config.has("extruder"))
+        return;
+
+    const int extruder_id = config.extruder();
+    if (extruder_id >= 1 && extruder_id <= num_filaments)
+        used_slots.insert(extruder_id - 1);
+}
+
 wxDEFINE_EVENT(EVT_SCHEDULE_BACKGROUND_PROCESS,     SimpleEvent);
 wxDEFINE_EVENT(EVT_SLICING_UPDATE,                  SlicingStatusEvent);
 wxDEFINE_EVENT(EVT_SLICING_COMPLETED,               wxCommandEvent);
@@ -8420,6 +8486,9 @@ struct Plater::priv
     Plater *q;
     MainFrame *main_frame;
     bool filament_usage_sync_pending = false;
+    bool filament_temp_mixing_notification_initialized = false;
+    int filament_temp_mixing_notification_plate = -1;
+    FilamentTempMixingState filament_temp_mixing_notification_state = FilamentTempMixingState::Compatible;
 
     MenuFactory menus;
 
@@ -13594,7 +13663,11 @@ void Plater::priv::on_process_completed(SlicingProcessCompletedEvent &evt)
     else
     {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(":slicing all, plate %1% finished, start next slice...")%m_cur_slice_plate;
-        m_cur_slice_plate++;
+        m_cur_slice_plate = q->find_next_sliceable_plate_for_slice_all(m_cur_slice_plate + 1);
+        if (m_cur_slice_plate < 0) {
+            m_is_slicing = false;
+            return;
+        }
 
         q->Freeze();
         q->select_plate(m_cur_slice_plate);
@@ -13698,12 +13771,16 @@ void Plater::priv::on_action_slice_all(SimpleEvent&)
         Model::setExtruderParams(config, numExtruders);
         Model::setPrintSpeedTable(config, print_config);
 
-        if (!q->confirm_filament_temp_mixing_before_slice())
+        if (!q->confirm_filament_temp_mixing_before_slice_all())
             return;
 
         m_slice_all = true;
         m_slice_all_only_has_gcode = true;
-        m_cur_slice_plate = 0;
+        m_cur_slice_plate = q->find_next_sliceable_plate_for_slice_all(0);
+        if (m_cur_slice_plate < 0) {
+            m_slice_all = false;
+            return;
+        }
         //select plate
         q->select_plate(m_cur_slice_plate);
         q->reslice();
@@ -20103,69 +20180,52 @@ void Plater::config_change_notification(const DynamicPrintConfig &config, const 
     // notification for more options
 }
 
-bool Plater::check_filament_temp_mixing()
+bool Plater::check_filament_temp_mixing(int plate_index)
 {
-    const DynamicPrintConfig& full_cfg = wxGetApp().preset_bundle->full_config();
-    auto* ft_opt = full_cfg.option<ConfigOptionStrings>("filament_type");
-    if (!ft_opt || ft_opt->values.empty())
+    const int plate_count = p->partplate_list.get_plate_count();
+    if (plate_index < 0 || plate_index >= plate_count)
         return true;
 
-    int num_filaments = (int)ft_opt->values.size();
+    const DynamicPrintConfig& full_cfg = wxGetApp().preset_bundle->full_config();
+    const ConfigOptionStrings* filament_type_option = full_cfg.option<ConfigOptionStrings>("filament_type");
+    if (filament_type_option == nullptr || filament_type_option->values.empty())
+        return true;
+
+    const int num_filaments = static_cast<int>(filament_type_option->values.size());
     std::set<int> used_slots;
 
-    PartPlate* curr_plate = p->partplate_list.get_curr_plate();
-    auto object_is_on_curr_plate = [curr_plate](size_t obj_idx, const ModelObject* mo) {
-        if (!curr_plate)
-            return true;
-        for (int inst_idx = 0; inst_idx < (int)mo->instances.size(); ++inst_idx) {
-            if (curr_plate->contain_instance((int)obj_idx, inst_idx))
-                return true;
-        }
-        return false;
-    };
+    PartPlate* plate = p->partplate_list.get_plate(plate_index);
 
-    bool has_object_on_curr_plate = false;
+    bool has_object_on_plate = false;
     for (size_t obj_idx = 0; obj_idx < wxGetApp().model().objects.size(); ++obj_idx) {
-        if (object_is_on_curr_plate(obj_idx, wxGetApp().model().objects[obj_idx])) {
-            has_object_on_curr_plate = true;
+        const ModelObject* model_object = wxGetApp().model().objects[obj_idx];
+        if (model_object_is_on_plate(plate, obj_idx, model_object)) {
+            has_object_on_plate = true;
             break;
         }
     }
-    if (!has_object_on_curr_plate)
+    if (!has_object_on_plate)
         return true;
-
-    auto collect_from_cfg = [&](const DynamicPrintConfig& cfg) {
-        static const char* keys_1based[] = {"wall_filament", "solid_infill_filament"};
-        for (auto key : keys_1based) {
-            auto* opt = cfg.option<ConfigOptionInt>(key);
-            if (opt && opt->value >= 1 && opt->value <= num_filaments)
-                used_slots.insert(opt->value - 1);
-        }
-        static const char* keys_0based[] = {"support_filament", "support_interface_filament", "wipe_tower_filament"};
-        for (auto key : keys_0based) {
-            auto* opt = cfg.option<ConfigOptionInt>(key);
-            if (opt && opt->value >= 1 && opt->value <= num_filaments)
-                used_slots.insert(opt->value - 1);
-        }
-    };
 
     // Collect from the Plater's working config for global Process settings.
     // Defaults are 0 (skipped by the >= 1 check).
-    collect_from_cfg(*this->config());
+    collect_filament_slots_from_config(*this->config(), num_filaments, used_slots);
 
     // Also collect from current plate's config for any plate-level overrides
-    if (curr_plate)
-        collect_from_cfg(*curr_plate->config());
+    if (plate)
+        collect_filament_slots_from_config(*plate->config(), num_filaments, used_slots);
 
     // Collect from ModelVolume painting extruders for objects on the current plate
     for (size_t obj_idx = 0; obj_idx < wxGetApp().model().objects.size(); ++obj_idx) {
-        const ModelObject* mo = wxGetApp().model().objects[obj_idx];
-        if (!object_is_on_curr_plate(obj_idx, mo))
+        const ModelObject* model_object = wxGetApp().model().objects[obj_idx];
+        if (!model_object_is_on_plate(plate, obj_idx, model_object))
             continue;
-        for (const ModelVolume* mv : mo->volumes) {
-            for (int eid : mv->get_extruders()) {
-                if (eid >= 1 && eid <= num_filaments)
-                    used_slots.insert(eid - 1);
+        collect_filament_slots_from_model_config(model_object->config, num_filaments, used_slots);
+        for (const ModelVolume* model_volume : model_object->volumes) {
+            collect_filament_slots_from_model_config(model_volume->config, num_filaments, used_slots);
+            for (int extruder_id : model_volume->get_extruders()) {
+                if (extruder_id >= 1 && extruder_id <= num_filaments)
+                    used_slots.insert(extruder_id - 1);
             }
         }
     }
@@ -20181,11 +20241,11 @@ bool Plater::check_filament_temp_mixing()
     bool has_high = false, has_low = false;
 
     for (int slot : used_slots) {
-        if (slot < (int)bundle->filament_presets.size()) {
+        if (slot < static_cast<int>(bundle->filament_presets.size())) {
             const Preset* preset = bundle->filaments.find_preset(
                 bundle->filament_presets[slot], true);
-            if (preset) {
-                bool is_high = preset->config.opt_bool("filament_is_high_temperature", 0);
+            if (preset != nullptr) {
+                const bool is_high = preset->config.opt_bool("filament_is_high_temperature", 0);
                 if (is_high)
                     has_high = true;
                 else
@@ -20193,14 +20253,19 @@ bool Plater::check_filament_temp_mixing()
             }
         }
     }
-    bool compatible = !(has_high && has_low);
+    const bool compatible = !(has_high && has_low);
 
     return compatible;
 }
 
-Plater::FilamentTempMixingState Plater::get_filament_temp_mixing_state()
+bool Plater::check_filament_temp_mixing()
 {
-    if (check_filament_temp_mixing())
+    return check_filament_temp_mixing(p->partplate_list.get_curr_plate_index());
+}
+
+Plater::FilamentTempMixingState Plater::get_filament_temp_mixing_state(int plate_index)
+{
+    if (check_filament_temp_mixing(plate_index))
         return FilamentTempMixingState::Compatible;
 
     return wxGetApp().app_config->get_bool("allow_filament_temp_mixing") ?
@@ -20208,42 +20273,125 @@ Plater::FilamentTempMixingState Plater::get_filament_temp_mixing_state()
         FilamentTempMixingState::BlockedError;
 }
 
+Plater::FilamentTempMixingState Plater::get_filament_temp_mixing_state()
+{
+    return get_filament_temp_mixing_state(p->partplate_list.get_curr_plate_index());
+}
+
+bool Plater::is_plate_blocked_by_filament_temp_mixing(int plate_index)
+{
+    return get_filament_temp_mixing_state(plate_index) == FilamentTempMixingState::BlockedError;
+}
+
+bool Plater::has_sliceable_plate_for_slice_all()
+{
+    return find_next_sliceable_plate_for_slice_all(0) >= 0;
+}
+
+int Plater::find_next_sliceable_plate_for_slice_all(int start_plate_index)
+{
+    const int plate_count = p->partplate_list.get_plate_count();
+    if (start_plate_index < 0)
+        start_plate_index = 0;
+
+    for (int plate_index = start_plate_index; plate_index < plate_count; ++plate_index)
+    {
+        PartPlate* plate = p->partplate_list.get_plate(plate_index);
+        if (plate != nullptr && plate->can_slice() && !is_plate_blocked_by_filament_temp_mixing(plate_index))
+            return plate_index;
+    }
+
+    return -1;
+}
+
 bool Plater::sync_filament_temp_mixing_notification()
 {
-    switch (get_filament_temp_mixing_state()) {
+    const int curr_plate_index = get_partplate_list().get_curr_plate_index();
+    PartPlate* curr_plate = get_partplate_list().get_curr_plate();
+    const FilamentTempMixingState mixing_state = get_filament_temp_mixing_state(curr_plate_index);
+    const bool notification_state_changed =
+        !p->filament_temp_mixing_notification_initialized ||
+        p->filament_temp_mixing_notification_plate != curr_plate_index ||
+        p->filament_temp_mixing_notification_state != mixing_state;
+    bool slicing_allowed = true;
+
+    switch (mixing_state) {
     case FilamentTempMixingState::Compatible:
         get_notification_manager()->close_validate_error_notification(filament_temp_mixing_error_text());
         get_notification_manager()->close_validate_warning_notification(filament_temp_mixing_warning_text());
         get_partplate_list().get_curr_plate()->update_apply_result_invalid(false);
-        return true;
+        slicing_allowed = true;
+        break;
     case FilamentTempMixingState::AllowedWarning:
         get_notification_manager()->close_validate_error_notification(filament_temp_mixing_error_text());
         get_partplate_list().get_curr_plate()->update_apply_result_invalid(false);
-        get_notification_manager()->push_notification(
-            NotificationType::ValidateWarning,
-            NotificationManager::NotificationLevel::WarningNotificationLevel,
-            _u8L("WARNING:") + "\n" + filament_temp_mixing_warning_text());
-        return true;
+        if (notification_state_changed) {
+            get_notification_manager()->push_notification(
+                NotificationType::ValidateWarning,
+                NotificationManager::NotificationLevel::WarningNotificationLevel,
+                _u8L("WARNING:") + "\n" + filament_temp_mixing_warning_text());
+        }
+        slicing_allowed = true;
+        break;
     case FilamentTempMixingState::BlockedError: {
         StringObjectException err;
         err.type   = STRING_EXCEPT_FILAMENTS_DIFFERENT_TEMP;
         err.string = filament_temp_mixing_error_text();
         get_notification_manager()->close_validate_warning_notification(filament_temp_mixing_warning_text());
-        get_notification_manager()->push_validate_error_notification(err);
+        if (notification_state_changed)
+            get_notification_manager()->push_validate_error_notification(err);
         get_partplate_list().get_curr_plate()->update_apply_result_invalid(true);
-        return false;
+        slicing_allowed = false;
+        break;
     }
     }
 
-    return true;
+    p->filament_temp_mixing_notification_initialized = true;
+    p->filament_temp_mixing_notification_plate = curr_plate_index;
+    p->filament_temp_mixing_notification_state = mixing_state;
+
+    const bool can_slice = curr_plate != nullptr && curr_plate->can_slice() && slicing_allowed;
+    p->main_frame->update_slice_print_status(MainFrame::eEventPlateUpdate, can_slice);
+    return slicing_allowed;
 }
 
 bool Plater::confirm_filament_temp_mixing_before_slice()
 {
-    if (get_filament_temp_mixing_state() != FilamentTempMixingState::AllowedWarning)
+    switch (get_filament_temp_mixing_state()) {
+    case FilamentTempMixingState::Compatible:
+        return true;
+    case FilamentTempMixingState::BlockedError:
+        sync_filament_temp_mixing_notification();
+        return false;
+    case FilamentTempMixingState::AllowedWarning:
+        break;
+    }
+
+    wxMessageDialog dlg(this, _L("This material combination may cause risks. Do you want to continue?"),
+                        _L("Confirm"), wxYES_NO | wxICON_WARNING);
+    return dlg.ShowModal() == wxID_YES;
+}
+
+bool Plater::confirm_filament_temp_mixing_before_slice_all()
+{
+    if (!has_sliceable_plate_for_slice_all())
+        return false;
+
+    bool has_allowed_warning = false;
+    for (int plate_index = 0; plate_index < p->partplate_list.get_plate_count(); ++plate_index)
+    {
+        if (get_filament_temp_mixing_state(plate_index) == FilamentTempMixingState::AllowedWarning)
+        {
+            has_allowed_warning = true;
+            break;
+        }
+    }
+
+    if (!has_allowed_warning)
         return true;
 
-    wxMessageDialog dlg(this, _L("该组合可能导致风险，是否继续"), _L("确认"), wxYES_NO | wxICON_WARNING);
+    wxMessageDialog dlg(this, _L("This material combination may cause risks. Do you want to continue?"),
+                        _L("Confirm"), wxYES_NO | wxICON_WARNING);
     return dlg.ShowModal() == wxID_YES;
 }
 
@@ -21087,6 +21235,7 @@ int Plater::select_plate(int plate_index, bool need_slice)
 
     SimpleEvent event(EVT_GLCANVAS_PLATE_SELECT);
     p->on_plate_selected(event);
+    notify_filament_usage_changed();
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(" %1%: plate %2%, return %3%")%__LINE__ %plate_index %ret;
     return ret;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8523,6 +8523,7 @@ struct Plater::priv
     PartPlateList partplate_list;
     //BBS: add a flag to ignore cancel event
     bool m_ignore_event{false};
+    bool m_in_select_view_3D{false};
     bool m_slice_all{false};
     bool m_is_slicing {false};
     bool m_is_publishing {false};
@@ -9703,12 +9704,17 @@ void Plater::priv::apply_free_camera_correction(bool apply/* = true*/)
 //BBS: add no slice option
 void Plater::priv::select_view_3D(const std::string& name, bool no_slice)
 {
+    if (m_in_select_view_3D)
+        return;
+    m_in_select_view_3D = true;
+
     if (name == "3D") {
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << __LINE__ << "select view3D";
         if (q->only_gcode_mode() || q->using_exported_file()) {
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format("goto preview page when loading gcode/exported_3mf");
         }
         set_current_panel(view3D, no_slice);
+        wxGetApp().mainframe->select_tab(size_t(MainFrame::tp3DEditor));
     }
     else if (name == "Preview") {
         BOOST_LOG_TRIVIAL(info) << "select preview";
@@ -9721,10 +9727,12 @@ void Plater::priv::select_view_3D(const std::string& name, bool no_slice)
         Model::setExtruderParams(config, numExtruders);
         Model::setPrintSpeedTable(config, print_config);
         set_current_panel(preview, no_slice);
+        wxGetApp().mainframe->select_tab(size_t(MainFrame::tpPreview));
     }
     else if (name == "Assemble") {
         BOOST_LOG_TRIVIAL(info) << "select assemble view";
         set_current_panel(assemble_view, no_slice);
+        wxGetApp().mainframe->select_tab(size_t(MainFrame::tp3DEditor));
     }
 
     //BBS update selection
@@ -9732,6 +9740,7 @@ void Plater::priv::select_view_3D(const std::string& name, bool no_slice)
     selection_changed();
 
     apply_free_camera_correction(false);
+    m_in_select_view_3D = false;
 }
 
 void Plater::priv::select_next_view_3D()

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -264,19 +264,6 @@ static void collect_filament_slots_from_config(
         used_slots.insert(extruder_option->value - 1);
 }
 
-static void collect_filament_slots_from_model_config(
-    const ModelConfigObject& config,
-    int num_filaments,
-    std::set<int>& used_slots)
-{
-    if (!config.has("extruder"))
-        return;
-
-    const int extruder_id = config.extruder();
-    if (extruder_id >= 1 && extruder_id <= num_filaments)
-        used_slots.insert(extruder_id - 1);
-}
-
 wxDEFINE_EVENT(EVT_SCHEDULE_BACKGROUND_PROCESS,     SimpleEvent);
 wxDEFINE_EVENT(EVT_SLICING_UPDATE,                  SlicingStatusEvent);
 wxDEFINE_EVENT(EVT_SLICING_COMPLETED,               wxCommandEvent);
@@ -20245,27 +20232,44 @@ bool Plater::check_filament_temp_mixing(int plate_index)
     if (!has_object_on_plate)
         return true;
 
-    // Collect from the Plater's working config for global Process settings.
-    // Defaults are 0 (skipped by the >= 1 check).
-    collect_filament_slots_from_config(*this->config(), num_filaments, used_slots);
-
     // Also collect from current plate's config for any plate-level overrides
     if (plate)
         collect_filament_slots_from_config(*plate->config(), num_filaments, used_slots);
 
-    // Collect from ModelVolume painting extruders for objects on the current plate
+    // Collect from ModelVolume painting extruders and object configs for
+    // objects on the current plate. Track whether any object relies on the
+    // global default extruder so we can resolve it at the end.
+    bool uses_default_extruder = false;
     for (size_t obj_idx = 0; obj_idx < wxGetApp().model().objects.size(); ++obj_idx) {
         const ModelObject* model_object = wxGetApp().model().objects[obj_idx];
         if (!model_object_is_on_plate(plate, obj_idx, model_object))
             continue;
-        collect_filament_slots_from_model_config(model_object->config, num_filaments, used_slots);
+
+        const int obj_extruder = model_object->config.extruder();
+        if (obj_extruder >= 1 && obj_extruder <= num_filaments)
+            used_slots.insert(obj_extruder - 1);
+        else if (obj_extruder == 0)
+            uses_default_extruder = true;
+
         for (const ModelVolume* model_volume : model_object->volumes) {
-            collect_filament_slots_from_model_config(model_volume->config, num_filaments, used_slots);
+            if (model_volume->config.has("extruder")) {
+                const int vol_extruder = model_volume->config.extruder();
+                if (vol_extruder >= 1 && vol_extruder <= num_filaments)
+                    used_slots.insert(vol_extruder - 1);
+            }
             for (int extruder_id : model_volume->get_extruders()) {
                 if (extruder_id >= 1 && extruder_id <= num_filaments)
                     used_slots.insert(extruder_id - 1);
             }
         }
+    }
+
+    // Resolve the global default extruder if any object on this plate
+    // uses extruder=0 (meaning "inherit from global config").
+    if (uses_default_extruder) {
+        const ConfigOptionInt* extruder_opt = full_cfg.option<ConfigOptionInt>("extruder");
+        if (extruder_opt != nullptr && extruder_opt->value >= 1 && extruder_opt->value <= num_filaments)
+            used_slots.insert(extruder_opt->value - 1);
     }
 
     if (used_slots.empty())

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -20525,11 +20525,14 @@ bool Plater::confirm_filament_temp_mixing_before_slice_all()
     if (!has_sliceable_plate_for_slice_all())
         return false;
 
+    // Only count plates that can be sliced AND haven't been sliced
+    // yet. Already-sliced plates don't need re-confirmation.
     bool has_allowed_warning = false;
     for (int plate_index = 0; plate_index < p->partplate_list.get_plate_count(); ++plate_index)
     {
         PartPlate* plate = p->partplate_list.get_plate(plate_index);
         if (plate != nullptr && plate->can_slice() &&
+            !plate->is_slice_result_valid() &&
             get_filament_temp_mixing_state(plate_index) == FilamentTempMixingState::AllowedWarning)
         {
             has_allowed_warning = true;

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -513,14 +513,38 @@ public:
     bool update_filament_colors_in_full_config();
     void config_change_notification(const DynamicPrintConfig &config, const std::string& key);
     void on_config_change(const DynamicPrintConfig &config);
-    /// Check whether high-temperature and low-temperature filaments are mixed on the current plate.
-    /// Returns true if compatible (no mixing), false if mixing is detected and error notification is shown.
+    /// @brief Check whether high-temperature and low-temperature filaments are mixed on the current plate.
+    /// @return True if compatible; false if high/low temperature materials are mixed.
     bool check_filament_temp_mixing();
+    /// @brief Check whether high-temperature and low-temperature filaments are mixed on a specific plate.
+    /// @param plate_index Plate index to check.
+    /// @return True if compatible or plate index is invalid; false if high/low temperature materials are mixed.
+    bool check_filament_temp_mixing(int plate_index);
+    /// @brief Get high/low temperature material mixing state for the current plate.
+    /// @return Current plate material mixing state.
     FilamentTempMixingState get_filament_temp_mixing_state();
+    /// @brief Get high/low temperature material mixing state for a specific plate.
+    /// @param plate_index Plate index to check.
+    /// @return Plate material mixing state.
+    FilamentTempMixingState get_filament_temp_mixing_state(int plate_index);
+    /// @brief Check whether a specific plate is blocked by high/low temperature material mixing.
+    /// @param plate_index Plate index to check.
+    /// @return True if slicing this plate is blocked; otherwise false.
+    bool is_plate_blocked_by_filament_temp_mixing(int plate_index);
+    /// @brief Check whether slice-all has at least one plate that can be sliced.
+    /// @return True if any plate can be sliced and is not blocked by material mixing.
+    bool has_sliceable_plate_for_slice_all();
+    /// @brief Find the next plate that can be sliced by slice-all.
+    /// @param start_plate_index First plate index to check.
+    /// @return Plate index if found; otherwise -1.
+    int find_next_sliceable_plate_for_slice_all(int start_plate_index);
     /// Sync notification state with current filament temp mixing status.
     /// Returns true if slicing is allowed, false if high/low temperature mixing blocks slicing.
     bool sync_filament_temp_mixing_notification();
     bool confirm_filament_temp_mixing_before_slice();
+    /// @brief Confirm warning-level high/low temperature material mixing before slicing all plates.
+    /// @return True if slice-all can continue; otherwise false.
+    bool confirm_filament_temp_mixing_before_slice_all();
     /// Queue a single UI sync after filament preset/assignment/plate usage changes.
     void notify_filament_usage_changed();
     void force_filament_colors_update();

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -232,7 +232,8 @@ class Plater: public wxPanel
 {
 public:
     using fs_path = boost::filesystem::path;
-    enum class FilamentTempMixingState {
+    enum class FilamentTempMixingState
+    {
         Compatible,
         AllowedWarning,
         BlockedError
@@ -541,8 +542,12 @@ public:
     /// Sync notification state with current filament temp mixing status.
     /// Returns true if slicing is allowed, false if high/low temperature mixing blocks slicing.
     bool sync_filament_temp_mixing_notification();
+    /// Check and guard filament temp mixing before slicing current plate.
     bool guard_before_slice_plate();
+    /// Check and guard filament temp mixing before slicing all plates.
     bool guard_before_slice_all();
+    /// @brief Show confirmation dialog for allowed high/low temperature mixing before slice.
+    /// @return True if slicing can proceed; false if blocked or user cancelled.
     bool confirm_filament_temp_mixing_before_slice();
     /// @brief Confirm warning-level high/low temperature material mixing before slicing all plates.
     /// @return True if slice-all can continue; otherwise false.

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -541,6 +541,8 @@ public:
     /// Sync notification state with current filament temp mixing status.
     /// Returns true if slicing is allowed, false if high/low temperature mixing blocks slicing.
     bool sync_filament_temp_mixing_notification();
+    bool guard_before_slice_plate();
+    bool guard_before_slice_all();
     bool confirm_filament_temp_mixing_before_slice();
     /// @brief Confirm warning-level high/low temperature material mixing before slicing all plates.
     /// @return True if slice-all can continue; otherwise false.

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -104,6 +104,7 @@ wxDECLARE_EVENT(EVT_GLCANVAS_COLOR_MODE_CHANGED,   SimpleEvent);
 wxDECLARE_EVENT(EVT_PRINT_FROM_SDCARD_VIEW,   SimpleEvent);
 wxDECLARE_EVENT(EVT_CREATE_FILAMENT, SimpleEvent);
 wxDECLARE_EVENT(EVT_MODIFY_FILAMENT, SimpleEvent);
+wxDECLARE_EVENT(EVT_FILAMENT_USAGE_CHANGED, SimpleEvent);
 wxDECLARE_EVENT(EVT_ADD_FILAMENT, SimpleEvent);
 wxDECLARE_EVENT(EVT_DEL_FILAMENT, SimpleEvent);
 using ColorEvent = Event<wxColour>;
@@ -231,6 +232,11 @@ class Plater: public wxPanel
 {
 public:
     using fs_path = boost::filesystem::path;
+    enum class FilamentTempMixingState {
+        Compatible,
+        AllowedWarning,
+        BlockedError
+    };
 
     Plater(wxWindow *parent, MainFrame *main_frame);
     Plater(Plater &&) = delete;
@@ -510,9 +516,13 @@ public:
     /// Check whether high-temperature and low-temperature filaments are mixed on the current plate.
     /// Returns true if compatible (no mixing), false if mixing is detected and error notification is shown.
     bool check_filament_temp_mixing();
+    FilamentTempMixingState get_filament_temp_mixing_state();
     /// Sync notification state with current filament temp mixing status.
-    /// Returns true if compatible (no mixing), false if mixing detected.
+    /// Returns true if slicing is allowed, false if high/low temperature mixing blocks slicing.
     bool sync_filament_temp_mixing_notification();
+    bool confirm_filament_temp_mixing_before_slice();
+    /// Queue a single UI sync after filament preset/assignment/plate usage changes.
+    void notify_filament_usage_changed();
     void force_filament_colors_update();
     void force_print_bed_update();
     // On activating the parent window.

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -762,6 +762,9 @@ wxBoxSizer *PreferencesDialog::create_item_checkbox(wxString title, wxWindow *pa
         app_config->set_bool(param, checkbox->GetValue());
         app_config->save();
 
+        if (param == "allow_filament_temp_mixing" && wxGetApp().plater())
+            wxGetApp().plater()->notify_filament_usage_changed();
+
         if (param == PRIVACY_POLICY_FLAGS)
             {
             app_config->set("app", PRIVACY_POLICY_FLAGS, checkbox->GetValue());            

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3110,8 +3110,7 @@ void TabPrintModel::on_value_change(const std::string& opt_key, const boost::any
     }
     wxGetApp().params_panel()->notify_object_config_changed();
 
-    // Real-time high/low temperature filament mixing check after object-level config change
-    wxGetApp().plater()->sync_filament_temp_mixing_notification();
+    wxGetApp().plater()->notify_filament_usage_changed();
 }
 
 void TabPrintModel::reload_config()


### PR DESCRIPTION
## Summary

- **Filament temperature mixing**: per-plate detection using per-object feature keys, conditional global key collection, CLI-only guard, unified confirm dialog with translations, tab sync fixes, pre-slice confirmation
- **Slice-all flow**: skip already-sliced plates in confirmation dialog to avoid redundant slicing
- **wxWidgets encoding**: fix `wxEntry` encoding mismatch on Windows when the exe path contains non-ASCII characters by rebuilding `argv[0]` from `GetModuleFileNameW` with proper CP_ACP conversion

## Test plan

- [ ] Slice a multi-plate project with mixed high/low temp filaments — confirm dialog appears per-plate
- [ ] Verify slice-all skips already-sliced plates
- [ ] Run OrcaSlicer from a path containing non-ASCII characters (e.g., Chinese) — no wxWidgets encoding warnings

## doc
https://snapmaker.feishu.cn/wiki/SXWswuS1LiOI2kkkALucrb46nNc?table=tbl9bj4JG7Qaw1vq&view=vewGEOSfWK

🤖 Generated with [Claude Code](https://claude.com/claude-code)