### PR TITLE
fix: enable XML_LARGE_SIZE in expat to support 3MF files larger than 2GB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,11 +649,8 @@ include_directories(BEFORE SYSTEM ${EIGEN3_INCLUDE_DIR})
 find_package(EXPAT)
 
 if (NOT EXPAT_FOUND)
-    add_library(expat STATIC
-        ${LIBDIR}/expat/xmlparse.c
-        ${LIBDIR}/expat/xmlrole.c
-        ${LIBDIR}/expat/xmltok.c
-    )
+    # deps_src/expat provides the expat target with XML_LARGE_SIZE enabled.
+    # Just set the variables needed by consumers.
     set(EXPAT_FOUND 1)
     set(EXPAT_INCLUDE_DIRS ${LIBDIR}/expat/)
     set(EXPAT_LIBRARIES expat)

--- a/deps/EXPAT/expat/CMakeLists.txt
+++ b/deps/EXPAT/expat/CMakeLists.txt
@@ -73,6 +73,10 @@ add_library(expat
 
 target_include_directories(expat PRIVATE ${PROJECT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
+# Enable 64-bit size/index types (XML_Size, XML_Index) to support
+# parsing of very large XML files (>2GB) without internal overflow.
+target_compile_definitions(expat PUBLIC XML_LARGE_SIZE)
+
 include(GNUInstallDirs)
 
 install( 

--- a/deps_src/expat/CMakeLists.txt
+++ b/deps_src/expat/CMakeLists.txt
@@ -32,6 +32,10 @@ if(WIN32)
     target_compile_definitions(expat PRIVATE COMPILED_FROM_DSP XML_STATIC)
 endif()
 
+# Enable 64-bit size/index types (XML_Size, XML_Index) to support
+# parsing of very large XML files (>2GB) without internal overflow.
+target_compile_definitions(expat PUBLIC XML_LARGE_SIZE)
+
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
     target_compile_options(expat PRIVATE -Wno-unused-parameter)
 endif()


### PR DESCRIPTION
Without XML_LARGE_SIZE, expat uses 32-bit types (long/unsigned long) for internal position/size counters (XML_Index, XML_Size), which overflow when parsing a single XML file exceeding ~2GB. This happens when exporting a project as a generic 3MF, since all object meshes are inlined into one 3dmodel.model file.

Added target_compile_definitions(expat PUBLIC XML_LARGE_SIZE) in:
  - deps_src/expat/CMakeLists.txt (primary build path)
  - deps/EXPAT/expat/CMakeLists.txt (ExternalProject fallback)

Also removed the redundant add_library(expat ...) from the root CMakeLists.txt fallback to avoid a target name conflict with deps_src/expat, since deps_src now always provides the expat target.

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
