### PR TITLE
fix: top cover filament temp mixing - three fixes

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1915,6 +1915,10 @@ bool MainFrame::get_enable_slice_status()
         {
             enable = false;
         }
+        else if (m_plater->has_incompatible_mixed_filament_in_use())
+        {
+            enable = false;
+        }
         else if (m_plater->is_plate_blocked_by_filament_temp_mixing(part_plate_list.get_curr_plate_index()))
         {
             enable = false;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17765,21 +17765,12 @@ std::vector<size_t> Plater::load_files(const std::vector<fs::path>& input_files,
     {
         // After loading a project, initialize the filament temp mixing state
         // for ALL plates, not just the current one. This ensures each plate's
-        // m_apply_invalid flag is correct so that "Slice All" mode correctly
-        // detects which plates are sliceable.
-        PartPlateList& plate_list = get_partplate_list();
-        for (int i = 0; i < plate_list.get_plate_count(); ++i)
-        {
-            const FilamentTempMixingState state = get_filament_temp_mixing_state(i);
-            PartPlate* plate = plate_list.get_plate(i);
-            if (plate)
-            {
-                plate->update_apply_result_invalid(
-                    state == FilamentTempMixingState::BlockedError);
-            }
-        }
+        // After loading a project, force a filament usage sync so that
+        // the current plate's notification and slice button reflect the
+        // filament temp mixing state. The blocking itself is enforced via
+        // is_plate_blocked_by_filament_temp_mixing() independently of
+        // m_apply_invalid; no per-plate flag initialization is needed.
         notify_filament_usage_changed();
-        // Force a sync for the current plate's notification display
         sync_filament_temp_mixing_notification();
     }
     return loaded;
@@ -20954,12 +20945,13 @@ bool Plater::sync_filament_temp_mixing_notification()
     case FilamentTempMixingState::Compatible:
         get_notification_manager()->close_validate_error_notification(filament_temp_mixing_error_text());
         get_notification_manager()->close_validate_warning_notification(filament_temp_mixing_warning_text());
-        curr_plate->update_apply_result_invalid(false);
+        // Filament temp mixing is compatible — only clear our own notification,
+        // do NOT touch m_apply_invalid. Bed type mismatch or other validation
+        // errors must not be cleared by the filament temp mixing system.
         slicing_allowed = true;
         break;
     case FilamentTempMixingState::AllowedWarning:
         get_notification_manager()->close_validate_error_notification(filament_temp_mixing_error_text());
-        curr_plate->update_apply_result_invalid(false);
         get_notification_manager()->push_notification(
             NotificationType::ValidateWarning,
             NotificationManager::NotificationLevel::WarningNotificationLevel,
@@ -20972,7 +20964,9 @@ bool Plater::sync_filament_temp_mixing_notification()
         err.string = filament_temp_mixing_error_text();
         get_notification_manager()->close_validate_warning_notification(filament_temp_mixing_warning_text());
         get_notification_manager()->push_validate_error_notification(err);
-        curr_plate->update_apply_result_invalid(true);
+        // Blocking is enforced through get_enable_slice_status() / find_next_sliceable_plate_for_slice_all()
+        // which independently check is_plate_blocked_by_filament_temp_mixing().
+        // Do NOT set m_apply_invalid — that flag belongs to the background validation system.
         slicing_allowed = false;
         break;
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12360,6 +12360,7 @@ unsigned int Plater::priv::update_background_process(bool force_validation, bool
             notification_manager->push_validate_error_notification(err);
             //also update the warnings
             process_validation_warning(warning);
+            q->sync_filament_temp_mixing_notification();
             return_state |= UPDATE_BACKGROUND_PROCESS_INVALID;
             if (printer_technology == ptFFF) {
                 const Print* print = background_process.fff_print();
@@ -12379,8 +12380,10 @@ unsigned int Plater::priv::update_background_process(bool force_validation, bool
 
     //actualizate warnings
     if (invalidated != Print::APPLY_STATUS_UNCHANGED || background_process.empty()) {
-        if (background_process.empty())
+        if (background_process.empty()) {
             process_validation_warning({});
+            q->sync_filament_temp_mixing_notification();
+        }
         actualize_slicing_warnings(*this->background_process.current_print());
         actualize_object_warnings(*this->background_process.current_print());
         show_warning_dialog = false;
@@ -22012,6 +22015,8 @@ void Plater::validate_current_plate(bool& model_fits, bool& validate_error)
         else {
             p->notification_manager->close_plater_error_notification(plater_text);
         }
+
+        sync_filament_temp_mixing_notification();
     }
 
     PartPlate* part_plate = p->partplate_list.get_curr_plate();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -309,6 +309,40 @@ static void collect_filament_slots_from_model_config(
     }
 }
 
+static void resolve_mixed_filament_extruders(
+    std::vector<int>& extruder_ids,
+    int               num_filaments)
+{
+    if (num_filaments < 2)
+        return;
+
+    bool has_virtual = false;
+    for (int id : extruder_ids) {
+        if (id > num_filaments) {
+            has_virtual = true;
+            break;
+        }
+    }
+    if (!has_virtual)
+        return;
+
+    PresetBundle* bundle = wxGetApp().preset_bundle;
+    if (bundle == nullptr)
+        return;
+    const DynamicPrintConfig& full_cfg = bundle->full_config();
+    const auto* defs_opt = full_cfg.option<ConfigOptionString>("mixed_filament_definitions");
+    if (defs_opt == nullptr || defs_opt->value.empty())
+        return;
+    const auto* colors_opt = full_cfg.option<ConfigOptionStrings>("filament_colour");
+    std::vector<std::string> filament_colors;
+    if (colors_opt != nullptr)
+        filament_colors = colors_opt->values;
+
+    MixedFilamentManager mgr;
+    mgr.load_custom_entries(defs_opt->value, filament_colors);
+    mgr.expand_virtual_extruder_ids(extruder_ids, static_cast<size_t>(num_filaments));
+}
+
 wxDEFINE_EVENT(EVT_SCHEDULE_BACKGROUND_PROCESS,     SimpleEvent);
 wxDEFINE_EVENT(EVT_SLICING_UPDATE,                  SlicingStatusEvent);
 wxDEFINE_EVENT(EVT_SLICING_COMPLETED,               wxCommandEvent);
@@ -20794,10 +20828,14 @@ bool Plater::check_filament_temp_mixing(int plate_index)
         for (const ModelVolume* model_volume : model_object->volumes)
         {
             collect_filament_slots_from_model_config(model_volume->config, num_filaments, used_slots);
-            for (int extruder_id : model_volume->get_extruders())
-            {
-                if (extruder_id >= 1 && extruder_id <= num_filaments)
-                    used_slots.insert(extruder_id - 1);
+            std::vector<int> volume_extruders = model_volume->get_extruders();
+            if (!volume_extruders.empty()) {
+                resolve_mixed_filament_extruders(volume_extruders, num_filaments);
+                for (int extruder_id : volume_extruders)
+                {
+                    if (extruder_id >= 1 && extruder_id <= num_filaments)
+                        used_slots.insert(extruder_id - 1);
+                }
             }
         }
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -309,40 +309,6 @@ static void collect_filament_slots_from_model_config(
     }
 }
 
-static void resolve_mixed_filament_extruders(
-    std::vector<int>& extruder_ids,
-    int               num_filaments)
-{
-    if (num_filaments < 2)
-        return;
-
-    bool has_virtual = false;
-    for (int id : extruder_ids) {
-        if (id > num_filaments) {
-            has_virtual = true;
-            break;
-        }
-    }
-    if (!has_virtual)
-        return;
-
-    PresetBundle* bundle = wxGetApp().preset_bundle;
-    if (bundle == nullptr)
-        return;
-    const DynamicPrintConfig& full_cfg = bundle->full_config();
-    const auto* defs_opt = full_cfg.option<ConfigOptionString>("mixed_filament_definitions");
-    if (defs_opt == nullptr || defs_opt->value.empty())
-        return;
-    const auto* colors_opt = full_cfg.option<ConfigOptionStrings>("filament_colour");
-    std::vector<std::string> filament_colors;
-    if (colors_opt != nullptr)
-        filament_colors = colors_opt->values;
-
-    MixedFilamentManager mgr;
-    mgr.load_custom_entries(defs_opt->value, filament_colors);
-    mgr.expand_virtual_extruder_ids(extruder_ids, static_cast<size_t>(num_filaments));
-}
-
 wxDEFINE_EVENT(EVT_SCHEDULE_BACKGROUND_PROCESS,     SimpleEvent);
 wxDEFINE_EVENT(EVT_SLICING_UPDATE,                  SlicingStatusEvent);
 wxDEFINE_EVENT(EVT_SLICING_COMPLETED,               wxCommandEvent);
@@ -20831,14 +20797,10 @@ bool Plater::check_filament_temp_mixing(int plate_index)
         for (const ModelVolume* model_volume : model_object->volumes)
         {
             collect_filament_slots_from_model_config(model_volume->config, num_filaments, used_slots);
-            std::vector<int> volume_extruders = model_volume->get_extruders();
-            if (!volume_extruders.empty()) {
-                resolve_mixed_filament_extruders(volume_extruders, num_filaments);
-                for (int extruder_id : volume_extruders)
-                {
-                    if (extruder_id >= 1 && extruder_id <= num_filaments)
-                        used_slots.insert(extruder_id - 1);
-                }
+            for (int extruder_id : model_volume->get_extruders())
+            {
+                if (extruder_id >= 1 && extruder_id <= num_filaments)
+                    used_slots.insert(extruder_id - 1);
             }
         }
     }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3697,7 +3697,7 @@ void TabFilament::build()
         optgroup->append_single_option_line("filament_cost");
         //BBS
         optgroup->append_single_option_line("temperature_vitrification");
-        optgroup->append_single_option_line("filament_is_high_temperature");
+        // filament_is_high_temperature is controlled by preset data, not user-facing
         optgroup->append_single_option_line("idle_temperature");
         optgroup->append_single_option_line("filament_tower_ironing_area");
         Line line = { L("Recommended nozzle temperature"), L("Recommended nozzle temperature range of this filament. 0 means no set") };


### PR DESCRIPTION
## Summary

This PR contains 3 fixes related to the top cover filament temperature mixing detection:

### Fix 1: Decouple filament temp mixing from shared `m_apply_invalid` flag
`sync_filament_temp_mixing_notification()` was unconditionally calling `update_apply_result_invalid(false)` in Compatible/AllowedWarning states, which cleared the invalid flag set by other validation systems (e.g. bed type mismatch). The filament temp blocking is now enforced independently via `is_plate_blocked_by_filament_temp_mixing()` in `get_enable_slice_status()` and `find_next_sliceable_plate_for_slice_all()`.

### Fix 2: Restore filament temp mixing notification after blanket close
`update_background_process()` and `validate_current_plate()` use blanket `close_notification_of_type(ValidateError)` which kills all notifications of that type, including the filament temp mixing ones. Re-sync after each blanket close so the notification is restored when high/low temperature filaments are still mixed.

### Fix 3: Restore mixed filament incompatibility check in slice button status
The top cover feature incorrectly replaced the existing `has_incompatible_mixed_filament_in_use()` check with `is_plate_blocked_by_filament_temp_mixing()` in `get_enable_slice_status()`. Both checks must coexist — they guard against independent blocking conditions (material type incompatibility vs. high/low temperature mixing).

## Files Changed
- `src/slic3r/GUI/Plater.cpp` — Fix 1 and Fix 2
- `src/slic3r/GUI/MainFrame.cpp` — Fix 3

## Test Plan
- [ ] Mixed incompatible material types in mixed-color filament → slice button disabled
- [ ] High/low temp mixing (physical filaments) → slice button disabled + notification shown
- [ ] Bed type mismatch + filament temp compatible → slice button stays disabled (not cleared by sync)
- [ ] Notification persists after background validation re-runs (Fix 2)
- [ ] Normal single-type filaments → slice button enabled
- [ ] Slice All mode skips blocked plates correctly