### PR TITLE
Fix sentry bug solve extruder order

### DIFF
--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -150,6 +150,11 @@ void remove_duplicates_preserve_order(std::vector<unsigned int> &values)
 // Shortest hamilton path problem
 static std::vector<unsigned int> solve_extruder_order(const std::vector<std::vector<float>>& wipe_volumes, std::vector<unsigned int> all_extruders, std::optional<unsigned int> start_extruder_id) 
 {
+	for (auto id : all_extruders) {
+    if (id >= wipe_volumes.size())
+        return all_extruders;
+	}
+	
     bool add_start_extruder_flag = false;
 
     if (start_extruder_id) {

--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -151,8 +151,10 @@ void remove_duplicates_preserve_order(std::vector<unsigned int> &values)
 static std::vector<unsigned int> solve_extruder_order(const std::vector<std::vector<float>>& wipe_volumes, std::vector<unsigned int> all_extruders, std::optional<unsigned int> start_extruder_id) 
 {
 	for (auto id : all_extruders) {
-    if (id >= wipe_volumes.size())
-        return all_extruders;
+	    if (id >= wipe_volumes.size()){
+			BOOST_LOG_TRIVIAL(error) << "fail to solve extruder order, because the extruder ID exceeds the bounds of the wipe volumes matrix.";
+	        return all_extruders;
+		}
 	}
 	
     bool add_start_extruder_flag = false;


### PR DESCRIPTION
# Description

Sentry #7256025247 — Array out-of-bounds crash in Slic3r::solve_extruder_order.

# Root Cause Analysis

the size of flush_volumes_matrix does not stay in sync with the filament count under certain conditions, resulting in a matrix that is too small for the valid extruder IDs.



# Fix
In solve_extruder_order, before the start_extruder_id handling block, add a bounds check:

for (auto id : all_extruders) {
    if (id >= wipe_volumes.size())
        return all_extruders;
}
4 lines, placed correctly, catch all out-of-bounds paths.
