### PR TITLE
fix: add Hollow and Lighting base pattern warning for normal support

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -8814,6 +8814,14 @@ msgstr "Organic支撑分支的直径不得小于支撑材料挤出宽度的2倍�
 msgid "Organic support branch diameter must not be smaller than support tree tip diameter."
 msgstr "Organic支撑分支的直径不得小于支撑树尖端的直径。"
 
+msgid "For Organic supports, two walls are supported only with the Hollow/Default base pattern."
+msgstr "对于有机支撑，仅在空心/默认主体图案下支持双墙"
+
+msgid "The Lightning base pattern is not supported by this support type; Rectilinear will be used instead."
+msgstr "此支撑类型不支持闪电主体图案；将改用直线图案。"
+
+msgid "The Hollow base pattern is not supported by this support type; Rectilinear will be used instead."
+msgstr "此支撑类型不支持空心主体图案；将改用直线图案。"
 msgid "Support enforcers are used but support is not enabled. Please enable support."
 msgstr "使用了支撑添加器但没有打开支撑。请打开支撑。"
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1826,18 +1826,41 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
 
                 // Prusa: Fixing crashes with invalid tip diameter or branch diameter
                 // https://github.com/prusa3d/PrusaSlicer/commit/96b3ae85013ac363cd1c3e98ec6b7938aeacf46d
-                if (is_tree(object->config().support_type.value) && (object->config().support_style == smsTreeOrganic ||
-                    // Orca: use organic as default
-                    object->config().support_style == smsDefault)) {
-                    float extrusion_width = std::min(
-                        support_material_flow(object).width(),
-                        support_material_interface_flow(object).width());
-                    if (object->config().tree_support_tip_diameter < extrusion_width - EPSILON)
-                        return { L("Organic support tree tip diameter must not be smaller than support material extrusion width."), object, "tree_support_tip_diameter" };
-                    if (object->config().tree_support_branch_diameter_organic < 2. * extrusion_width - EPSILON)
-                        return { L("Organic support branch diameter must not be smaller than 2x support material extrusion width."), object, "tree_support_branch_diameter_organic" };
-                    if (object->config().tree_support_branch_diameter_organic < object->config().tree_support_tip_diameter)
-                        return { L("Organic support branch diameter must not be smaller than support tree tip diameter."), object, "tree_support_branch_diameter_organic" };
+                if (is_tree(object->config().support_type.value)) {
+                    if (object->config().support_style == smsTreeOrganic ||
+                        // Orca: use organic as default
+                        object->config().support_style == smsDefault) {
+                        if (warning) {
+                            // Orca: check if the Lightning base pattern selected
+                            if (object->config().support_base_pattern == SupportMaterialPattern::smpLightning) {
+                                warning->string = L("The Lightning base pattern is not supported by this support type; Rectilinear will be used instead.");
+                                warning->opt_key = "support_base_pattern";
+                            }
+                            // Orca: check the support wall count and the base pattern
+                            else if (object->config().tree_support_wall_count > 1 &&
+                                object->config().support_base_pattern != SupportMaterialPattern::smpNone &&
+                                object->config().support_base_pattern != SupportMaterialPattern::smpDefault) {
+                                warning->string = L("For Organic supports, two walls are supported only with the Hollow/Default base pattern.");
+                                warning->opt_key = "support_base_pattern";
+                            }
+                        }
+
+                        float extrusion_width = std::min(support_material_flow(object).width(),support_material_interface_flow(object).width());
+                        if (object->config().tree_support_tip_diameter < extrusion_width - EPSILON)
+                            return {L("Organic support tree tip diameter must not be smaller than support material extrusion width."),object, "tree_support_tip_diameter"};
+                        if (object->config().tree_support_branch_diameter_organic < 2. * extrusion_width - EPSILON)
+                            return {L("Organic support branch diameter must not be smaller than 2x support material extrusion width."),object, "tree_support_branch_diameter_organic"};
+                        if (object->config().tree_support_branch_diameter_organic < object->config().tree_support_tip_diameter)
+                            return {L("Organic support branch diameter must not be smaller than support tree tip diameter."), object,"tree_support_branch_diameter_organic"};
+                    }
+                } else if (object->config().support_base_pattern == SupportMaterialPattern::smpLightning && warning) {
+                    // Orca: check if the Lightning base pattern selected
+                    warning->string = L("The Lightning base pattern is not supported by this support type; Rectilinear will be used instead.");
+                    warning->opt_key = "support_base_pattern";
+                } else if (object->config().support_base_pattern == SupportMaterialPattern::smpNone) {
+                    // Orca: check if the Hollow base pattern selected
+                    warning->string = L("The Hollow base pattern is not supported by this support type; Rectilinear will be used instead.");
+                    warning->opt_key = "support_base_pattern";
                 }
             }
 


### PR DESCRIPTION
Summary

This PR adds a missing validation warning when the Hollow (smpNone) base pattern is selected with an unsupported support type, and provides its Chinese (zh_CN) translation.

Changes

src/libslic3r/Print.cpp
- Added a new validation check for support_base_pattern == SupportMaterialPattern::smpNone (Hollow), which was previously unhandled. The user now sees a warning: "The Hollow base pattern is not supported by this support type; Rectilinear will be used instead."
- This makes the Hollow pattern warning consistent with the existing Lightning (smpLightning) pattern check.

localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
- Added Chinese translation for the new warning: 此支撑类型不支持空心主体图案；将改用直线图案。

Before / After

| Scenario | Before | After |
|---|---|---|
| Lightning base pattern + unsupported type | Warning shown | Warning shown (unchanged) |
| Hollow base pattern + unsupported type | Silently falls back to Rectilinear | Warning shown |
| Chinese UI (Lightning) | Translated | Translated |
| Chinese UI (Hollow) | Untranslated English | 中文翻译 |

Testing

- Select "Hollow" base pattern with a support type that does not support it (e.g., organic/tree support). The warning should appear.
- Switch language to 中文, the warning should display in Chinese.


https://github.com/user-attachments/assets/cf7d534b-43af-4ea7-b4f2-d1b03d2fe71e


