### PR TITLE
fix: guard extruder() call against missing key in filament temp mixing check

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -20792,7 +20792,7 @@ bool Plater::check_filament_temp_mixing(int plate_index)
         if (!model_object_is_on_plate(plate, obj_idx, model_object))
             continue;
         collect_filament_slots_from_model_config(model_object->config, num_filaments, used_slots);
-        if (model_object->config.extruder() == 0)
+        if (!model_object->config.has("extruder") || model_object->config.extruder() == 0)
             uses_default_extruder = true;
         for (const ModelVolume* model_volume : model_object->volumes)
         {


### PR DESCRIPTION
## Summary
- `ModelConfig::extruder()` dereferences a null pointer when the `"extruder"` key is absent from the config
- Add `has("extruder")` guard before the call in `check_filament_temp_mixing()`, treating a missing key as "use default extruder"

## Root Cause
`ed29afecd9` (Feature top cover #504) introduced `check_filament_temp_mixing()`, which calls
`model_object->config.extruder()` on every object on the plate. `ModelObject::config` is a
`DynamicConfig` that makes no guarantee any key exists. Every other of the 23 `extruder()` call
sites in the codebase guards with `has("extruder")` — this was the single omission.

## Fix
[Plater.cpp:20795](src/slic3r/GUI/Plater.cpp#L20795) — one-line change:
`model_object->config.extruder() == 0` → `!model_object->config.has("extruder") || model_object->config.extruder() == 0`

## Test Plan
- [ ] Load a `.3mf` project without extruder config — verify no crash
- [ ] Switch plates — verify high/low temp mixing detection works
- [ ] Add/remove/move objects across plates — verify mixing notification updates correctly