### PR TITLE
fix: sentry bug 347

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -5282,14 +5282,42 @@ int PartPlateList::rebuild_plates_after_deserialize(std::vector<bool>& previous_
 			}
 		}
 
-		//can not find, create a new one
+		//can not find, create a new one using an unused print index.
+		while (m_print_list.count(m_print_index) > 0 || m_gcode_result_list.count(m_print_index) > 0)
+		{
+			++m_print_index;
+		}
+
+		const int new_print_index = m_print_index++;
+
 		Print* print = new Print();
 		GCodeResult* gcode = new GCodeResult();
-		m_print_list.emplace(m_print_index, print);
-		m_gcode_result_list.emplace(m_print_index, gcode);
-		m_plate_list[i]->set_print(print, gcode, m_print_index);
+
+		auto print_result = m_print_list.emplace(new_print_index, print);
+		auto gcode_result = m_gcode_result_list.emplace(new_print_index, gcode);
+
+		if (!print_result.second || !gcode_result.second)
+		{
+			BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": failed to insert Print/GCodeResult, index=" << new_print_index;
+
+			if (print_result.second)
+				m_print_list.erase(print_result.first);
+
+			if (gcode_result.second)
+				m_gcode_result_list.erase(gcode_result.first);
+
+			delete print;
+			print = nullptr;
+			delete gcode;
+			gcode = nullptr;
+
+			ret = -1;
+			continue;
+		}
+
+		m_plate_list[i]->set_print(print, gcode, new_print_index);
+
 		print->set_plate_index(i);
-		m_print_index++;
 	}
 
 	//go through the print list, and delete the one not used by plate


### PR DESCRIPTION
* Fix：Print mapping conflicts after plate undo restoration

During Undo/Redo restoration, PartPlateList restores the serialized plate state but does not restore m_print_list. Meanwhile, m_print_index could be reset by reset()/init(), causing newly created Print objects to reuse an already occupied index.

When std::map::emplace() failed because the key already existed, the code still called set_print() with the newly allocated Print pointer. This could break the mapping between PartPlate::m_print, PartPlate::m_print_index, and m_print_list, eventually leading to stale pointers, incorrect deletion, and use-after-free crashes.

Fix the issue by:

* Ensuring newly allocated Print/GCodeResult pairs use an unused index.
* Checking emplace() results before binding the new objects to a PartPlate.
* Preventing set_print() from running when map insertion fails.


