### PR TITLE
fix: resolve app freeze and optimize texture compression to reduce GUI lag

### DIFF
--- a/src/slic3r/GUI/GLTexture.cpp
+++ b/src/slic3r/GUI/GLTexture.cpp
@@ -534,9 +534,18 @@ bool GLTexture::generate_from_text(const std::string &text_str, wxFont &font, wx
     glsafe(::glPixelStorei(GL_UNPACK_ALIGNMENT, 1));
     glsafe(::glGenTextures(1, &m_id));
     glsafe(::glBindTexture(GL_TEXTURE_2D, (GLuint)m_id));
-    if (OpenGLManager::are_compressed_textures_supported())
-        glsafe(::glTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA_S3TC_DXT5_EXT, (GLsizei)m_width, (GLsizei)m_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, (const void*)data.data()));
-    else
+    if (OpenGLManager::are_compressed_textures_supported()) {
+        constexpr size_t kDxt5BlockPixels = 4u;  // DXT5 4×4 pixel blocks
+        constexpr size_t kDxt5BlockBytes  = 16u; // Each block is 16 bytes
+        size_t dxt5_blocks = ((static_cast<size_t>(m_width)  + kDxt5BlockPixels - 1u) / kDxt5BlockPixels)
+                           * ((static_cast<size_t>(m_height) + kDxt5BlockPixels - 1u) / kDxt5BlockPixels);
+        std::vector<unsigned char> compressed(dxt5_blocks * kDxt5BlockBytes, 0);
+        int compressed_size = 0;
+        rygCompress(compressed.data(), data.data(), m_width, m_height, 1, compressed_size);
+        compressed.resize(compressed_size);
+        glsafe(::glCompressedTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,
+            (GLsizei)m_width, (GLsizei)m_height, 0, compressed_size, compressed.data()));
+    } else
         glsafe(::glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, (GLsizei)m_width, (GLsizei)m_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, (const void*)data.data()));
     glsafe(::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
     glsafe(::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));

--- a/src/slic3r/GUI/WebPresetDialog.cpp
+++ b/src/slic3r/GUI/WebPresetDialog.cpp
@@ -31,6 +31,7 @@
 #include "CreatePresetsDialog.hpp"
 #include "slic3r/GUI/Tab.hpp"
 #include <mutex>
+#include <atomic>
 
 using namespace nlohmann;
 
@@ -38,6 +39,7 @@ namespace Slic3r { namespace GUI {
 
 extern json m_ProfileJson;
 extern std::mutex m_ProfileJson_mutex;
+
 extern void StringReplace(string& strBase, string strSrc, string strDes);
 
 static wxString update_custom_filaments()
@@ -183,12 +185,7 @@ WebPresetDialog::WebPresetDialog(GUI_App* pGUI, long style)
     // Connect the idle events
     // Bind(wxEVT_IDLE, &WebPresetDialog::OnIdle, this);
     // Bind(wxEVT_CLOSE_WINDOW, &WebPresetDialog::OnClose, this);
-    m_load_thread = new std::thread([this]() {
-            LoadProfile();
-    });
-    // LoadProfile();
-
-    m_load_thread->detach();
+    m_load_thread = std::make_unique<std::thread>([this]() { LoadProfile(); });
 
     // UI
     SetStartPage(BBL_REGION);
@@ -199,6 +196,11 @@ WebPresetDialog::WebPresetDialog(GUI_App* pGUI, long style)
 
 WebPresetDialog::~WebPresetDialog()
 {
+    // Signal the loader to stop scheduling UI work, then wait for it to finish
+    // so the background thread can no longer access this object (no UAF).
+    m_destroy.store(true, std::memory_order_release);
+    if (m_load_thread && m_load_thread->joinable())
+        m_load_thread->join();
     if (m_browser) {
         delete m_browser;
         m_browser = nullptr;
@@ -424,69 +426,11 @@ void WebPresetDialog::OnScriptMessage(wxWebViewEvent& evt)
                 PrivacyUse = false;
             }
         } else if (strCmd == "request_userguide_profile") {
-            json m_Res           = json::object();
-            m_Res["command"]     = "response_userguide_profile";
-            m_Res["sequence_id"] = "10001";
-
-            json res_json;
-            {
-                std::lock_guard<std::mutex> lock(m_ProfileJson_mutex);
-                res_json = m_ProfileJson;
+            if (!m_profile_ready.load(std::memory_order_acquire)) {
+                m_profile_request_pending = true;
+                return;
             }
-
-            // 把所有的选中信息取消，换成当前连接的机器
-            std::string model_name = "";
-            std::vector<std::string> nozzle_sizes;
-            if (m_device_id != "") {
-                DeviceInfo info;
-                if (wxGetApp().app_config->get_device_info(m_device_id, info)) {
-                    if (info.model_name != "") {
-                        // test
-                        if (info.model_name == "lava" || info.model_name == "Snapmaker test") {
-                            info.model_name = "Snapmaker U1";
-                        }
-                        model_name = info.model_name;
-                        nozzle_sizes = info.nozzle_sizes;
-                    }
-                }
-            }
-
-            
-            if (res_json.count("model")) {
-                json& model = res_json["model"];
-                for (size_t i = 0; i < model.size(); ++i) {
-                    json& item = model[i];
-                    if (item.count("nozzle_selected")) {
-                        if (item["model"].get<std::string>() == model_name) {
-                            if (!nozzle_sizes.empty()) {
-                                item["nozzle_selected"] = nozzle_sizes[0];
-                            } else {
-                                item["nozzle_selected"] = "";
-                            }
-                            
-                            if (m_bind_nozzle) {
-                                json cp_item = item;
-                                res_json["model"].clear();
-                                res_json["model"].push_back(cp_item);
-                                break;
-                            }
-                        } else {
-                            item["nozzle_selected"] = "";
-                        }
-                    }
-                }
-            }
-            m_Res["response"]    = res_json;
-
-
-            
-            
-
-            // wxString strJS = wxString::Format("HandleStudio(%s)", m_Res.dump(-1, ' ', false, json::error_handler_t::ignore));
-            wxString strJS = wxString::Format("HandleStudio(%s)", m_Res.dump(-1, ' ', true));
-
-            // BOOST_LOG_TRIVIAL(trace) << "WebPresetDialog::OnScriptMessage;request_userguide_profile:" << strJS.c_str();
-            wxGetApp().CallAfter([this, strJS] { RunScript(strJS); });
+            SendUserGuideProfile();
         } else if (strCmd == "request_custom_filaments") {
             wxString strJS = update_custom_filaments();
             wxGetApp().CallAfter([this, strJS] { RunScript(strJS); });
@@ -646,6 +590,72 @@ void WebPresetDialog::OnScriptMessage(wxWebViewEvent& evt)
     {
         std::lock_guard<std::mutex> lock(m_ProfileJson_mutex);
         wxString strAll = m_ProfileJson.dump(-1, ' ', false, json::error_handler_t::ignore);
+    }
+}
+
+void WebPresetDialog::SendUserGuideProfile()
+{
+    json m_Res           = json::object();
+    m_Res["command"]     = "response_userguide_profile";
+    m_Res["sequence_id"] = "10001";
+
+    json res_json;
+    {
+        std::lock_guard<std::mutex> lock(m_ProfileJson_mutex);
+        res_json = m_ProfileJson;
+    }
+
+    std::string              model_name = "";
+    std::vector<std::string> nozzle_sizes;
+    if (m_device_id != "") {
+        DeviceInfo info;
+        if (wxGetApp().app_config->get_device_info(m_device_id, info)) {
+            if (info.model_name != "") {
+                // test
+                if (info.model_name == "lava" || info.model_name == "Snapmaker test") {
+                    info.model_name = "Snapmaker U1";
+                }
+                model_name   = info.model_name;
+                nozzle_sizes = info.nozzle_sizes;
+            }
+        }
+    }
+
+    if (res_json.count("model")) {
+        json& model = res_json["model"];
+        for (size_t i = 0; i < model.size(); ++i) {
+            json& item = model[i];
+            if (item.count("nozzle_selected")) {
+                if (item["model"].get<std::string>() == model_name) {
+                    if (!nozzle_sizes.empty()) {
+                        item["nozzle_selected"] = nozzle_sizes[0];
+                    } else {
+                        item["nozzle_selected"] = "";
+                    }
+
+                    if (m_bind_nozzle) {
+                        json cp_item = item;
+                        res_json["model"].clear();
+                        res_json["model"].push_back(cp_item);
+                        break;
+                    }
+                } else {
+                    item["nozzle_selected"] = "";
+                }
+            }
+        }
+    }
+    m_Res["response"] = res_json;
+
+    wxString strJS = wxString::Format("HandleStudio(%s)", m_Res.dump(-1, ' ', true));
+    wxGetApp().CallAfter([this, strJS] { RunScript(strJS); });
+}
+
+void WebPresetDialog::FlushPendingProfileRequest()
+{
+    if (m_profile_request_pending) {
+        m_profile_request_pending = false;
+        SendUserGuideProfile();
     }
 }
 
@@ -1147,7 +1157,7 @@ int WebPresetDialog::GetFilamentInfo(std::string VendorDirectory, json& pFilaLis
 
 int WebPresetDialog::LoadProfile()
 {
-    std::lock_guard<std::mutex> lock(m_ProfileJson_mutex);
+    std::unique_lock<std::mutex> lock(m_ProfileJson_mutex);
     try {
         // wxString ExePath            = boost::dll::program_location().parent_path().string();
         // wxString TargetFolder       = ExePath + "\\resources\\profiles\\";
@@ -1317,6 +1327,13 @@ int WebPresetDialog::LoadProfile()
 
     std::string strAll = m_ProfileJson.dump(-1, ' ', false, json::error_handler_t::ignore);
     // wxLogMessage("GUIDE: profile_json_s2  %s ", m_ProfileJson.dump(-1, ' ', false, json::error_handler_t::ignore));
+    lock.unlock(); // release before marking ready / scheduling UI work
+
+    m_profile_ready.store(true, std::memory_order_release);
+    if (!m_destroy.load(std::memory_order_acquire))
+        CallAfter([this] {
+            FlushPendingProfileRequest();
+        });
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ", finished, json contents: " << std::endl << strAll;
     return 0;

--- a/src/slic3r/GUI/WebPresetDialog.hpp
+++ b/src/slic3r/GUI/WebPresetDialog.hpp
@@ -22,6 +22,7 @@
 #include "wx/fs_arc.h"
 #include "wx/fs_mem.h"
 #include "wx/stdpaths.h"
+#include <memory>
 #include <wx/frame.h>
 #include <wx/tbarbase.h>
 #include "wx/textctrl.h"
@@ -31,6 +32,8 @@
 #include "slic3r/Utils/PresetUpdater.hpp"
 
 #include <nlohmann/json.hpp>
+#include <atomic>
+#include <thread>
 
 namespace Slic3r { namespace GUI {
 
@@ -123,7 +126,13 @@ public:
     wxString    m_sm_user_agent;
     std::string m_editing_filament_id;
 
-    std::thread* m_load_thread = nullptr;
+    std::unique_ptr<std::thread> m_load_thread;
+    std::atomic<bool> m_profile_ready{false};
+    bool              m_profile_request_pending{false};
+    std::atomic<bool> m_destroy{false};
+
+    void SendUserGuideProfile();
+    void FlushPendingProfileRequest();
 };
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/Utils/EmbossStyleManager.cpp
+++ b/src/slic3r/Utils/EmbossStyleManager.cpp
@@ -6,6 +6,7 @@
 #include <libslic3r/Utils.hpp> // ScopeGuard
 
 #include "WxFontUtils.hpp"
+#include "stb_dxt/stb_dxt.h"
 #include "slic3r/GUI/3DScene.hpp" // ::glsafe
 #include "slic3r/GUI/Jobs/CreateFontStyleImagesJob.hpp"
 #include "slic3r/GUI/ImGuiWrapper.hpp" // check of font ranges
@@ -495,9 +496,18 @@ ImFont *StyleManager::create_imgui_font(const std::string &text, double scale)
     glsafe(::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
     glsafe(::glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
     glsafe(::glPixelStorei(GL_UNPACK_ROW_LENGTH, 0));
-    if (OpenGLManager::are_compressed_textures_supported())
-        glsafe(::glTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA_S3TC_DXT5_EXT, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
-    else
+    if (OpenGLManager::are_compressed_textures_supported()) {
+        constexpr size_t kDxt5BlockPixels = 4u;
+        constexpr size_t kDxt5BlockBytes  = 16u;
+        size_t dxt5_blocks = ((static_cast<size_t>(width)  + kDxt5BlockPixels - 1u) / kDxt5BlockPixels)
+                           * ((static_cast<size_t>(height) + kDxt5BlockPixels - 1u) / kDxt5BlockPixels);
+        std::vector<unsigned char> compressed(dxt5_blocks * kDxt5BlockBytes, 0);
+        int compressed_size = 0;
+        rygCompress(compressed.data(), pixels, width, height, 1, compressed_size);
+        compressed.resize(compressed_size);
+        glsafe(::glCompressedTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,
+            width, height, 0, compressed_size, compressed.data()));
+    } else
         glsafe(::glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
 
     // Store our identifier


### PR DESCRIPTION
## Summary

This PR addresses application lag and freeze issues with two targeted fixes:

### Changes

1. **fix: prevent app freeze and UAF in WebPresetDialog profile loading** (a005449e9)
   - Fixes a use-after-free (UAF) bug in WebPresetDialog that could cause the application to freeze during profile loading
   - Ensures safe asynchronous callback handling when loading web preset configurations

2. **perf: use CPU-side rygCompress instead of driver DXT5 compression for font/icon textures** (b2c5b3c01)
   - Replaces GPU driver-based DXT5 texture compression with CPU-side rygCompress for font and icon textures
   - Reduces GUI rendering latency by avoiding driver-dependent compression paths
   - Improves overall UI responsiveness, especially during initial rendering

### Impact

- Eliminates a known crash/freeze scenario in the WebPresetDialog
- Reduces texture compression overhead during UI rendering
- No API or configuration changes — fully backward compatible
