### PR TITLE
fix: prevent crashes during GLCanvas3D destruction and plate deletion

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -1203,7 +1203,7 @@ GLCanvas3D::GLCanvas3D(wxGLCanvas* canvas, Bed3D &bed)
 
 GLCanvas3D::~GLCanvas3D()
 {
-    reset_volumes();
+    reset_volumes(ResetVolumesMode::CanvasDestruction);
 
     m_sel_plate_toolbar.del_all_item();
     m_sel_plate_toolbar.del_stats_item();
@@ -1340,7 +1340,7 @@ unsigned int GLCanvas3D::get_volumes_count() const
     return (unsigned int)m_volumes.volumes.size();
 }
 
-void GLCanvas3D::reset_volumes()
+void GLCanvas3D::reset_volumes(ResetVolumesMode mode)
 {
     if (!m_initialized)
         return;
@@ -1350,9 +1350,12 @@ void GLCanvas3D::reset_volumes()
 
     _set_current();
 
-    m_selection.clear();
+    m_selection.clear(mode == ResetVolumesMode::Normal);
     m_volumes.clear();
     m_dirty = true;
+
+    if (mode == ResetVolumesMode::CanvasDestruction)
+        return;
 
     auto pLater = wxGetApp().plater();
     if (pLater) {
@@ -1541,7 +1544,7 @@ void GLCanvas3D::set_config(const DynamicPrintConfig* config)
     // Orca: Filament shrinkage compensation
     const Print *print = fff_print();
     if (print != nullptr)
-        m_layers_editing.set_shrinkage_compensation(fff_print()->shrinkage_compensation());
+        m_layers_editing.set_shrinkage_compensation(print->shrinkage_compensation());
 }
 
 void GLCanvas3D::set_process(BackgroundSlicingProcess *process)

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -754,7 +754,11 @@ public:
 
     unsigned int get_volumes_count() const;
     const GLVolumeCollection& get_volumes() const { return m_volumes; }
-    void reset_volumes();
+    enum class ResetVolumesMode {
+        Normal,
+        CanvasDestruction
+    };
+    void reset_volumes(ResetVolumesMode mode = ResetVolumesMode::Normal);
     ModelInstanceEPrintVolumeState check_volumes_outside_state() const;
     bool is_all_plates_selected() { return m_sel_plate_toolbar.m_all_plates_stats_item && m_sel_plate_toolbar.m_all_plates_stats_item->selected; }
     const float get_scale() const;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -21259,6 +21259,11 @@ int Plater::delete_plate(int plate_index)
         index = p->partplate_list.get_curr_plate_index();
 
     take_snapshot("delete partplate");
+
+    // CRASH FIX: Clear fff_print reference before PartPlateList::delete_plate destroys the Print,
+    // preventing dangling pointer access during subsequent update calls.
+    p->background_process.set_fff_print(nullptr);
+
     ret = p->partplate_list.delete_plate(index);
 
     //BBS: update the current print to the current plate


### PR DESCRIPTION
Cherry-pick crash fixes from PRs #467 and #475:

1. GLCanvas3D (#467):
   - Add ResetVolumesMode enum (Normal / CanvasDestruction)
   - Use CanvasDestruction mode in ~GLCanvas3D() to skip Plater/UI callbacks during destruction
   - Reuse local `print` variable in set_config()

2. Plater (#475):
   - Clear background_process.fff_print before delete_plate destroys the Print, preventing dangling pointer access