### PR TITLE
fix: avoid boost::any_cast type mismatch crash in extruders_count sync

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1840,7 +1840,8 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
 
     //Orca: sync filament num if it's a multi tool printer
     if (opt_key == "extruders_count" && !m_config->opt_bool("single_extruder_multi_material")){
-        auto num_extruder = static_cast<size_t>(boost::any_cast<int>(value));
+        const auto *nozzle_diameter = dynamic_cast<const ConfigOptionFloats*>(m_config->option("nozzle_diameter"));
+        size_t num_extruder = (nozzle_diameter != nullptr) ? nozzle_diameter->values.size() : 0;
         int         old_filament_size = wxGetApp().preset_bundle->filament_presets.size();
         std::vector<std::string> new_colors;
         for (int i = old_filament_size; i < num_extruder; ++i) {


### PR DESCRIPTION
# Description
on_value_change("extruders_count", value) passes size_t when called from extruders_count_changed(), but int when called from the config UI callback path. boost::any_cast requires exact type match, so reading from m_config's nozzle_diameter directly avoids the crash.

