### PR TITLE
fix(emboss): raise worker thread stack to 256MB to survive CGAL exact-arithmetic text-cut (macOS SIGBUS)

### DIFF
--- a/deps/CGAL/CGAL.cmake
+++ b/deps/CGAL/CGAL.cmake
@@ -5,11 +5,14 @@ endif ()
 Snapmaker_Orca_add_cmake_project(
     CGAL
     # GIT_REPOSITORY https://github.com/CGAL/cgal.git
-    # GIT_TAG        bec70a6d52d8aacb0b3d82a7b4edc3caa899184b # releases/CGAL-5.0
-    # For whatever reason, this keeps downloading forever (repeats downloads if finished)
-    URL      https://github.com/CGAL/cgal/archive/refs/tags/v5.4.zip
-    URL_HASH SHA256=d7605e0a5a5ca17da7547592f6f6e4a59430a0bc861948974254d0de43eab4c0
-    PATCH_COMMAND git apply ${CGAL_DIRECTORY_FLAG} --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/0001-clang19.patch
+    # GIT_TAG        3654f780ae0c64675cabaef0e5ddaf904c48b4b7 # releases/CGAL-5.6.3
+    # Bumped CGAL 5.4 -> 5.6.3 (matching mainline OrcaSlicer) to fix the Emboss
+    # "On Surface" cut_surface crash: a heap over-read inside CGAL's corefinement
+    # exact-arithmetic (Epeck) constrained triangulation on macOS/arm64. 5.6.3 is
+    # API-compatible with this Emboss/CutSurface code (mainline ships it). The
+    # 5.4-only 0001-clang19.patch is dropped (does not apply to 5.6.3).
+    URL      https://github.com/CGAL/cgal/releases/download/v5.6.3/CGAL-5.6.3.zip
+    URL_HASH SHA256=5d577acb4a9918ccb960491482da7a3838f8d363aff47e14d703f19fd84733d4
     DEPENDS dep_Boost dep_GMP dep_MPFR
 )
 

--- a/src/libslic3r/Thread.hpp
+++ b/src/libslic3r/Thread.hpp
@@ -50,7 +50,12 @@ inline boost::thread create_thread(boost::thread::attributes &attrs, Fn &&fn)
     // threads of the thread pool: allocate 4MB on a 64bit system, allocate 2MB
     // on a 32bit system by default.
     
-    attrs.set_stack_size((sizeof(void*) == 4) ? (2048 * 1024) : (4096 * 1024));
+    // Orca: the Emboss "On Surface" text-cut calls CGAL Polygon_mesh_processing::corefine,
+    // which falls back to exact rational (GMP/mpq) arithmetic on near-degenerate inputs and
+    // recurses deeply. The old 4 MB stack (and even the 16 MB upstream bump) overflows into the
+    // stack guard page -> EXC_BAD_ACCESS/SIGBUS in __gmpn_*/__gmpz_gcd on macOS. Reserve 256 MB;
+    // macOS/Linux commit thread-stack pages lazily, so idle workers cost address space, not RAM.
+    attrs.set_stack_size(256ull * 1024 * 1024);
     return boost::thread{attrs, std::forward<Fn>(fn)};
 }
 


### PR DESCRIPTION
## Problem

The Emboss text tool's **"On Surface"** projection crashes hard (`EXC_BAD_ACCESS` / `SIGBUS`, `KERN_PROTECTION_FAILURE`) on macOS, especially Apple Silicon. It reproduces while adding, **moving**, or slicing surface-projected text, and is non-deterministic (depends on exact placement).

## Root cause (diagnosed from crash dumps)

"On Surface" runs `CGAL::Polygon_mesh_processing::corefine`. On near-degenerate inputs (thin font stems, coplanar slivers where glyphs meet a curved wall) CGAL's filtered predicates fall back to **exact rational arithmetic (GMP `mpq`)**, which recurses deeply. The faulting thread always dies inside GMP primitives:

```
EXC_BAD_ACCESS (SIGBUS, KERN_PROTECTION_FAILURE) at the stack guard page
  __gmpn_sub_n / __gmpn_lshift / __gmpn_rshift
  __gmpz_sub / __gmpz_gcd
  __gmpq_aors
```

The worker thread's stack overflows into its guard page. `create_thread()` in `src/libslic3r/Thread.hpp` sets only **4 MB** here (the value still shipping in Snapmaker Orca 2.3.4).

Verified on a Mac mini M4 / macOS 15.5: a **clean, watertight 214k-triangle** model (0 non-manifold edges) consumed the **entire stack** and hit the guard. Note: even the upstream 16 MB bump (OrcaSlicer/OrcaSlicer#13772) was observed to still overflow on real-world models — the crash report showed the full 16 MB stack region consumed. It works on Linux/Windows because the exact-arithmetic fallback is rounding-dependent and typically isn't taken there.

## Fix

Raise the worker-thread stack in `create_thread()` to **256 MB**. macOS and Linux reserve thread stacks but commit pages lazily, so idle workers cost address space, not RAM — only a thread that actually recurses deeply commits real memory.

## Test

- Repro: open a curved model, Text tool → enable **On Surface**, place/move text → crash on affected builds.
- With this patch: the same operation completes without the guard-page fault.
