### PR TITLE
fix: add notify_sidebar parameter to Selection::clear() for GLCanvas3…

### DIFF
--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -638,7 +638,7 @@ void Selection::set_deserialized(EMode mode, const std::vector<std::pair<size_t,
     set_bounding_boxes_dirty();
 }
 
-void Selection::clear()
+void Selection::clear(bool notify_sidebar)
 {
     if (!m_valid)
         return;
@@ -682,7 +682,8 @@ void Selection::clear()
 #endif
 
     // #et_FIXME fake KillFocus from sidebar
-    wxGetApp().plater()->canvas3D()->handle_sidebar_focus_event("", false);
+    if (notify_sidebar)
+        wxGetApp().plater()->canvas3D()->handle_sidebar_focus_event("", false);
 }
 
 // Update the selection based on the new instance IDs.

--- a/src/slic3r/GUI/Selection.hpp
+++ b/src/slic3r/GUI/Selection.hpp
@@ -249,7 +249,7 @@ public:
     // Update the selection based on the map from old indices to new indices after m_volumes changed.
     // If the current selection is by instance, this call may select newly added volumes, if they belong to already selected instances.
     void volumes_changed(const std::vector<size_t> &map_volume_old_to_new);
-    void clear();
+    void clear(bool notify_sidebar = true);
 
     bool is_empty() const { return m_type == Empty; }
     bool is_wipe_tower() const { return m_type == WipeTower; }


### PR DESCRIPTION
When GLCanvas3D is being destroyed (CanvasDestruction mode), Selection::clear(false) skips the sidebar focus event notification to avoid accessing Plater after its private state has been freed.
