### PR TITLE
Fix sentry bug 347

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -5282,8 +5282,7 @@ int PartPlateList::rebuild_plates_after_deserialize(std::vector<bool>& previous_
 			}
 		}
 
-		//can not find, create a new one
-		// Create a new one using an unused print index.
+		//can not find, create a new one using an unused print index.
 		while (m_print_list.count(m_print_index) > 0 || m_gcode_result_list.count(m_print_index) > 0)
 		{
 			++m_print_index;
@@ -5295,21 +5294,11 @@ int PartPlateList::rebuild_plates_after_deserialize(std::vector<bool>& previous_
 		GCodeResult* gcode = new GCodeResult();
 
 		auto print_result = m_print_list.emplace(new_print_index, print);
-
 		auto gcode_result = m_gcode_result_list.emplace(new_print_index, gcode);
 
 		if (!print_result.second || !gcode_result.second)
 		{
-			BOOST_LOG_TRIVIAL(error)
-				<< "[ORCA-347] failed to create Print mapping"
-				<< ", plate_index=" << i
-				<< ", print_index=" << new_print_index
-				<< ", print_inserted="
-				<< (print_result.second ? 1 : 0)
-				<< ", gcode_inserted="
-				<< (gcode_result.second ? 1 : 0)
-				<< ", new_print="
-				<< static_cast<const void*>(print);
+			BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": failed to insert Print/GCodeResult, index=" << new_print_index;
 
 			if (print_result.second)
 				m_print_list.erase(print_result.first);
@@ -5318,9 +5307,12 @@ int PartPlateList::rebuild_plates_after_deserialize(std::vector<bool>& previous_
 				m_gcode_result_list.erase(gcode_result.first);
 
 			delete print;
+			print = nullptr;
 			delete gcode;
+			gcode = nullptr;
 
-			return -1;
+			ret = -1;
+			continue;
 		}
 
 		m_plate_list[i]->set_print(print, gcode, new_print_index);

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -5283,13 +5283,49 @@ int PartPlateList::rebuild_plates_after_deserialize(std::vector<bool>& previous_
 		}
 
 		//can not find, create a new one
+		// Create a new one using an unused print index.
+		while (m_print_list.count(m_print_index) > 0 || m_gcode_result_list.count(m_print_index) > 0)
+		{
+			++m_print_index;
+		}
+
+		const int new_print_index = m_print_index++;
+
 		Print* print = new Print();
 		GCodeResult* gcode = new GCodeResult();
-		m_print_list.emplace(m_print_index, print);
-		m_gcode_result_list.emplace(m_print_index, gcode);
-		m_plate_list[i]->set_print(print, gcode, m_print_index);
+
+		auto print_result = m_print_list.emplace(new_print_index, print);
+
+		auto gcode_result = m_gcode_result_list.emplace(new_print_index, gcode);
+
+		if (!print_result.second || !gcode_result.second)
+		{
+			BOOST_LOG_TRIVIAL(error)
+				<< "[ORCA-347] failed to create Print mapping"
+				<< ", plate_index=" << i
+				<< ", print_index=" << new_print_index
+				<< ", print_inserted="
+				<< (print_result.second ? 1 : 0)
+				<< ", gcode_inserted="
+				<< (gcode_result.second ? 1 : 0)
+				<< ", new_print="
+				<< static_cast<const void*>(print);
+
+			if (print_result.second)
+				m_print_list.erase(print_result.first);
+
+			if (gcode_result.second)
+				m_gcode_result_list.erase(gcode_result.first);
+
+			delete print;
+			delete gcode;
+
+			return -1;
+		}
+
+		m_plate_list[i]->set_print(print, gcode, new_print_index);
+
 		print->set_plate_index(i);
-		m_print_index++;
 	}
 
 	//go through the print list, and delete the one not used by plate

--- a/src/slic3r/GUI/PartPlate.hpp
+++ b/src/slic3r/GUI/PartPlate.hpp
@@ -856,17 +856,7 @@ public:
     {
         //ar(cereal::base_class<ObjectBase>(this));
         //Cancel undo/redo for m_shape ,Because the printing area of different models is different, currently if the grid changes, it cannot correspond to the model on the left ui
-        ar(m_plate_width,
-            m_plate_depth,
-            m_plate_height,
-            m_height_to_lid,
-            m_height_to_rod,
-            m_height_limit_mode,
-            m_plate_count,
-            m_current_plate,
-            m_plate_list,
-            unprintable_plate,
-            m_print_index);
+        ar(m_plate_width, m_plate_depth, m_plate_height, m_height_to_lid, m_height_to_rod, m_height_limit_mode, m_plate_count, m_current_plate, m_plate_list, unprintable_plate);
         //ar(m_plate_width, m_plate_depth, m_plate_height, m_plate_count, m_current_plate);
     }
 

--- a/src/slic3r/GUI/PartPlate.hpp
+++ b/src/slic3r/GUI/PartPlate.hpp
@@ -856,7 +856,17 @@ public:
     {
         //ar(cereal::base_class<ObjectBase>(this));
         //Cancel undo/redo for m_shape ,Because the printing area of different models is different, currently if the grid changes, it cannot correspond to the model on the left ui
-        ar(m_plate_width, m_plate_depth, m_plate_height, m_height_to_lid, m_height_to_rod, m_height_limit_mode, m_plate_count, m_current_plate, m_plate_list, unprintable_plate);
+        ar(m_plate_width,
+            m_plate_depth,
+            m_plate_height,
+            m_height_to_lid,
+            m_height_to_rod,
+            m_height_limit_mode,
+            m_plate_count,
+            m_current_plate,
+            m_plate_list,
+            unprintable_plate,
+            m_print_index);
         //ar(m_plate_width, m_plate_depth, m_plate_height, m_plate_count, m_current_plate);
     }
 


### PR DESCRIPTION
Fix Print index conflicts during plate restoration after Undo

# Description
## Problem

During Undo/Redo restoration, PartPlateList::rebuild_plates_after_deserialize() may need to create a new Print and GCodeResult pair when the previously associated objects can no longer be found.

The existing implementation directly used m_print_index as the map key without checking whether that index was already occupied. If std::map::emplace() failed because the key already existed, the code still continued to call set_print() with the newly allocated objects.

This could break the consistency between:

PartPlate::m_print
PartPlate::m_print_index
m_print_list
m_gcode_result_list

As a result, a plate could hold a Print* that did not match the object stored under its print_index, potentially causing incorrect object deletion and use-after-free crashes during subsequent plate operations.

## Fix

Search for an unused print index before creating a new Print/GCodeResult pair.
Use the same new_print_index consistently for both map insertion and plate binding.
Check the return value of both emplace() calls.
Roll back partial insertions and release allocated objects if either insertion fails.
Skip the failed plate restoration while continuing to process the remaining plates.

## Result

This prevents duplicate print-index mappings and ensures that every restored plate remains consistently associated with the corresponding Print and GCodeResult objects.