### PR TITLE
docs: fix Snapmaker Orca license attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Orca Slicer's logo is designed by community member Justin Levine(@freejstnalxndr
 
 
 # License
-Snapmaker Orca is licensed under the GNU Affero General Public License, version 3. Orca Slicer is based on Snapmaker_Orca by SoftFever
+Snapmaker Orca is licensed under the GNU Affero General Public License, version 3. Snapmaker_Orca is based on Orca Slicer by SoftFever
 
 Orca Slicer is licensed under the GNU Affero General Public License, version 3. Orca Slicer is based on Bambu Studio by BambuLab.
 


### PR DESCRIPTION
## Summary
- Correct the license attribution line in `README.md` to match the relationship described in #553.

Fixes #553.

## Validation
- Ran `git diff --check`.
- Verified the final diff is one README line: 1 insertion and 1 deletion.