### PR TITLE
fix: Exclude raft layers from slow-down layer count

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7439,8 +7439,10 @@ std::string GCode::_extrude(const ExtrusionPath& path, std::string description, 
         if (path.role() != erBottomSurface)
             speed = m_config.get_abs_value("initial_layer_speed");
     } else if (m_config.slow_down_layers > 1) {
-        const auto _layer = layer_id();
-        if (_layer > 0 && _layer < m_config.slow_down_layers) {
+        // Subtract raft layers so the slow-down count starts from the first model layer
+        const int raft_layers = int(m_layer->object()->slicing_parameters().raft_layers());
+        const int _layer      = layer_id() - raft_layers;
+        if (_layer >= 0 && _layer < m_config.slow_down_layers) {
             const auto first_layer_speed = is_perimeter(path.role()) ? m_config.get_abs_value("initial_layer_speed") :
                                                                        m_config.get_abs_value("initial_layer_infill_speed");
             if (first_layer_speed < speed) {


### PR DESCRIPTION
## Summary

Fixes a bug where slow-down layers (`slow_down_layers`) incorrectly counted raft layers, causing the model's actual first few layers to receive insufficient speed reduction.

## Root Cause

In `GCode::_extrude()`, the slow-down layer lerp used raw `layer_id()` which includes raft layers in its counting. With 3 raft layers and `slow_down_layers=5`, the 3 raft layers consumed 3 slow-down slots, leaving only 2 for the actual model layers.

## Fix

- Subtract `raft_layers()` from `layer_id()` so slow-down counting starts from the first model layer
- Change `_layer > 0` to `_layer >= 0` so the first model layer over raft also receives proper initial speed

## Changes

| File | Lines |
|------|-------|
| `src/libslic3r/GCode.cpp` | +5, -2 |

## Behavior (example: 3 raft layers + slow_down_layers=5)

| Before (bug) | After (fix) |
|---|---|
| Raft layers 1-2: slow-down applied | Raft layers: normal speed |
| Model layers 1-2: slow-down (only 2 of 5) | Model layers 1-5: full slow-down gradient |

## Verification

- Compiled successfully with MSVC 19.44 (VS 2022)
- Application starts and runs correctly