### PR TITLE
fix: add Hollow and Lighting base pattern warning for normal support

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -8820,6 +8820,9 @@ msgstr "对于有机支撑，仅在空心/默认主体图案下支持双墙"
 msgid "The Lightning base pattern is not supported by this support type; Rectilinear will be used instead."
 msgstr "此支撑类型不支持闪电主体图案；将改用直线图案。"
 
+msgid "The Hollow base pattern is not supported by this support type; Rectilinear will be used instead."
+msgstr "此支撑类型不支持空心主体图案；将改用直线图案。"
+
 msgid "Support enforcers are used but support is not enabled. Please enable support."
 msgstr "使用了支撑添加器但没有打开支撑。请打开支撑。"
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1876,8 +1876,11 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
                     }
                 } else if (object->config().support_base_pattern == SupportMaterialPattern::smpLightning && warning) {
                     // Orca: check if the Lightning base pattern selected
-                    warning->string = L(
-                        "The Lightning base pattern is not supported by this support type; Rectilinear will be used instead.");
+                    warning->string = L("The Lightning base pattern is not supported by this support type; Rectilinear will be used instead.");
+                    warning->opt_key = "support_base_pattern";
+                } else if (object->config().support_base_pattern == SupportMaterialPattern::smpNone) {
+                    // Orca: check if the Hollow base pattern selected
+                    warning->string = L("The Hollow base pattern is not supported by this support type; Rectilinear will be used instead.");
                     warning->opt_key = "support_base_pattern";
                 }
             }


### PR DESCRIPTION
Summary

This PR adds a missing validation warning when the Hollow (smpNone) base pattern is selected with an unsupported support type, and provides its Chinese (zh_CN) translation.

Changes

src/libslic3r/Print.cpp
- Added a new validation check for support_base_pattern == SupportMaterialPattern::smpNone (Hollow), which was previously unhandled. The user now sees a warning: "The Hollow base pattern is not supported by this support type; Rectilinear will be used instead."
- This makes the Hollow pattern warning consistent with the existing Lightning (smpLightning) pattern check.

localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
- Added Chinese translation for the new warning: 此支撑类型不支持空心主体图案；将改用直线图案。

Before / After

| Scenario | Before | After |
|---|---|---|
| Lightning base pattern + unsupported type | Warning shown | Warning shown (unchanged) |
| Hollow base pattern + unsupported type | Silently falls back to Rectilinear | Warning shown |
| Chinese UI (Lightning) | Translated | Translated |
| Chinese UI (Hollow) | Untranslated English | 中文翻译 |

Testing

- Select "Hollow" base pattern with a support type that does not support it (e.g., organic/tree support). The warning should appear.
- Switch language to 中文, the warning should display in Chinese.


https://github.com/user-attachments/assets/cf7d534b-43af-4ea7-b4f2-d1b03d2fe71e


