### PR TITLE
fix: NetworkTestDialog thread-safety crash in multi-threaded network …

### DIFF
--- a/src/slic3r/GUI/NetworkTestDialog.cpp
+++ b/src/slic3r/GUI/NetworkTestDialog.cpp
@@ -1151,13 +1151,21 @@ void NetworkTestDialog::log_section_header(const wxString& title)
 
 void NetworkTestDialog::update_status(int job_id, wxString info)
 {
+	if (m_closing.load())
+		return;
+
+	if (!wxThread::IsMain()) {
+		wxGetApp().CallAfter([weak_this = weak_this, job_id, info]() {
+			if (auto self = weak_this.lock())
+				self->update_status(job_id, info);
+		});
+		return;
+	}
+
 	// Send log to MainFrame for file writing
 	auto log_evt = new wxCommandEvent(EVT_NETWORK_TEST_LOG_UPDATE);
 	log_evt->SetString(info);
 	wxQueueEvent(wxGetApp().mainframe, log_evt);
-
-	if (m_closing.load())
-		return;
 
 	switch (job_id)
 	{


### PR DESCRIPTION
# Description

## Root Cause

The network test dialog crashes frequently when using "Start Test Multi-Thread" mode.

Commit 9cab4ec ("Adds enhanced logging capabilities") removed the original wxQueueEvent mechanism that dispatched UI updates to the main thread, and replaced it with direct wxStaticText::SetLabelText() / wxTextCtrl::AppendText() calls from worker threads. wxWidgets UI controls are not thread-safe — concurrent access from multiple boost::thread instances causes data races and crashes.
