### PR TITLE
fix: eliminate data race on SSWCP_Instance causing EXCEPTION_ACCESS_VIOLATION 

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -932,13 +932,21 @@ void SSWCP_Instance::sw_GetFileStream() {
 
 void SSWCP_Instance::handle_general_fail(int code, const wxString& msg)
 {
+    // CAS gate: protects all callers (on_timeout, MQTT Agent worker CallAfter, etc.)
+    bool expected = false;
+    if (!m_response_sent.compare_exchange_strong(expected, true)) {
+        return;
+    }
     try {
+        std::unique_lock<std::mutex> lock(m_data_mtx);
         m_status = code;
         m_msg    = msg.ToUTF8();
+        m_job_finished.store(true);
+        lock.unlock();
         send_to_js();
         finish_job();
     } catch (std::exception& e) {}
-    
+
 }
 
 // Mark instance as invalid
@@ -976,11 +984,12 @@ void SSWCP_Instance::send_to_js()
         }
 
         json response, payload;
+        std::unique_lock<std::mutex> lock(m_data_mtx);
         response["header"] = m_header;
-
-        payload["code"] = m_status;
-        payload["message"]  = m_msg;
-        payload["data"] = m_res_data;
+        payload["code"]    = m_status;
+        payload["message"] = m_msg;
+        payload["data"]    = m_res_data;
+        lock.unlock();
 
         response["payload"] = payload;
 
@@ -1003,9 +1012,9 @@ void SSWCP_Instance::send_to_js()
     } catch (std::exception& e) {}
 }
 
-// Clean up instance
+// Clean up instance — requires SSWCP_Instance to be managed by std::shared_ptr
 void SSWCP_Instance::finish_job() {
-    SSWCP::delete_target(this);
+    SSWCP::delete_target(shared_from_this());
 }
 
 // Asynchronous test implementation
@@ -1225,42 +1234,57 @@ void SSWCP_Instance::on_mqtt_status_msg_arrived(std::shared_ptr<SSWCP_Instance> 
     if (!obj) {
         return;
     }
+    bool is_timeout = false;
+    std::unique_lock<std::mutex> lock(obj->m_data_mtx);
+    if (obj->m_job_finished.load()) {
+        return;
+    }
     if (response.is_null()) {
         obj->m_status = -1;
         obj->m_msg    = "failure";
-        obj->send_to_js();
     } else if (response.count("error")) {
         if (response["error"].is_string() && "timeout" == response["error"].get<std::string>()) {
-            obj->on_timeout();
+            is_timeout = true;
         } else {
             obj->m_res_data = response;
-            obj->send_to_js();
         }
     } else {
         obj->m_res_data = response;
-        obj->send_to_js();
     }
+    lock.unlock();
+    if (is_timeout) {
+        obj->on_timeout();
+        return;
+    }
+    obj->send_to_js();
 }
 
 void SSWCP_Instance::on_mqtt_msg_arrived(std::shared_ptr<SSWCP_Instance> obj, const json& response) {
     if (!obj) {
         return;
     }
+    // CAS gate: only one terminal writer (on_mqtt_msg_arrived or on_timeout) proceeds
+    bool expected = false;
+    if (!obj->m_response_sent.compare_exchange_strong(expected, true)) {
+        return;  // winner is responsible for cleanup
+    }
+    std::unique_lock<std::mutex> lock(obj->m_data_mtx);
     if (response.is_null()) {
         obj->m_status = -1;
         obj->m_msg    = "failure";
-        obj->send_to_js();
     } else if (response.count("error")) {
         if (response["error"].is_string() && "timeout" == response["error"].get<std::string>()) {
-            obj->on_timeout();
+            obj->m_status = -2;
+            obj->m_msg    = "time out";
         } else {
             obj->m_res_data = response;
-            obj->send_to_js();
         }
     } else {
         obj->m_res_data = response;
-        obj->send_to_js();
     }
+    obj->m_job_finished.store(true);
+    lock.unlock();
+    obj->send_to_js();
     obj->finish_job();
 }
 
@@ -1530,8 +1554,7 @@ void SSWCP_Instance::sw_Unsubscribe_Filter() {
 
 // Handle timeout event
 void SSWCP_Instance::on_timeout() {
-    handle_general_fail(-2, "time out");
-    finish_job();
+    handle_general_fail(-2, "time out");  // CAS gate is inside handle_general_fail
 }
 
 void SSWCP_Instance::update_filament_info(const json& objects, bool send_message)
@@ -6337,9 +6360,9 @@ void SSWCP::handle_web_message(std::string message, wxWebView* webview) {
 }
 
 // Delete instance from list
-void SSWCP::delete_target(SSWCP_Instance* target) {
+void SSWCP::delete_target(std::shared_ptr<SSWCP_Instance> target) {
     wxGetApp().CallAfter([target]() {
-        m_instance_list.remove(target);
+        m_instance_list.remove(target.get());
     });
 }
 

--- a/src/slic3r/GUI/SSWCP.hpp
+++ b/src/slic3r/GUI/SSWCP.hpp
@@ -2,6 +2,7 @@
 #ifndef SSWCP_HPP
 #define SSWCP_HPP
 
+#include <atomic>
 #include <iostream>
 #include <mutex>
 #include <stack>
@@ -221,6 +222,9 @@ protected:
 private:
     bool m_illegal = false;      // Invalid flag
     std::mutex m_illegal_mtx;    // Mutex for illegal flag
+    std::mutex m_data_mtx;                      // Protects m_res_data, m_status, m_msg, m_header
+    std::atomic<bool> m_response_sent{false};   // CAS gate: exactly one terminal writer wins
+    std::atomic<bool> m_job_finished{false};    // Prevents double-send after finish_job
 };
 
 // Instance class for handling machine connection
@@ -598,7 +602,7 @@ public:
         std::string cmd, const json& header, const json& data, std::string event_id, wxWebView* webview);
 
     // Delete instance
-    static void delete_target(SSWCP_Instance* target);
+    static void delete_target(std::shared_ptr<SSWCP_Instance> target);
 
     // Stop machine discovery
     static void stop_machine_find();
@@ -640,7 +644,7 @@ private:
     static std::unordered_set<std::string> m_page_state_cmd_list; // page state change commands;
 
     static TimeoutMap<SSWCP_Instance*, std::shared_ptr<SSWCP_Instance>> m_instance_list;  // Active instances
-    static constexpr std::chrono::milliseconds DEFAULT_INSTANCE_TIMEOUT{80000}; // Default timeout (8s)
+    static constexpr std::chrono::milliseconds DEFAULT_INSTANCE_TIMEOUT{80000}; // Default timeout (80s)
 
     static std::string m_active_gcode_filename; // name of the file which is pretend to be upload and print
     static std::string m_display_gcode_filename; // name for display


### PR DESCRIPTION
## Root Cause

`SSWCP_Instance::m_res_data` (nlohmann::json) is concurrently accessed from multiple threads without synchronization:

```
MQTT network thread  -> on_mqtt_msg_arrived -> writes m_res_data
TimeoutMap bg thread -> on_timeout -> handle_general_fail -> reads m_res_data via send_to_js
```

nlohmann::json internally uses `std::map`. Concurrent read+write on `std::map` is UB, causing heap corruption.

### Sentry Issues Fixed

| Issue | Error | Crash site |
|-------|-------|------------|
| `SNAPMAKER_ORCA-JK` | `ACCESS_VIOLATION / 0x0` | `json::count` -> `json.hpp:4580` |
| `SNAPMAKER_ORCA-YK` | `HEAP_CORRUPTION` | `RtlpFreeHeapInternal` |
| `SNAPMAKER_ORCA-2H9` | `ACCESS_VIOLATION / 0xffffffff` | `free_base` |

All three are the same root cause surfacing at different heap operations.

## Fix

Three lightweight synchronization mechanisms that **preserve the async MQTT design** (no CallAfter to main thread):

1. **`std::mutex m_data_mtx`** - protects `m_res_data`/`m_status`/`m_msg`/`m_header`. `send_to_js()` snapshots all four fields under a single lock acquisition for consistent reads.

2. **`std::atomic<bool> m_response_sent`** (CAS gate) - exactly one terminal writer (`on_mqtt_msg_arrived` or `on_timeout`) wins. Loser returns immediately.

3. **`std::atomic<bool> m_job_finished`** - prevents subscription callbacks (`on_mqtt_status_msg_arrived`) from sending after the terminal response. Checked inside the mutex to close TOCTOU window.

Also: `delete_target` signature changed from raw pointer to `shared_ptr` to eliminate use-after-free risk in the `CallAfter` lambda.

## Files Changed

| File | Change |
|------|--------|
| `src/slic3r/GUI/SSWCP.hpp` | Add `m_data_mtx`, `m_response_sent`, `m_job_finished`; `delete_target` signature |
| `src/slic3r/GUI/SSWCP.cpp` | Lock guards in `send_to_js`, `handle_general_fail`, `on_mqtt_msg_arrived`, `on_mqtt_status_msg_arrived`, `on_timeout`; `delete_target` -> `shared_ptr` |