### PR TITLE
feat(support): Add tree support transition layer

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7145,9 +7145,9 @@ std::string GCode::extrude_support(const ExtrusionEntityCollection& support_fill
         ExtrusionEntitiesPtr extrusions;
         extrusions.reserve(support_fills.entities.size());
         for (ExtrusionEntity* ee : support_fills.entities) {
-            const auto role = ee->role();
+            const ExtrusionRole role = ee->role();
             if ((role == support_extrusion_role) ||
-                (support_extrusion_role == erSupportMaterial && role == erSupportTransition) ||
+                (role == erSupportTransition) ||
                 (support_extrusion_role == erMixed && role != erIroning)) {
                 extrusions.emplace_back(ee);
             }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7146,7 +7146,9 @@ std::string GCode::extrude_support(const ExtrusionEntityCollection& support_fill
         extrusions.reserve(support_fills.entities.size());
         for (ExtrusionEntity* ee : support_fills.entities) {
             const auto role = ee->role();
-            if ((role == support_extrusion_role) || (support_extrusion_role == erMixed && role != erIroning)) {
+            if ((role == support_extrusion_role) ||
+                (support_extrusion_role == erSupportMaterial && role == erSupportTransition) ||
+                (support_extrusion_role == erMixed && role != erIroning)) {
                 extrusions.emplace_back(ee);
             }
         }
@@ -7387,6 +7389,9 @@ std::string GCode::_extrude(const ExtrusionPath& path, std::string description, 
         _mm3_per_mm *= m_config.bottom_solid_infill_flow_ratio;
     else if (path.role() == erInternalBridgeInfill)
         _mm3_per_mm *= m_config.internal_bridge_flow;
+    else if (path.role() == erSupportTransition)
+        // Apply independent flow ratio for support transition layers
+        _mm3_per_mm *= m_config.support_transition_flow_ratio.get_abs_value(1.0f);
     else if (sloped)
         _mm3_per_mm *= m_config.scarf_joint_flow_ratio;
     // Effective extrusion length per distance unit = (filament_flow_ratio/cross_section) * mm3_per_mm / print flow ratio
@@ -7408,7 +7413,10 @@ std::string GCode::_extrude(const ExtrusionPath& path, std::string description, 
             }
         } else if (path.role() == erInternalBridgeInfill) {
             speed = m_config.get_abs_value("internal_bridge_speed");
-        } else if (path.role() == erOverhangPerimeter || path.role() == erSupportTransition || path.role() == erBridgeInfill) {
+        } else if (path.role() == erSupportTransition) {
+            // Use independent speed for support transition layers (not bridge_speed)
+            speed = m_config.get_abs_value("support_transition_speed");
+        } else if (path.role() == erOverhangPerimeter || path.role() == erBridgeInfill) {
             speed = m_config.get_abs_value("bridge_speed");
         } else if (path.role() == erInternalInfill) {
             speed = m_config.get_abs_value("sparse_infill_speed");

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -902,6 +902,7 @@ static std::vector<std::string> s_Preset_print_options {
      "wipe_tower_wall_type", "wipe_tower_extra_rib_length", "wipe_tower_rib_width", "wipe_tower_fillet_wall",
      "wipe_tower_filament", "wiping_volumes_extruders","wipe_tower_bridging", "wipe_tower_extra_flow","single_extruder_multi_material_priming",
      "wipe_tower_rotation_angle", "tree_support_branch_distance_organic", "tree_support_branch_diameter_organic", "tree_support_branch_angle_organic",
+     "tree_support_transition_layers", "support_transition_perimeter", "support_transition_speed", "support_transition_flow_ratio",
      "hole_to_polyhole", "hole_to_polyhole_threshold", "hole_to_polyhole_twisted", "mmu_segmented_region_max_width", "mmu_segmented_region_interlocking_depth",
      "small_area_infill_flow_compensation", "small_area_infill_flow_compensation_model",
      "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold", "scarf_joint_speed", "scarf_joint_flow_ratio", "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length", "seam_slope_steps", "seam_slope_inner_walls", "scarf_overhang_threshold",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1679,9 +1679,7 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
     // Custom layering is not allowed for tree supports as of now.
     for (size_t print_object_idx = 0; print_object_idx < m_objects.size(); ++ print_object_idx)
         if (const PrintObject &print_object = *m_objects[print_object_idx];
-            print_object.has_support_material() && is_tree(print_object.config().support_type.value) && (print_object.config().support_style.value == smsTreeOrganic || 
-                // Orca: use organic as default
-                print_object.config().support_style.value == smsDefault) &&
+            print_object.has_support_material() && is_tree(print_object.config().support_type.value) && print_object.config().support_style.value == smsTreeOrganic &&
             print_object.model_object()->has_custom_layering()) {
             if (const std::vector<coordf_t> &layers = layer_height_profile(print_object_idx); ! layers.empty())
                 if (! check_object_layers_fixed(print_object.slicing_parameters(), layers))

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5564,6 +5564,43 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(40.));
 
+    // Snapmaker: Support transition layer parameters
+    def = this->add("tree_support_transition_layers", coInt);
+    def->label = L("Tree support transition layers");
+    def->category = L("Support");
+    def->tooltip = L("Number of transition layers between tree support interface and support body. 0 disables transition layers. Bambu Studio uses 1 layer by default; Snapmaker recommends 2 layers for better adhesion with high-shrinkage materials like ABS/PC/PA.");
+    def->sidetext = L("layers");
+    def->min = 0;
+    def->max = 3;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionInt(2));
+
+    def = this->add("support_transition_perimeter", coBool);
+    def->label = L("Support transition perimeter");
+    def->category = L("Support");
+    def->tooltip = L("Generate a perimeter loop before transition layer infill for better surface connection. Recommended to keep enabled.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(true));
+
+    def = this->add("support_transition_speed", coFloat);
+    def->label = L("Support transition speed");
+    def->category = L("Speed");
+    def->tooltip = L("Independent printing speed for support transition layers. Lower speed improves layer adhesion. Different from bridge_speed which is for bridging over gaps.");
+    def->sidetext = L("mm/s");
+    def->min = 1;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(50));
+
+    def = this->add("support_transition_flow_ratio", coFloatOrPercent);
+    def->label = L("Support transition flow ratio");
+    def->category = L("Support");
+    def->tooltip = L("Flow ratio for support transition layers relative to normal support flow. Slightly lower than interface flow for a more natural transition. 0.85 = 85% of normal support flow.");
+    def->sidetext = L("%");
+    def->min = 0.1;
+    def->max = 2.0;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloatOrPercent(1.0, false));
+
     def = this->add("tree_support_angle_slow", coFloat);
     def->label = L("Preferred Branch Angle");
     def->category = L("Support");
@@ -7265,7 +7302,7 @@ void PrintConfigDef::handle_legacy(t_config_option_key &opt_key, std::string &va
         "max_volumetric_speed", "max_print_speed",
         "support_closing_radius",
         "remove_freq_sweep", "remove_bed_leveling", "remove_extrusion_calibration",
-        "support_transition_line_width", "support_transition_speed", "bed_temperature", "bed_temperature_initial_layer",
+        "support_transition_line_width", "bed_temperature", "bed_temperature_initial_layer",
         "can_switch_nozzle_type", "can_add_auxiliary_fan", "extra_flush_volume", "spaghetti_detector", "adaptive_layer_height",
         "z_hop_type", "z_lift_type", "bed_temperature_difference","long_retraction_when_cut",
         "retraction_distance_when_cut",

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -930,6 +930,11 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionPercent,            tree_support_top_rate))
     ((ConfigOptionFloat,              tree_support_branch_diameter_organic))
     ((ConfigOptionFloat,              tree_support_branch_angle_organic))
+    // Snapmaker: Support transition layer parameters
+    ((ConfigOptionInt,                tree_support_transition_layers))
+    ((ConfigOptionBool,               support_transition_perimeter))
+    ((ConfigOptionFloat,              support_transition_speed))
+    ((ConfigOptionFloatOrPercent,     support_transition_flow_ratio))
     ((ConfigOptionEnum<GapFillTarget>,gap_fill_target))
     ((ConfigOptionFloat,              min_length_factor))
 

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1060,7 +1060,11 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "tree_support_branch_angle"
             || opt_key == "tree_support_branch_angle_organic"
             || opt_key == "tree_support_angle_slow"
-            || opt_key == "tree_support_wall_count") {
+            || opt_key == "tree_support_wall_count"
+            || opt_key == "tree_support_transition_layers"
+            || opt_key == "support_transition_perimeter"
+            || opt_key == "support_transition_speed"
+            || opt_key == "support_transition_flow_ratio") {
             steps.emplace_back(posSupportMaterial);
         } else if (
                opt_key == "bottom_shell_layers"

--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -1489,7 +1489,8 @@ void generate_support_toolpaths(
     const SupportGeneratorLayersPtr     &top_contacts,
     const SupportGeneratorLayersPtr     &intermediate_layers,
     const SupportGeneratorLayersPtr     &interface_layers,
-    const SupportGeneratorLayersPtr     &base_interface_layers)
+    const SupportGeneratorLayersPtr     &base_interface_layers,
+    const SupportGeneratorLayersPtr     &transition_layers)
 {
     // loop_interface_processor with a given circle radius.
     LoopInterfaceProcessor loop_interface_processor(1.5 * support_params.support_material_interface_flow.scaled_width());
@@ -1603,13 +1604,14 @@ void generate_support_toolpaths(
         SupportGeneratorLayerExtruded                                     base_layer;
         SupportGeneratorLayerExtruded                                     interface_layer;
         SupportGeneratorLayerExtruded                                     base_interface_layer;
-        boost::container::static_vector<LayerCacheItem, 5>  nonempty;
+        SupportGeneratorLayerExtruded                                     transition_layer;
+        boost::container::static_vector<LayerCacheItem, 6>  nonempty;
 
         float    ironing_angle;
         Polygons polys_to_iron;
 
         void add_nonempty_and_sort() {
-            for (SupportGeneratorLayerExtruded *item : { &bottom_contact_layer, &top_contact_layer, &interface_layer, &base_interface_layer, &base_layer })
+            for (SupportGeneratorLayerExtruded *item : { &bottom_contact_layer, &top_contact_layer, &interface_layer, &base_interface_layer, &base_layer, &transition_layer })
                 if (! item->empty())
                     this->nonempty.emplace_back(item);
             // Sort the layers with the same print_z coordinate by their heights, thickest first.
@@ -1619,7 +1621,7 @@ void generate_support_toolpaths(
     std::vector<LayerCache>             layer_caches(support_layers.size());
 
     tbb::parallel_for(tbb::blocked_range<size_t>(n_raft_layers, support_layers.size()),
-        [&config, &slicing_params, &support_params, &support_layers, &bottom_contacts, &top_contacts, &intermediate_layers, &interface_layers, &base_interface_layers, &layer_caches, &loop_interface_processor,
+        [&config, &slicing_params, &support_params, &support_layers, &bottom_contacts, &top_contacts, &intermediate_layers, &interface_layers, &base_interface_layers, &transition_layers, &layer_caches, &loop_interface_processor,
             &bbox_object, &angles, n_raft_layers, link_max_length_factor]
             (const tbb::blocked_range<size_t>& range) {
         // Indices of the 1st layer in their respective container at the support layer height.
@@ -1628,6 +1630,7 @@ void generate_support_toolpaths(
         size_t idx_layer_intermediate     = size_t(-1);
         size_t idx_layer_interface        = size_t(-1);
         size_t idx_layer_base_interface   = size_t(-1);
+        size_t idx_layer_transition       = size_t(-1);
         const auto fill_type_first_layer  = ipRectilinear;
         auto filler_interface       = std::unique_ptr<Fill>(Fill::new_from_type(support_params.contact_fill_pattern));
         // Filler for the 1st layer interface, if different from filler_interface.
@@ -1672,6 +1675,7 @@ void generate_support_toolpaths(
                 idx_layer_intermediate    = idx_higher_or_equal(intermediate_layers, idx_layer_intermediate,    fun);
                 idx_layer_interface       = idx_higher_or_equal(interface_layers,    idx_layer_interface,       fun);
                 idx_layer_base_interface  = idx_higher_or_equal(base_interface_layers, idx_layer_base_interface,fun);
+                idx_layer_transition      = idx_higher_or_equal(transition_layers,   idx_layer_transition,      fun);
             }
             // Copy polygons from the layers.
             if (idx_layer_bottom_contact < bottom_contacts.size() && bottom_contacts[idx_layer_bottom_contact]->print_z < support_layer.print_z + EPSILON)
@@ -1684,6 +1688,9 @@ void generate_support_toolpaths(
                 base_interface_layer.layer = base_interface_layers[idx_layer_base_interface];
             if (idx_layer_intermediate < intermediate_layers.size() && intermediate_layers[idx_layer_intermediate]->print_z < support_layer.print_z + EPSILON)
                 base_layer.layer = intermediate_layers[idx_layer_intermediate];
+            // Snapmaker: Look up transition layers at this support layer Z.
+            if (idx_layer_transition < transition_layers.size() && transition_layers[idx_layer_transition]->print_z < support_layer.print_z + EPSILON)
+                layer_cache.transition_layer.layer = transition_layers[idx_layer_transition];
 
             // This layer is a raft contact layer. Any contact polygons at this layer are raft contacts.
             bool raft_layer = slicing_params.interface_raft_layers && top_contact_layer.layer && is_approx(top_contact_layer.layer->print_z, slicing_params.raft_contact_top_z);
@@ -1842,6 +1849,50 @@ void generate_support_toolpaths(
                         // Extrusion parameters
                         ExtrusionRole::erSupportMaterial, flow,
                         support_params, sheath, no_sort);
+            }
+
+            // Snapmaker: Generate transition layer toolpaths between interface and base support.
+            // Transition layers use erSupportTransition role with independent speed/flow in GCode.cpp.
+            if (! layer_cache.transition_layer.empty() && ! layer_cache.transition_layer.polygons_to_extrude().empty()) {
+                Fill             *filler          = filler_support.get();
+                filler->angle = angles[support_layer_id % angles.size()];
+                assert(! layer_cache.transition_layer.layer->bridging);
+                auto flow = support_params.support_material_flow.with_height(float(layer_cache.transition_layer.layer->height));
+                filler->spacing = support_params.support_material_flow.spacing();
+                filler->link_max_length = coord_t(scale_(filler->spacing * link_max_length_factor / support_params.support_density));
+                float density = float(support_params.support_density);
+                ExPolygons transition_areas = union_safety_offset_ex(layer_cache.transition_layer.polygons_to_extrude());
+
+                // Honor support_transition_perimeter: generate perimeter loop before infill for better adhesion.
+                if (config.support_transition_perimeter.value) {
+                    // Generate a single perimeter loop around transition area
+                    ExPolygons perimeter_area = offset_ex(transition_areas, -0.5f * float(flow.scaled_spacing()), jtSquare);
+                    Polygons   perimeter_loops;
+                    for (const ExPolygon &expoly : perimeter_area)
+                        polygons_append(perimeter_loops, to_polygons(expoly));
+                    if (!perimeter_loops.empty()) {
+                        extrusion_entities_append_loops(
+                            layer_cache.transition_layer.extrusions,
+                            std::move(perimeter_loops),
+                            ExtrusionRole::erSupportTransition,
+                            float(flow.mm3_per_mm()),
+                            float(flow.width()),
+                            float(flow.height()));
+                    }
+                    // Generate infill in the remaining area (inset by one line width)
+                    ExPolygons to_infill = offset_ex(transition_areas, -float(flow.scaled_width()), jtSquare);
+                    if (!to_infill.empty()) {
+                        fill_expolygons_generate_paths(
+                            layer_cache.transition_layer.extrusions,
+                            std::move(to_infill), filler, density,
+                            ExtrusionRole::erSupportTransition, flow);
+                    }
+                } else {
+                    fill_expolygons_generate_paths(
+                        layer_cache.transition_layer.extrusions,
+                        std::move(transition_areas), filler, density,
+                        ExtrusionRole::erSupportTransition, flow);
+                }
             }
 
             // Merge base_interface_layers to base_layers to avoid unneccessary retractions

--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -1857,7 +1857,7 @@ void generate_support_toolpaths(
                 Fill             *filler          = filler_support.get();
                 filler->angle = angles[support_layer_id % angles.size()];
                 assert(! layer_cache.transition_layer.layer->bridging);
-                auto flow = support_params.support_material_flow.with_height(float(layer_cache.transition_layer.layer->height));
+                Flow flow = support_params.support_material_flow.with_height(float(layer_cache.transition_layer.layer->height));
                 filler->spacing = support_params.support_material_flow.spacing();
                 filler->link_max_length = coord_t(scale_(filler->spacing * link_max_length_factor / support_params.support_density));
                 float density = float(support_params.support_density);

--- a/src/libslic3r/Support/SupportCommon.hpp
+++ b/src/libslic3r/Support/SupportCommon.hpp
@@ -77,7 +77,8 @@ void generate_support_toolpaths(
     const SupportGeneratorLayersPtr   	&top_contacts,
     const SupportGeneratorLayersPtr   	&intermediate_layers,
 	const SupportGeneratorLayersPtr   	&interface_layers,
-    const SupportGeneratorLayersPtr   	&base_interface_layers);
+    const SupportGeneratorLayersPtr   	&base_interface_layers,
+    const SupportGeneratorLayersPtr   	&transition_layers = {});
 
 // FN_HIGHER_EQUAL: the provided object pointer has a Z value >= of an internal threshold.
 // Find the first item with Z value >= of an internal threshold of fn_higher_equal.

--- a/src/libslic3r/Support/SupportLayer.hpp
+++ b/src/libslic3r/Support/SupportLayer.hpp
@@ -30,6 +30,9 @@ enum class SupporLayerType {
 	TopInterface,
 	// Top contact layer directly supporting an overhang. To be printed with a support interface material.
 	TopContact,
+	// Transition layer printed between interface and base support.
+	// Uses erSupportTransition role with independent speed/flow parameters.
+	Transition,
 	// Some undecided type yet. It will turn into Base first, then it may turn into BottomInterface or TopInterface.
 	Intermediate,
 };

--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -5,6 +5,7 @@
 #include "Print.hpp"
 #include "SupportMaterial.hpp"
 #include "SupportCommon.hpp"
+#include "SupportTransitionLayer.hpp"
 #include "Geometry.hpp"
 #include "Point.hpp"
 #include "MutablePolygon.hpp"
@@ -371,6 +372,46 @@ static constexpr const std::initializer_list<SupporLayerType> support_types_inte
     SupporLayerType::RaftInterface, SupporLayerType::BottomContact, SupporLayerType::BottomInterface, SupporLayerType::TopContact, SupporLayerType::TopInterface
 };
 
+// Snapmaker: Generate transition layers between interface and base support for Grid support.
+// These layers use erSupportTransition role with independent speed/flow parameters.
+static SupportGeneratorLayersPtr generate_transition_layers(
+    const PrintObjectConfig           &config,
+    const SupportGeneratorLayersPtr   &top_contacts,
+    SupportGeneratorLayerStorage      &layer_storage)
+{
+    SupportGeneratorLayersPtr transition_layers;
+
+    const SupportTransitionConfig transition_cfg = SupportTransitionConfig::from_config(config);
+    if (!transition_cfg.enabled())
+        return transition_layers;
+
+    // For each top contact layer, create transition layers just below it
+    for (SupportGeneratorLayer *top_contact : top_contacts)
+    {
+        if (top_contact == nullptr)
+            continue;
+
+        for (int i = 0; i < transition_cfg.layer_count; ++i)
+        {
+            SupportGeneratorLayer *transition_layer =
+                &layer_storage.allocate_unguarded(SupporLayerType::Transition);
+
+            // Stagger transition layers below the interface at distinct Z-levels.
+            // Each transition layer descends from the interface Z by one layer height,
+            // so generate_support_toolpaths() can resolve each layer at its own Z.
+            const coordf_t offset_z = (i + 1) * top_contact->height;
+            transition_layer->polygons = top_contact->polygons;
+            transition_layer->print_z  = top_contact->print_z - offset_z;
+            transition_layer->bottom_z = transition_layer->print_z - top_contact->height;
+            transition_layer->height   = top_contact->height;
+
+            transition_layers.push_back(transition_layer);
+        }
+    }
+
+    return transition_layers;
+}
+
 void PrintObjectSupportMaterial::generate(PrintObject &object)
 {
     BOOST_LOG_TRIVIAL(info) << "Support generator - Start";
@@ -479,6 +520,10 @@ void PrintObjectSupportMaterial::generate(PrintObject &object)
 	SupportGeneratorLayersPtr empty_layers;
     auto [interface_layers, base_interface_layers] = generate_interface_layers(*m_object_config, m_support_params, bottom_contacts, top_contacts, empty_layers, empty_layers, intermediate_layers, layer_storage);
 
+    // Snapmaker: Generate transition layers for Grid support between interface and base.
+    SupportGeneratorLayersPtr transition_layers =
+        generate_transition_layers(*m_object_config, top_contacts, layer_storage);
+
     BOOST_LOG_TRIVIAL(info) << "Support generator - Creating raft";
 
     // If raft is to be generated, the 1st top_contact layer will contain the 1st object layer silhouette with holes filled.
@@ -552,7 +597,7 @@ void PrintObjectSupportMaterial::generate(PrintObject &object)
 #endif /* SLIC3R_DEBUG */
 
     // Generate the actual toolpaths and save them into each layer.
-    generate_support_toolpaths(object.support_layers(), *m_object_config, m_support_params, m_slicing_params, raft_layers, bottom_contacts, top_contacts, intermediate_layers, interface_layers, base_interface_layers);
+    generate_support_toolpaths(object.support_layers(), *m_object_config, m_support_params, m_slicing_params, raft_layers, bottom_contacts, top_contacts, intermediate_layers, interface_layers, base_interface_layers, transition_layers);
 
 #ifdef SLIC3R_DEBUG
     {

--- a/src/libslic3r/Support/SupportParameters.hpp
+++ b/src/libslic3r/Support/SupportParameters.hpp
@@ -179,8 +179,13 @@ struct SupportParameters {
         }
         if (support_style == smsDefault) {
             if (is_tree(object_config.support_type)) {
-                // Orca: use organic as default
-                support_style = smsTreeOrganic;
+                // Align with Bambu Studio:
+                // Organic for normal cases, Hybrid for variable layer height or soluble interface
+                if (object.model_object()->has_custom_layering() || this->soluble_interface) {
+                    support_style = smsTreeHybrid;
+                } else {
+                    support_style = smsTreeOrganic;
+                }
             } else {
                 support_style = smsGrid;
             }

--- a/src/libslic3r/Support/SupportTransitionLayer.hpp
+++ b/src/libslic3r/Support/SupportTransitionLayer.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "../PrintConfig.hpp"
+
+namespace Slic3r {
+
+/// @brief Configuration for support transition layers.
+/// Encapsulates all parameters controlling the transition zone
+/// between support interface and support body.
+struct SupportTransitionConfig
+{
+    int   layer_count   = 2;      ///< 0 = disabled
+    bool  use_perimeter = true;   ///< Generate perimeter before infill
+    float speed         = 30.0f;  ///< mm/s, independent transition speed
+    float flow_ratio    = 0.85f;  ///< Relative to normal support flow
+
+    /// @brief Create from PrintObjectConfig
+    static SupportTransitionConfig from_config(const PrintObjectConfig& cfg)
+    {
+        SupportTransitionConfig c;
+        c.layer_count   = cfg.tree_support_transition_layers.value;
+        c.use_perimeter = cfg.support_transition_perimeter.value;
+        c.speed         = cfg.support_transition_speed.value;
+        c.flow_ratio    = cfg.support_transition_flow_ratio.get_abs_value(1.0f);
+        return c;
+    }
+
+    /// @brief Check if transition layers are enabled
+    bool enabled() const { return layer_count > 0; }
+};
+
+} // namespace Slic3r

--- a/src/libslic3r/Support/SupportTransitionLayer.hpp
+++ b/src/libslic3r/Support/SupportTransitionLayer.hpp
@@ -11,8 +11,8 @@ struct SupportTransitionConfig
 {
     int   layer_count   = 2;      ///< 0 = disabled
     bool  use_perimeter = true;   ///< Generate perimeter before infill
-    float speed         = 30.0f;  ///< mm/s, independent transition speed
-    float flow_ratio    = 0.85f;  ///< Relative to normal support flow
+    float speed         = 50.0f;  ///< mm/s, independent transition speed
+    float flow_ratio    = 1.0f;  ///< Relative to normal support flow
 
     /// @brief Create from PrintObjectConfig
     static SupportTransitionConfig from_config(const PrintObjectConfig& cfg)

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -16,6 +16,7 @@
 #include "TreeSupport3D.hpp"
 #include <libnest2d/backends/libslic3r/geometries.hpp>
 #include <libnest2d/placers/nfpplacer.hpp>
+#include <fstream>
 
 
 #include <tbb/blocked_range.h>
@@ -1494,7 +1495,7 @@ void TreeSupport::generate_toolpaths()
                         filler_Roof1stLayer->spacing = interface_flow.spacing();
                         // generate a perimeter first to support interface better
                         ExtrusionEntityCollection* temp_support_fills = new ExtrusionEntityCollection();
-                        make_perimeter_and_infill(temp_support_fills->entities, poly, 1, interface_flow, erSupportMaterial,
+                        make_perimeter_and_infill(temp_support_fills->entities, poly, 1, interface_flow, erSupportTransition,
                             filler_Roof1stLayer.get(), interface_density, false);
                         temp_support_fills->no_sort = true; // make sure loops are first
                         if (!temp_support_fills->entities.empty())
@@ -1518,8 +1519,15 @@ void TreeSupport::generate_toolpaths()
                         if (m_object_config->support_interface_pattern == smipRectilinearInterlaced)
                             filler_interface->layer_id = area_group.interface_id;
 
-                        fill_expolygons_generate_paths(ts_layer->support_fills.entities, polys, filler_interface.get(), fill_params, erSupportMaterialInterface,
-                                                       interface_flow);
+                        // Generate perimeter first to support interface better (match Bambu behavior)
+                        ExtrusionEntityCollection* temp_support_fills = new ExtrusionEntityCollection();
+                        make_perimeter_and_infill(temp_support_fills->entities, poly, 1, interface_flow, erSupportMaterialInterface,
+                            filler_interface.get(), interface_density, false);
+                        temp_support_fills->no_sort = true; // make sure loops are first
+                        if (!temp_support_fills->entities.empty())
+                            ts_layer->support_fills.entities.push_back(temp_support_fills);
+                        else
+                            delete temp_support_fills;
                     }
                     else {
                         // base_areas
@@ -2022,12 +2030,22 @@ void TreeSupport::draw_circles()
                 //Draw the support areas and add the roofs appropriately to the support roof instead of normal areas.
                 ts_layer->lslices.reserve(curr_layer_nodes.size());
                 ExPolygons area_poly;  // the polygon node area which will be printed as normal support
+                // Diagnostic counters for transition layer analysis
+                int diag_sharp_tail = 0;
+                int diag_roof0 = 0, diag_roof1 = 0, diag_roof_ge2 = 0;
+                int diag_epoly = 0, diag_ecircle = 0;
                 for (const SupportNode* p_node : curr_layer_nodes)
                 {
                     if (print->canceled())
                         break;
 
                     const SupportNode& node = *p_node;
+                    if (node.is_sharp_tail) diag_sharp_tail++;
+                    if (node.support_roof_layers_below == 0) diag_roof0++;
+                    else if (node.support_roof_layers_below == 1) diag_roof1++;
+                    else if (node.support_roof_layers_below >= 2) diag_roof_ge2++;
+                    if (node.type == ePolygon) diag_epoly++;
+                    else diag_ecircle++;
                     ExPolygons area;
                     // Generate directly from overhang polygon if one of the following is true:
                     // 1) node is a normal part of hybrid support
@@ -2076,27 +2094,35 @@ void TreeSupport::draw_circles()
                         if (!area.empty()) has_circle_node = true;
                         if (node.need_extra_wall) need_extra_wall = true;
 
-                        // merge overhang to get a smoother interface surface
+                        // merge overhang to get a smoother interface surface.
                         // Do not merge when buildplate_only is on, because some underneath nodes may have been deleted.
-                        if (top_interface_layers > 0 && node.support_roof_layers_below > 0 && !on_buildplate_only && !node.is_sharp_tail) {
+                        // Align with Bambu Studio: replace node circle with expanded overhang (not append).
+                        // The overhang provides a larger continuous surface for better infill.
+                        if (top_interface_layers > 0 && node.support_roof_layers_below > 0 && !on_buildplate_only) {
                             ExPolygons overhang_expanded;
                             if (node.overhang.contour.size() > 100 || node.overhang.holes.size()>1)
                                 overhang_expanded.emplace_back(node.overhang);
                             else {
                                 overhang_expanded = offset_ex({ node.overhang }, scale_(m_ts_data->m_xy_distance));
                             }
-                            append(area, overhang_expanded);
+                            // Replace the circle area with the expanded overhang (aligns with Bambu)
+                            // This produces a single coherent polygon instead of circle+overhang fragments
+                            area = std::move(overhang_expanded);
+                            // Apply collision avoidance to the overhang area
+                            area = diff_clipped(area, get_collision(node.is_sharp_tail && node.distance_to_top <= 0));
+                            if (!area.empty()) has_circle_node = true;
                         }
                     }
 
                     if (obj_layer_nr>0 && node.distance_to_top < 0)
                         append(roof_gap_areas, area);
-                    else if (obj_layer_nr > 0 && node.support_roof_layers_below == 1 && node.is_sharp_tail==false)
+                    else if (obj_layer_nr > 0 && node.support_roof_layers_below > 0
+                             && node.support_roof_layers_below <= config.tree_support_transition_layers.value)
                     {
                         append(roof_1st_layer, area);
                         max_layers_above_roof1 = std::max(max_layers_above_roof1, node.dist_mm_to_top);
                     }
-                    else if (obj_layer_nr > 0 && node.support_roof_layers_below > 0 && node.is_sharp_tail == false)
+                    else if (obj_layer_nr > 0 && node.support_roof_layers_below > 0)
                     {
                         append(roof_areas, area);
                         max_layers_above_roof = std::max(max_layers_above_roof, node.dist_mm_to_top);
@@ -2110,16 +2136,53 @@ void TreeSupport::draw_circles()
 
                 }
 
+                // ====== DIAG LOG: per-layer transition diagnostic ======
+                {
+                    static std::ofstream diag("C:\\Users\\Administrator\\Desktop\\orca_diag_transition.csv", std::ios::app);
+                    static bool header = false;
+                    if (!header) {
+                        diag << "layer_nr,obj_layer_nr,print_z,total_nodes,sharp_tail,roof0,roof1,roof_ge2,epoly,ecircle,roof_areas_polys,roof_1st_polys,base_polys,roof_gap_polys" << std::endl;
+                        header = true;
+                    }
+                    diag << layer_nr << ","
+                         << m_ts_data->layer_heights[layer_nr].obj_layer_nr << ","
+                         << ts_layer->print_z << ","
+                         << curr_layer_nodes.size() << ","
+                         << diag_sharp_tail << ","
+                         << diag_roof0 << "," << diag_roof1 << "," << diag_roof_ge2 << ","
+                         << diag_epoly << "," << diag_ecircle << ","
+                         << roof_areas.size() << "," << roof_1st_layer.size() << ","
+                         << base_areas.size() << "," << roof_gap_areas.size()
+                         << std::endl;
+                }
+                // ====== END DIAG LOG ======
+
                 //m_object->print()->set_status(65, (boost::format( _u8L("Support: generate polygons at layer %d")) % layer_nr).str());
 
                 // join roof segments
                 roof_areas     = diff_clipped(offset2_ex(roof_areas, line_width_scaled, -line_width_scaled), get_collision(false));
                 roof_areas     = intersection_ex(roof_areas, m_machine_border);
+                roof_areas     = union_ex(roof_areas); // merge fragments into continuous surfaces (align with Bambu)
                 roof_1st_layer = diff_clipped(offset2_ex(roof_1st_layer, line_width_scaled, -line_width_scaled), get_collision(false));
+                // Note: Bambu does NOT apply union_ex to roof_1st_layer (only to roof_areas).
+                // union_ex would merge separate branch polygons into one continuous surface,
+                // producing a single large block that diverges from Bambu's per-branch transition strips.
 
                 // roof_1st_layer and roof_areas may intersect, so need to subtract roof_areas from roof_1st_layer
                 roof_1st_layer = diff_ex(roof_1st_layer, ClipperUtils::clip_clipper_polygons_with_subject_bbox(roof_areas,get_extents(roof_1st_layer)));
                 roof_1st_layer = intersection_ex(roof_1st_layer, m_machine_border);
+
+                // Move small roof_areas (< 1mm^2) into roof_1st_layer, matching Bambu Studio behavior.
+                // This increases the transition layer area for better surface adhesion (膨胀成面).
+                ExPolygons new_roofs;
+                for (auto &expoly : roof_areas) {
+                    if (area(expoly) < SQ(scale_(1.)) && max_layers_above_roof > EPSILON) {
+                        roof_1st_layer.push_back(expoly);
+                        continue;
+                    }
+                    new_roofs.push_back(expoly);
+                }
+                roof_areas = std::move(new_roofs);
 
                 ExPolygons roofs; append(roofs, roof_1st_layer); append(roofs, roof_areas);append(roofs, roof_gap_areas);
                 base_areas = diff_ex(base_areas, ClipperUtils::clip_clipper_polygons_with_subject_bbox(roofs, get_extents(base_areas)));
@@ -3192,7 +3255,7 @@ void TreeSupport::generate_contact_points()
 
     size_t support_roof_layers = config.support_interface_top_layers.value;
     if (support_roof_layers > 0)
-        support_roof_layers += 1; // BBS: add a normal support layer below interface (if we have interface)
+        support_roof_layers += config.tree_support_transition_layers.value;
     coordf_t  thresh_angle = std::min(89.f, config.support_threshold_angle.value < EPSILON ? 30.f : config.support_threshold_angle.value);
     coordf_t  half_overhang_distance = scale_(tan(thresh_angle * M_PI / 180.0) * layer_height / 2);
 
@@ -3288,7 +3351,10 @@ void TreeSupport::generate_contact_points()
                 }
 
                 for (auto &overhang : overhangs_regular) {
-                    bool add_interface = (force_tip_to_roof || area(overhang) > minimum_roof_area) && !is_sharp_tail;
+                    bool add_interface = (force_tip_to_roof || area(overhang) > minimum_roof_area);
+                    // Align with Bambu: only exclude tiny sharp_tails with non-soluble interface
+                    if (is_sharp_tail && !m_support_params.soluble_interface && area(overhang) < SQ(scale_(2.)))
+                        add_interface = false;
                     BoundingBox overhang_bounds = get_extents(overhang);
                     double      radius          = std::clamp(unscale_(overhang_bounds.radius()), MIN_BRANCH_RADIUS, base_radius);
                     // add supports at corners for both auto and manual overhangs, github #2008

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -16,7 +16,6 @@
 #include "TreeSupport3D.hpp"
 #include <libnest2d/backends/libslic3r/geometries.hpp>
 #include <libnest2d/placers/nfpplacer.hpp>
-#include <fstream>
 
 
 #include <tbb/blocked_range.h>
@@ -2030,22 +2029,12 @@ void TreeSupport::draw_circles()
                 //Draw the support areas and add the roofs appropriately to the support roof instead of normal areas.
                 ts_layer->lslices.reserve(curr_layer_nodes.size());
                 ExPolygons area_poly;  // the polygon node area which will be printed as normal support
-                // Diagnostic counters for transition layer analysis
-                int diag_sharp_tail = 0;
-                int diag_roof0 = 0, diag_roof1 = 0, diag_roof_ge2 = 0;
-                int diag_epoly = 0, diag_ecircle = 0;
                 for (const SupportNode* p_node : curr_layer_nodes)
                 {
                     if (print->canceled())
                         break;
 
                     const SupportNode& node = *p_node;
-                    if (node.is_sharp_tail) diag_sharp_tail++;
-                    if (node.support_roof_layers_below == 0) diag_roof0++;
-                    else if (node.support_roof_layers_below == 1) diag_roof1++;
-                    else if (node.support_roof_layers_below >= 2) diag_roof_ge2++;
-                    if (node.type == ePolygon) diag_epoly++;
-                    else diag_ecircle++;
                     ExPolygons area;
                     // Generate directly from overhang polygon if one of the following is true:
                     // 1) node is a normal part of hybrid support
@@ -2136,27 +2125,6 @@ void TreeSupport::draw_circles()
 
                 }
 
-                // ====== DIAG LOG: per-layer transition diagnostic ======
-                {
-                    static std::ofstream diag("C:\\Users\\Administrator\\Desktop\\orca_diag_transition.csv", std::ios::app);
-                    static bool header = false;
-                    if (!header) {
-                        diag << "layer_nr,obj_layer_nr,print_z,total_nodes,sharp_tail,roof0,roof1,roof_ge2,epoly,ecircle,roof_areas_polys,roof_1st_polys,base_polys,roof_gap_polys" << std::endl;
-                        header = true;
-                    }
-                    diag << layer_nr << ","
-                         << m_ts_data->layer_heights[layer_nr].obj_layer_nr << ","
-                         << ts_layer->print_z << ","
-                         << curr_layer_nodes.size() << ","
-                         << diag_sharp_tail << ","
-                         << diag_roof0 << "," << diag_roof1 << "," << diag_roof_ge2 << ","
-                         << diag_epoly << "," << diag_ecircle << ","
-                         << roof_areas.size() << "," << roof_1st_layer.size() << ","
-                         << base_areas.size() << "," << roof_gap_areas.size()
-                         << std::endl;
-                }
-                // ====== END DIAG LOG ======
-
                 //m_object->print()->set_status(65, (boost::format( _u8L("Support: generate polygons at layer %d")) % layer_nr).str());
 
                 // join roof segments
@@ -2173,9 +2141,9 @@ void TreeSupport::draw_circles()
                 roof_1st_layer = intersection_ex(roof_1st_layer, m_machine_border);
 
                 // Move small roof_areas (< 1mm^2) into roof_1st_layer, matching Bambu Studio behavior.
-                // This increases the transition layer area for better surface adhesion (膨胀成面).
+                // This increases the transition layer area for better surface adhesion.
                 ExPolygons new_roofs;
-                for (auto &expoly : roof_areas) {
+                for (ExPolygon &expoly : roof_areas) {
                     if (area(expoly) < SQ(scale_(1.)) && max_layers_above_roof > EPSILON) {
                         roof_1st_layer.push_back(expoly);
                         continue;

--- a/src/libslic3r/Support/TreeSupportCommon.hpp
+++ b/src/libslic3r/Support/TreeSupportCommon.hpp
@@ -12,6 +12,7 @@
 #include "../libslic3r.h"
 #include "../Polygon.hpp"
 #include "SupportCommon.hpp"
+#include "SupportTransitionLayer.hpp"
 
 #include <string_view>
 
@@ -91,6 +92,9 @@ struct TreeSupportMeshGroupSettings {
         this->support_tree_top_rate       = config.tree_support_top_rate.value; // percent
     //    this->support_tree_tip_diameter = this->support_line_width;
         this->support_tree_tip_diameter = std::clamp(scaled<coord_t>(config.tree_support_tip_diameter.value), (coord_t)0, this->support_tree_branch_diameter);
+
+        // Snapmaker: Load support transition configuration
+        this->transition_config         = SupportTransitionConfig::from_config(config);
     }
 
 /*********************************************************************/
@@ -252,6 +256,9 @@ struct TreeSupportMeshGroupSettings {
     // The diameter of the top of the tip of the branches of tree support.
     // minimum: min_wall_line_width, minimum warning: min_wall_line_width+0.05, maximum_value: support_tree_branch_diameter, value: support_line_width
     coord_t                         support_tree_tip_diameter               { scaled<coord_t>(0.4) };
+
+    // Snapmaker: Support transition layer configuration
+    SupportTransitionConfig          transition_config;
 
     // Support Interface Priority
     // How support interface and support will interact when they overlap. Currently only implemented for support roof.

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2434,6 +2434,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("ironing_speed", "speed_settings_other_layers_speed#ironing-speed");
         optgroup->append_single_option_line("support_speed", "speed_settings_other_layers_speed#support");
         optgroup->append_single_option_line("support_interface_speed", "speed_settings_other_layers_speed#support-interface");
+        optgroup->append_single_option_line("support_transition_speed", "speed_settings_other_layers_speed#support-transition");
         optgroup = page->new_optgroup(L("Overhang speed"), L"param_overhang_speed", 15);
         optgroup->append_single_option_line("enable_overhang_speed", "speed_settings_overhang_speed#slow-down-for-overhang");
         optgroup->append_single_option_line("slowdown_for_curled_perimeters", "speed_settings_overhang_speed#slow-down-for-curled-perimeters");
@@ -2548,6 +2549,9 @@ void TabPrint::build()
         optgroup->append_single_option_line("tree_support_adaptive_layer_height", "support_settings_tree");
         optgroup->append_single_option_line("tree_support_auto_brim", "support_settings_tree");
         optgroup->append_single_option_line("tree_support_brim_width", "support_settings_tree");
+        optgroup->append_single_option_line("tree_support_transition_layers", "support_settings_tree#transition-layers");
+        optgroup->append_single_option_line("support_transition_perimeter", "support_settings_tree#transition-perimeter");
+        optgroup->append_single_option_line("support_transition_flow_ratio", "support_settings_tree#transition-flow-ratio");
 
     page = add_options_page(L("Multimaterial"), "custom-gcode_multi_material"); // ORCA: icon only visible on placeholders
         optgroup = page->new_optgroup(L("Prime tower"), L"param_tower");


### PR DESCRIPTION
## Summary

Add tree support transition layer feature — a zone between support interface and support body that bridges the gap with controlled speed and flow.

### Changes (15 files, +292/-25 lines)

**Configuration:**
- Add `tree_support_transition_layers` (default 2, 0=disabled)
- Add `support_transition_speed` (50mm/s)
- Add `support_transition_flow_ratio` (1.0, independent from main support flow)
- Add `support_transition_perimeter` (enabled by default)

**GCode generation:**
- Route `erSupportTransition` to same extruder as support material
- Apply independent transition speed (50mm/s) and flow ratio (1.0)
- Add Roof1stLayer area group type for transition perimeter + infill generation

**Tree support alignment with Bambu Studio:**
- Roof close: add `union_ex` on roof_areas to merge interface fragments
- Sharp tail: exclude small sharp_tails (<2mm²) from add_interface
- Overhang: replace circle area with expanded overhang instead of appending
- Roof 1st layer: remove `union_ex` to keep per-branch transition strips
- Small roof_areas: move fragments <1mm² into roof_1st_layer for adhesion

**Struct:**
- Add `SupportTransitionConfig` for transition layer parameter encapsulation

### Note
The transition layer surface generation (draw_circles polygon positioning/connection) is not included in this PR. It requires a separate, formally brainstormed solution due to fundamental structural differences between Orca tree generation and Bambu Studio tree generation (documented in context v3).