### PR TITLE
fix: Prevent multi-color 3MF color loss via per-layer XY area cross-region carving

### DIFF
--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cmath>
 #include <cstdlib>
+#include <unordered_map>
 #include <fstream>
 #include <iomanip>
 #include <limits>
@@ -419,24 +420,49 @@ static std::vector<std::vector<ExPolygons>> slices_to_regions(
                                     temp_slices[idx_region + 1].expolygons = std::move(source);
                             } else if ((region.model_volume->is_model_part() && clip_multipart_objects) || region.model_volume->is_negative_volume()) {
                                 // Clip every non-zero region preceding it.
+                                // Pre-pass: accumulate per-layer XY area per print_object_region_id
+                                std::unordered_map<int, double> region_area_map;
+                                for (int i = 0; i < int(temp_slices.size()); ++i) {
+                                    const auto &ts = temp_slices[i];
+                                    if (ts.region_id >= 0 && !ts.expolygons.empty())
+                                        region_area_map[ts.region_id] += area(ts.expolygons);
+                                }
                                 for (int idx_region2 = 0; idx_region2 < idx_region; ++ idx_region2)
                                     if (! temp_slices[idx_region2].expolygons.empty()) {
                                         // Skip trim_overlap for now, because it slow down the performace so much for some special cases
-#if 1
+#if 0
                                         if (const PrintObjectRegions::VolumeRegion& region2 = layer_range.volume_regions[idx_region2];
                                             !region2.model_volume->is_negative_volume() && overlap_in_xy(*region.bbox, *region2.bbox))
                                             temp_slices[idx_region2].expolygons = diff_ex(temp_slices[idx_region2].expolygons, temp_slices[idx_region].expolygons);
 #else
                                         const PrintObjectRegions::VolumeRegion& region2 = layer_range.volume_regions[idx_region2];
                                         if (!region2.model_volume->is_negative_volume() && overlap_in_xy(*region.bbox, *region2.bbox))
-                                            //BBS: handle negative_volume seperately, always minus the negative volume and don't need to trim overlap
-                                            if (!region.model_volume->is_negative_volume())
-                                                trim_overlap(temp_slices[idx_region2].expolygons, temp_slices[idx_region].expolygons);
-                                            else
+                                            //BBS: handle negative_volume, same-region trim, or cross-region carve by print_region_id
+                                            if (region.model_volume->is_negative_volume()) {
                                                 temp_slices[idx_region2].expolygons = diff_ex(temp_slices[idx_region2].expolygons, temp_slices[idx_region].expolygons);
+                                            } else if (!region.region || !region2.region || region.region->print_object_region_id() == region2.region->print_object_region_id()) {
+                                                trim_overlap(temp_slices[idx_region2].expolygons, temp_slices[idx_region].expolygons);
+                                            } else {
+                                                // Different print regions: smaller per-layer XY area carves larger
+                                                int pid_current = region.region->print_object_region_id();
+                                                int pid_other   = region2.region->print_object_region_id();
+                                                double area_current = region_area_map[pid_current];
+                                                double area_other   = region_area_map[pid_other];
+                                                // Hysteresis guard: only switch carving direction if area ratio is significant
+                                                bool smaller_carves;
+                                                if (std::max(area_current, area_other) / std::min(area_current, area_other) < 1.5)
+                                                    smaller_carves = (pid_current <= pid_other);
+                                                else
+                                                    smaller_carves = (area_current <= area_other);
+                                                if (smaller_carves)
+                                                    temp_slices[idx_region2].expolygons = diff_ex(temp_slices[idx_region2].expolygons, temp_slices[idx_region].expolygons);
+                                                else
+                                                    temp_slices[idx_region].expolygons = diff_ex(temp_slices[idx_region].expolygons, temp_slices[idx_region2].expolygons);
+                                            }
 #endif
                                     }
                             }
+
                         }
                     // Sort by region_id, push empty slices to the end.
                     std::sort(temp_slices.begin(), temp_slices.end());

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -430,19 +430,12 @@ static std::vector<std::vector<ExPolygons>> slices_to_regions(
                                 for (int idx_region2 = 0; idx_region2 < idx_region; ++ idx_region2)
                                     if (! temp_slices[idx_region2].expolygons.empty()) {
                                         // Skip trim_overlap for now, because it slow down the performace so much for some special cases
-#if 0
-                                        if (const PrintObjectRegions::VolumeRegion& region2 = layer_range.volume_regions[idx_region2];
-                                            !region2.model_volume->is_negative_volume() && overlap_in_xy(*region.bbox, *region2.bbox))
-                                            temp_slices[idx_region2].expolygons = diff_ex(temp_slices[idx_region2].expolygons, temp_slices[idx_region].expolygons);
-#else
                                         const PrintObjectRegions::VolumeRegion& region2 = layer_range.volume_regions[idx_region2];
-                                        if (!region2.model_volume->is_negative_volume() && overlap_in_xy(*region.bbox, *region2.bbox))
-                                            //BBS: handle negative_volume, same-region trim, or cross-region carve by print_region_id
+                                        if (!region2.model_volume->is_negative_volume() && overlap_in_xy(*region.bbox, *region2.bbox)) {
                                             if (region.model_volume->is_negative_volume()) {
+                                                // Negative volume: always subtract with diff_ex
                                                 temp_slices[idx_region2].expolygons = diff_ex(temp_slices[idx_region2].expolygons, temp_slices[idx_region].expolygons);
-                                            } else if (!region.region || !region2.region || region.region->print_object_region_id() == region2.region->print_object_region_id()) {
-                                                trim_overlap(temp_slices[idx_region2].expolygons, temp_slices[idx_region].expolygons);
-                                            } else {
+                                            } else if (region.region && region2.region && region.region->print_object_region_id() != region2.region->print_object_region_id()) {
                                                 // Different print regions: smaller per-layer XY area carves larger
                                                 int pid_current = region.region->print_object_region_id();
                                                 int pid_other   = region2.region->print_object_region_id();
@@ -458,8 +451,12 @@ static std::vector<std::vector<ExPolygons>> slices_to_regions(
                                                     temp_slices[idx_region2].expolygons = diff_ex(temp_slices[idx_region2].expolygons, temp_slices[idx_region].expolygons);
                                                 else
                                                     temp_slices[idx_region].expolygons = diff_ex(temp_slices[idx_region].expolygons, temp_slices[idx_region2].expolygons);
+                                            } else {
+                                                // Default path (same region, no region ptrs): simple diff_ex
+                                                // Preserves Bambu's #if 1 performance-safe behavior
+                                                temp_slices[idx_region2].expolygons = diff_ex(temp_slices[idx_region2].expolygons, temp_slices[idx_region].expolygons);
                                             }
-#endif
+                                        }
                                     }
                             }
 

--- a/src/libslic3r/PrintObjectSlice.cpp
+++ b/src/libslic3r/PrintObjectSlice.cpp
@@ -423,7 +423,7 @@ static std::vector<std::vector<ExPolygons>> slices_to_regions(
                                 // Pre-pass: accumulate per-layer XY area per print_object_region_id
                                 std::unordered_map<int, double> region_area_map;
                                 for (int i = 0; i < int(temp_slices.size()); ++i) {
-                                    const auto &ts = temp_slices[i];
+                                    const RegionSlice &ts = temp_slices[i];
                                     if (ts.region_id >= 0 && !ts.expolygons.empty())
                                         region_area_map[ts.region_id] += area(ts.expolygons);
                                 }
@@ -449,7 +449,7 @@ static std::vector<std::vector<ExPolygons>> slices_to_regions(
                                                 double area_current = region_area_map[pid_current];
                                                 double area_other   = region_area_map[pid_other];
                                                 // Hysteresis guard: only switch carving direction if area ratio is significant
-                                                bool smaller_carves;
+                                                bool smaller_carves = false;
                                                 if (std::max(area_current, area_other) / std::min(area_current, area_other) < 1.5)
                                                     smaller_carves = (pid_current <= pid_other);
                                                 else


### PR DESCRIPTION
## Problem
Multi-color 3MF files suffered color loss during slicing. The root cause was that cross-region carving used a global bounding box instead of per-layer XY extrusion area, causing incorrect carving decisions on layers where the extrusion region differed from the global bounds.

## Solution
Add per-layer XY area comparison for cross-region carving, but **only when volumes belong to different print regions** (different `print_object_region_id`). This narrow scope:

- Fixes the multi-color color loss bug
- Preserves Bambu's original `#if 1` `diff_ex` default for same-region overlaps
- Avoids re-introducing the `trim_overlap` performance regression on same-region paths

### Decision tree (per overlapping volume pair):
| Condition | Behavior | Performance |
|-----------|----------|-------------|
| Negative volume | `diff_ex` | Fast |
| Cross-region (different `print_object_region_id`) | Per-layer XY area carving | Fast |
| Same region / no region ptrs | `diff_ex` (Bambu default) | Fast |

## Changes
| File | Lines |
|------|-------|
| `src/libslic3r/PrintObjectSlice.cpp` | +41 / -18 (3 commits) |

- Compute per-layer XY area per `print_object_region_id` before region clipping loop
- Cross-region carving uses smaller per-layer area to determine carving direction
- Hysteresis guard (ratio < 1.5x) uses `print_region_id` as tiebreaker
- Default path falls back to simple `diff_ex` (Bambu's `#if 1` performance-safe behavior)
- Explicit type declarations replace `auto` (code style compliance)

## PR Size: Small (1 file)
## Ported from: #519