### PR TITLE
Adjust filament sync dialog layout

### DIFF
--- a/src/slic3r/GUI/Widgets/SegmentedToggle.cpp
+++ b/src/slic3r/GUI/Widgets/SegmentedToggle.cpp
@@ -17,7 +17,7 @@ constexpr int g_buttonMinHeight  = 28;  // DIP
 constexpr int g_buttonPaddingW   = 6;   // DIP
 constexpr int g_buttonPaddingH   = 2;   // DIP
 constexpr int g_buttonRadius     = 4;   // DIP
-constexpr int g_buttonGap        = 24;  // DIP — gap between buttons
+constexpr int g_buttonGap        = 4;   // DIP — gap between buttons
 constexpr int g_buttonMarginV    = 0;   // DIP — vertical button margin (container already sized for button)
 constexpr int g_outerMargin      = 6;   // DIP — (block 40 - container 28) / 2
 

--- a/src/slic3r/GUI/filamentsync/FilamentColorMapBox.cpp
+++ b/src/slic3r/GUI/filamentsync/FilamentColorMapBox.cpp
@@ -1,6 +1,7 @@
 #include "FilamentColorMapBox.hpp"
 
 #include <wx/dcclient.h>
+#include <wx/dcbuffer.h>
 #include <wx/dcgraph.h>
 #include <wx/dcmemory.h>
 #include <wx/settings.h>

--- a/src/slic3r/GUI/filamentsync/FilamentColorMapBoxGroup.cpp
+++ b/src/slic3r/GUI/filamentsync/FilamentColorMapBoxGroup.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include <wx/dcclient.h>
+#include <wx/dcbuffer.h>
 #include <wx/dcgraph.h>
 #include <wx/dcmemory.h>
 #include <wx/sizer.h>

--- a/src/slic3r/GUI/filamentsync/FilamentScrollBar.cpp
+++ b/src/slic3r/GUI/filamentsync/FilamentScrollBar.cpp
@@ -1,6 +1,7 @@
 #include "FilamentScrollBar.hpp"
 
 #include <wx/dcclient.h>
+#include <wx/dcbuffer.h>
 #include <wx/dcgraph.h>
 #include <wx/settings.h>
 

--- a/src/slic3r/GUI/filamentsync/MachineFilamentPicker.cpp
+++ b/src/slic3r/GUI/filamentsync/MachineFilamentPicker.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include <wx/dcclient.h>
+#include <wx/dcbuffer.h>
 #include <wx/dcmemory.h>
 #include <wx/dcgraph.h>
 
@@ -21,6 +22,8 @@ constexpr int g_itemRowH      = 16; // DIP — row height
 constexpr int g_itemStepY     = 22; // DIP — vertical step between rows
 constexpr int g_firstRowY     = 12; // DIP — top of first row (after shadow)
 constexpr int g_itemGap       = 6;  // DIP — gap between rows
+constexpr int g_selectionInsetX = 3; // DIP — left/right inset for selected row background
+constexpr int g_contentOffsetX  = 1; // DIP — slight visual centering offset for row content
 
 // --- Checkmark (draw with path, roughly 8×8 DIP) ---
 constexpr int g_checkmarkX = 9;
@@ -109,7 +112,7 @@ public:
             }
         }
         int minWidthPx = FromDIP(g_popupMinWidth);
-        int contentWidthPx = FromDIP(g_textX) + maxTextWidthPx + FromDIP(g_textRightPadding);
+        int contentWidthPx = FromDIP(g_textX + g_contentOffsetX) + maxTextWidthPx + FromDIP(g_textRightPadding);
         int actualWidthPx = std::max(minWidthPx, contentWidthPx);
 
         wxSize sz(actualWidthPx, FromDIP(g_popupHeight));
@@ -180,14 +183,15 @@ private:
         if (isSelected) {
             dc.SetPen(*wxTRANSPARENT_PEN);
             dc.SetBrush(wxBrush(g_selectionBg));
-            dc.DrawRectangle(FromDIP(x), FromDIP(y),
-                             contentWidthPx,
+            const int insetX = FromDIP(g_selectionInsetX);
+            dc.DrawRectangle(FromDIP(x) + insetX, FromDIP(y),
+                             contentWidthPx - insetX * 2,
                              FromDIP(g_itemRowH));
         }
 
         // ---- Checkmark (selected only) ----
         if (isSelected) {
-            int cx = FromDIP(g_checkmarkX);
+            int cx = FromDIP(g_checkmarkX + g_contentOffsetX);
             int cy = FromDIP(y + g_checkmarkY);
             int cw = FromDIP(g_checkmarkW);
             int ch = FromDIP(g_checkmarkH);
@@ -198,7 +202,7 @@ private:
         bool isNone = isNoneEntry(data);
 
         // ---- Colour circle (bitmap) ----
-        int circleCxPx = FromDIP(g_circleCx);
+        int circleCxPx = FromDIP(g_circleCx + g_contentOffsetX);
         int circleCyPx = FromDIP(y + g_itemRowH / 2);
         int circleR    = FromDIP(g_circleRadius);
         int circleD    = circleR * 2;
@@ -221,7 +225,7 @@ private:
         dc.SetFont(labelFont);
         dc.SetTextForeground(isNone ? wxColour(0xBB, 0xBB, 0xBB) : g_textColor);
         wxString typeStr = wxString::FromUTF8(data.m_type.empty() ? "NONE" : data.m_type);
-        int textX = FromDIP(g_textX);
+        int textX = FromDIP(g_textX + g_contentOffsetX);
         int textH = dc.GetTextExtent(typeStr).y;
         int textY = FromDIP(y) + static_cast<int>(std::round((FromDIP(g_itemRowH) - textH) / 2.0));
 

--- a/src/slic3r/GUI/filamentsync/SyncFilamentColorDialog.cpp
+++ b/src/slic3r/GUI/filamentsync/SyncFilamentColorDialog.cpp
@@ -6,6 +6,7 @@
 #include <wx/sizer.h>
 #include <wx/image.h>
 #include <wx/statbox.h>
+#include <wx/dcbuffer.h>
 #include <wx/dcgraph.h>
 #include <cmath>
 #include <algorithm>
@@ -57,6 +58,7 @@ constexpr int g_scrollBarWidth = 10; // DIP — track width
 // Button sizing
 constexpr int g_btnW = 237;
 constexpr int g_btnH = 36;
+constexpr int g_btnRowGap = 12; // DIP — Reset / Sync button spacer width
 
 // Block 4 wrapper margins
 constexpr int g_block4PaddingV = 12; // DIP — top/bottom
@@ -320,8 +322,6 @@ SyncFilamentColorDialog::SyncFilamentColorDialog(wxWindow* parent,
 
         auto* btnRow = new wxBoxSizer(wxHORIZONTAL);
 
-        btnRow->AddStretchSpacer();
-
         m_pResetBtn = new Button(block, _L("Reset"));
         m_pResetBtn->SetMinSize(FromDIP(wxSize(g_btnW, g_btnH)));
         m_pResetBtn->SetCornerRadius(FromDIP(4));
@@ -335,10 +335,15 @@ SyncFilamentColorDialog::SyncFilamentColorDialog(wxWindow* parent,
         m_pResetBtn->SetBorderColor(StateColor(wxColour(g_secondaryBorder)));
         m_pResetBtn->SetTextColor(StateColor(wxColour(g_secondaryText)));
         m_pResetBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { onReset(); });
-        btnRow->Add(m_pResetBtn, 0, wxALIGN_CENTER_VERTICAL);
+        btnRow->Add(m_pResetBtn, 0, wxEXPAND | wxALIGN_CENTER_VERTICAL);
 
-        // Spring between buttons
-        btnRow->AddStretchSpacer();
+        wxSizerItem* spacerItem = btnRow->AddSpacer(FromDIP(g_btnRowGap));
+        m_pResetBtn->Bind(wxEVT_SHOW, [this, spacerItem](wxShowEvent& event) {
+            if (spacerItem) {
+                spacerItem->Show(event.IsShown());
+                Layout();
+            }
+        });
 
         m_pSyncBtn = new Button(block, _L("Sync Now"));
         m_pSyncBtn->SetMinSize(FromDIP(wxSize(g_btnW, g_btnH)));
@@ -352,7 +357,7 @@ SyncFilamentColorDialog::SyncFilamentColorDialog(wxWindow* parent,
             std::pair(wxColour(g_disabledText), (int)StateColor::Disabled),
             std::pair(wxColour(g_primaryText), (int)StateColor::Normal)));
         m_pSyncBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { onSync(); });
-        btnRow->Add(m_pSyncBtn, 0, wxALIGN_CENTER_VERTICAL);
+        btnRow->Add(m_pSyncBtn, 1, wxEXPAND | wxALIGN_CENTER_VERTICAL);
 
         // T/B = 12px margins
         auto* vPad = new wxBoxSizer(wxVERTICAL);


### PR DESCRIPTION
• ## Summary

  Cherry-picks `0962f4d2557832b1a9a3cb2de4019fbdd32c022c` onto `main`.

  This adjusts the filament sync dialog layout and related UI spacing/alignment.

  ## Changes

  - Refined layout behavior in the filament color sync dialog.
  - Adjusted spacing and sizing in filament sync UI components.
  - Updated segmented toggle and filament picker UI details.