### PR TITLE
fix: Fix tree support interface layer count and transition filament bugs

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -7184,7 +7184,7 @@ std::string GCode::extrude_support(const ExtrusionEntityCollection& support_fill
         for (ExtrusionEntity* ee : support_fills.entities) {
             const ExtrusionRole role = ee->role();
             if ((role == support_extrusion_role) ||
-                (role == erSupportTransition) ||
+                (role == erSupportTransition && support_extrusion_role == erSupportMaterial) ||
                 (support_extrusion_role == erMixed && role != erIroning)) {
                 extrusions.emplace_back(ee);
             }

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -1488,11 +1488,10 @@ void TreeSupport::generate_toolpaths()
                         fill_params.dont_adjust = true;
                     }
                     if (area_group.type == SupportLayer::Roof1stLayer) {
-                        // roof_1st_layer
+                        // roof_1st_layer — transition strips that use support body filament.
+                        // Use interface_flow to match Bambu Studio behavior (higher flow for dense transition).
                         fill_params.density = interface_density;
-                        // Note: spacing means the separation between two lines as if they are tightly extruded
                         filler_Roof1stLayer->spacing = interface_flow.spacing();
-                        // generate a perimeter first to support interface better
                         ExtrusionEntityCollection* temp_support_fills = new ExtrusionEntityCollection();
                         make_perimeter_and_infill(temp_support_fills->entities, poly, 1, interface_flow, erSupportTransition,
                             filler_Roof1stLayer.get(), interface_density, false);
@@ -2136,8 +2135,9 @@ void TreeSupport::draw_circles()
                 // union_ex would merge separate branch polygons into one continuous surface,
                 // producing a single large block that diverges from Bambu's per-branch transition strips.
 
-                // roof_1st_layer and roof_areas may intersect, so need to subtract roof_areas from roof_1st_layer
-                roof_1st_layer = diff_ex(roof_1st_layer, ClipperUtils::clip_clipper_polygons_with_subject_bbox(roof_areas,get_extents(roof_1st_layer)));
+                // roof_areas and roof_1st_layer may intersect.
+                // Subtract roof_1st_layer from roof_areas so transition strips keep support body filament.
+                roof_areas = diff_ex(roof_areas, roof_1st_layer);
                 roof_1st_layer = intersection_ex(roof_1st_layer, m_machine_border);
 
                 // Move small roof_areas (< 1mm^2) into roof_1st_layer, matching Bambu Studio behavior.
@@ -3283,7 +3283,7 @@ void TreeSupport::generate_contact_points()
                     // print_z=object_layer->bottom_z: it directly contacts the bottom
                     // height=z_distance_top: it's height is exactly the gap distance
                     // dist_mm_to_top=0: it directly contacts the bottom
-                    contact_node = m_ts_data->create_node(pt, -gap_layers, layer_nr-1, roof_layers + 1, to_buildplate, SupportNode::NO_PARENT, bottom_z, z_distance_top, 0,
+                    contact_node = m_ts_data->create_node(pt, -gap_layers, layer_nr-1, roof_layers + gap_layers, to_buildplate, SupportNode::NO_PARENT, bottom_z, z_distance_top, 0,
                                                           radius);
                     contact_node->overhang = overhang;
                     contact_node->is_sharp_tail = is_sharp_tail;


### PR DESCRIPTION
## Summary

Fixes two bugs in tree support transition layer generation:

1. **Extra interface layer when z-distance=0**: `roof_layers + 1` hardcoded the gap layer count, causing one extra interface layer. Fixed to use dynamic `gap_layers` (0 when z-distance=0, 1 otherwise).

2. **Transition layers printed with wrong filament & flow**: Two issues:
   - Transition layers printed by interface extruder's ironing second pass instead of support extruder. Fixed by restricting `erSupportTransition` collection to `support_extrusion_role == erSupportMaterial`.
   - Transition layer flow used `support_flow` (~2.3) instead of `interface_flow` (~3.7), causing under-extrusion. Reverted to match Bambu Studio behavior.

3. **Reversed diff_ex direction**: Fixed subtraction order so transition strips (`roof_1st_layer`) correctly keep support body filament.

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `src/libslic3r/Support/TreeSupport.cpp` | +4/-4 | Fix gap_layers, diff_ex, revert to interface_flow |
| `src/libslic3r/GCode.cpp` | +1/-1 | Restrict erSupportTransition to support extruder |

## Testing

- Verified with z-distance=0, interface=3, transition=2
- Layer count: 3 interface + 2 transition + body (was 4+2+body)
- Transition filament: all layers use support body filament
- Transition flow: matches Bambu Studio ~3.7