### PR TITLE
fix bridge support and supoort interface, add default value for organic tree.

### DIFF
--- a/resources/profiles/Snapmaker/process/fdm_process_U1_common.json
+++ b/resources/profiles/Snapmaker/process/fdm_process_U1_common.json
@@ -58,6 +58,7 @@
     "support_object_xy_distance": "0.35",
     "tree_support_branch_diameter": "2",
     "tree_support_branch_angle": "45",
+    "tree_support_branch_angle_organic": "45",
     "tree_support_wall_count": "0",
     "top_surface_pattern": "monotonicline",
     "top_surface_acceleration": "2000",


### PR DESCRIPTION
# Description

fix bridge support and supoort interface.

# Root Cause Analysis

Overall, it is because the angle of the tree support was too vertical, and it was trimmed off during detection. (bambu is 45°, orca is 40°)

# solution

Add the default value of tree_support_branch_angle_organic in the config file
