### PR TITLE
fix: prevent slice button re-enabling on mode switch with incompatible filament

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1907,6 +1907,10 @@ bool MainFrame::get_enable_slice_status()
         {
             enable = false;
         }
+        if (enable && m_plater->has_incompatible_mixed_filament_in_use())
+        {
+            enable = false;
+        }
     }
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": m_slice_select %1%, enable= %2% ")%m_slice_select %enable;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -15035,6 +15035,11 @@ void Plater::priv::on_action_layersediting(SimpleEvent&)
  * heights and may produce unexpected results.
  * @param local_z_enabled true if the Subdivide Mix Layer setting is active
  */
+bool Plater::has_incompatible_mixed_filament_in_use() const
+{
+    return p && p->has_incompatible_mixed_filament_in_use();
+}
+
 void Plater::notify_vhl_dithering_conflict(bool local_z_enabled)
 {
     if (!local_z_enabled)

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -526,6 +526,7 @@ public:
     void set_project_filename(const wxString& filename);
     void update_print_error_info(int code, std::string msg, std::string extra);
     void notify_vhl_dithering_conflict(bool local_z_enabled);
+    bool has_incompatible_mixed_filament_in_use() const;
 
     bool is_export_gcode_scheduled() const;
 


### PR DESCRIPTION
- Expose Plater::has_incompatible_mixed_filament_in_use() for MainFrame.
- Add incompatible filament check to get_enable_slice_status(), covering
  both the Slice All→Single menu toggle and the update_slice_print_status
  callback path that could override a previously disabled button state.