### PR TITLE
perf: parallelize profile JSON loading with TBB (no-exception style)

### DIFF
--- a/src/slic3r/GUI/ProfileLoadUtil.hpp
+++ b/src/slic3r/GUI/ProfileLoadUtil.hpp
@@ -1,0 +1,53 @@
+#ifndef slic3r_ProfileLoadUtil_hpp_
+#define slic3r_ProfileLoadUtil_hpp_
+
+#include <atomic>
+#include <vector>
+#include <nlohmann/json.hpp>
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
+
+namespace Slic3r { namespace GUI {
+
+// Drives the per-file loops used while loading a vendor profile family.
+//
+// work(n, slot) runs for n in [0, nsize) on TBB workers; each invocation writes
+// only its OWN slot, so there are no shared writes, no locks and no data races.
+// A malformed item leaves its slot null (null == "skip this item"). destroy is
+// checked per item so a cancel (the dialog was destroyed) unwinds promptly.
+//
+// Team convention - no exception control flow in this path: workers must use
+// the non-throwing nlohmann/boost APIs (json::parse(..., nullptr, false) +
+// is_discarded(), type-checked field access, error_code filesystem overloads),
+// so a malformed file drops only itself. Anything that still escapes a worker
+// (e.g. bad_alloc) propagates through parallel_for into the caller's catch.
+template <typename WorkFn>
+std::vector<nlohmann::json> parallel_load_items(int nsize, const std::atomic<bool> &destroy, WorkFn work)
+{
+    std::vector<nlohmann::json> slots(nsize);
+    tbb::parallel_for(tbb::blocked_range<int>(0, nsize), [&](const tbb::blocked_range<int> &range) {
+        for (int n = range.begin(); n != range.end(); ++n) {
+            if (destroy.load(std::memory_order_acquire)) return;
+            work(n, slots[n]);
+        }
+    });
+    return slots;
+}
+
+// parallel_load_items + an in-order serial merge: runs work across the range,
+// then calls merge(item) for every non-null slot in original list order
+// (preserving ordering and first-wins dedup). The merge is skipped when destroy
+// is set, so a destroyed dialog receives no partial writes; the caller should
+// still re-check destroy afterwards to abort the remaining sections.
+template <typename WorkFn, typename MergeFn>
+void load_section(int nsize, const std::atomic<bool> &destroy, WorkFn work, MergeFn merge)
+{
+    auto slots = parallel_load_items(nsize, destroy, work);
+    if (destroy.load(std::memory_order_acquire)) return;
+    for (int n = 0; n < nsize; ++n)
+        if (!slots[n].is_null()) merge(slots[n]);
+}
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_ProfileLoadUtil_hpp_

--- a/src/slic3r/GUI/WebGuideDialog.cpp
+++ b/src/slic3r/GUI/WebGuideDialog.cpp
@@ -34,6 +34,10 @@
 #include <libslic3r/Utils.hpp>
 #include "CreatePresetsDialog.hpp"
 #include <mutex>
+#include <vector>
+#include <tbb/parallel_for.h>
+#include <tbb/blocked_range.h>
+#include "ProfileLoadUtil.hpp"
 #include "sentry_wrapper/SentryWrapper.hpp"
 
 using namespace nlohmann;
@@ -419,11 +423,13 @@ void GuideFrame::OnScriptMessage(wxWebViewEvent &evt)
             wxString strJS = wxString::Format("HandleStudio(%s)", m_Res.dump(-1, ' ', true));
 
             // BOOST_LOG_TRIVIAL(trace) << "GuideFrame::OnScriptMessage;request_userguide_profile:" << strJS.c_str();
-            wxGetApp().CallAfter([this,strJS] { RunScript(strJS); });
+            // dialog-level CallAfter: discarded on destruction, cannot run on a dangling `this`
+            CallAfter([this,strJS] { RunScript(strJS); });
         }
         else if (strCmd == "request_custom_filaments") {
             wxString strJS = update_custom_filaments();
-            wxGetApp().CallAfter([this, strJS] { RunScript(strJS); });
+            // dialog-level CallAfter: discarded on destruction, cannot run on a dangling `this`
+            CallAfter([this, strJS] { RunScript(strJS); });
         }
         else if (strCmd == "create_custom_filament") {
             this->EndModal(wxID_OK);
@@ -944,15 +950,16 @@ bool GuideFrame::run()
         return false;
 }
 
-int GuideFrame::GetFilamentInfo( std::string VendorDirectory, json & pFilaList, std::string filepath, std::string &sVendor, std::string &sType)
+// NOTE: runs concurrently from TBB workers in LoadProfileFamily. pFilaList is
+// only read (const access), never modified - keep it that way.
+int GuideFrame::GetFilamentInfo( std::string VendorDirectory, const json & pFilaList, std::string filepath, std::string &sVendor, std::string &sType)
 {
     //GetStardardFilePath(filepath);
-    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " GetFilamentInfo:VendorDirectory - " << VendorDirectory << ", Filepath - "<<filepath;
+    BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << " GetFilamentInfo:VendorDirectory - " << VendorDirectory << ", Filepath - "<<filepath;
 
     try {
         std::string contents;
         LoadFile(filepath, contents);
-        BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": Json Contents: " << contents;
         json jLocal = json::parse(contents);
 
         if (sVendor == "") {
@@ -981,7 +988,12 @@ int GuideFrame::GetFilamentInfo( std::string VendorDirectory, json & pFilaList, 
                     return -1;
                 }
 
-                std::string FPath = pFilaList[FName]["sub_path"];
+                const json &inherited = pFilaList.at(FName); // contains()-checked above, cannot throw
+                if (!inherited.contains("sub_path") || !inherited["sub_path"].is_string()) {
+                    BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "inherits filament " << FName << " has no sub_path";
+                    return -1;
+                }
+                std::string FPath = inherited["sub_path"];
                 BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " Before Format Inherits Path: VendorDirectory - " << VendorDirectory << ", sub_path - " << FPath;
                 wxString strNewFile = wxString::Format("%s%c%s", wxString(VendorDirectory.c_str(), wxConvUTF8), boost::filesystem::path::preferred_separator, FPath);
                 boost::filesystem::path inherits_path(w2s(strNewFile));
@@ -1110,19 +1122,16 @@ int GuideFrame::LoadProfileData()
         }
 
         //sync to web
-        std::string strAll = m_ProfileJson.dump(-1, ' ', false, json::error_handler_t::ignore);  // Already locked at function start
-
-        BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ", finished, json contents: " << std::endl << strAll;
         json m_Res           = json::object();
         m_Res["command"]     = "userguide_profile_load_finish";
         m_Res["sequence_id"] = "10001";
         wxString strJS       = wxString::Format("HandleStudio(%s)", m_Res.dump(-1, ' ', true));
         if (!m_destroy)
-            wxGetApp().CallAfter([this, strJS] { RunScript(strJS); });
+            CallAfter([this, strJS] { RunScript(strJS); });
 
         //sync to appconfig
         if (!m_destroy)
-            wxGetApp().CallAfter([this] { SaveProfileData(); });
+            CallAfter([this] { SaveProfileData(); });
 
     } catch (std::exception& e) {
         // wxLogMessage("GUIDE: load_profile_error  %s ", e.what());
@@ -1216,7 +1225,10 @@ void StringReplace(string &strBase, string strSrc, string strDes)
     }
 }
 
-
+// Precondition: the caller (LoadProfileData) holds m_ProfileJson_mutex for the
+// whole load. The TBB workers below read the shared m_ProfileJson via const
+// references without locking; that is only race-free because every other
+// accessor of the global locks the same mutex and this thread owns it here.
 int GuideFrame::LoadProfileFamily(std::string strVendor, std::string strFilePath)
 {
     // wxString strFolder = strFilePath.BeforeLast(boost::filesystem::path::preferred_separator);
@@ -1225,12 +1237,13 @@ int GuideFrame::LoadProfileFamily(std::string strVendor, std::string strFilePath
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(",  vendor path %1%.") % vendor_dir.string();
     try {
         // wxLogMessage("GUIDE: json_path1  %s", w2s(strFilePath));
-
-        std::string contents;
-        LoadFile(strFilePath, contents);
-        // wxLogMessage("GUIDE: json_path1 content: %s", contents);
-        json jLocal = json::parse(contents);
-        // wxLogMessage("GUIDE: json_path1 Loaded");
+        std::string vendor_contents;
+        LoadFile(strFilePath, vendor_contents);
+        json jLocal = json::parse(vendor_contents, nullptr, false);
+        if (jLocal.is_discarded() || !jLocal.is_object()) {
+            BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": vendor index " << strFilePath << " malformed, skipped";
+            return -1;
+        }
 
         // BBS:models
         json pmodels = jLocal["machine_model_list"];
@@ -1238,74 +1251,107 @@ int GuideFrame::LoadProfileFamily(std::string strVendor, std::string strFilePath
 
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(",  got %1% machine models") % nsize;
 
-        for (int n = 0; n < nsize; n++) {
-            json OneModel = pmodels.at(n);
+        {
+            const json &pmodels_ro = pmodels;
+            load_section(nsize, m_destroy, [&](int n, json &slot) {
+                json OneModel = pmodels_ro.at(n);
+                if (!OneModel.is_object() || !OneModel["name"].is_string() || !OneModel["sub_path"].is_string()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: machine model " << n << " of vendor " << strVendor << " malformed, skipped";
+                    return;
+                }
 
-            OneModel["model"] = OneModel["name"];
-            OneModel.erase("name");
+                OneModel["model"] = OneModel["name"];
+                OneModel.erase("name");
 
-            std::string s1 = OneModel["model"];
-            std::string s2 = OneModel["sub_path"];
+                std::string s1 = OneModel["model"];
+                std::string s2 = OneModel["sub_path"];
 
-            boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
-            if (!boost::filesystem::exists(sub_path)) continue;
+                boost::system::error_code ec;
+                boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
+                if (!boost::filesystem::exists(sub_path, ec) || ec) return;
 
-            std::string             sub_file = sub_path.string();
+                std::string sub_file = sub_path.string();
+                std::string contents;
+                LoadFile(sub_file, contents);
+                json pm = json::parse(contents, nullptr, false);
+                if (pm.is_discarded() || !pm.is_object() || !pm["nozzle_diameter"].is_string()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: model file " << sub_file << " malformed, skipped";
+                    return;
+                }
 
-            // wxLogMessage("GUIDE: json_path2  %s", w2s(ModelFilePath));
-            LoadFile(sub_file, contents);
-            // wxLogMessage("GUIDE: json_path2 content: %s", contents);
-            json pm = json::parse(contents);
-            // wxLogMessage("GUIDE: json_path2  loaded");
+                OneModel["name"]      = pm["name"];
+                OneModel["vendor"]    = strVendor;
+                std::string NozzleOpt = pm["nozzle_diameter"];
+                StringReplace(NozzleOpt, " ", "");
+                OneModel["nozzle_diameter"] = NozzleOpt;
+                OneModel["materials"]       = pm["default_materials"];
 
-            OneModel["name"]      = pm["name"];
-            OneModel["vendor"]    = strVendor;
-            std::string NozzleOpt = pm["nozzle_diameter"];
-            StringReplace(NozzleOpt, " ", "");
-            OneModel["nozzle_diameter"] = NozzleOpt;
-            OneModel["materials"]       = pm["default_materials"];
+                std::string             cover_file = s1 + "_cover.png";
+                boost::filesystem::path cover_path = boost::filesystem::absolute(boost::filesystem::path(resources_dir()) / "/profiles/" / strVendor / cover_file).make_preferred();
+                if (!boost::filesystem::exists(cover_path, ec) || ec) {
+                    cover_path =
+                        (boost::filesystem::absolute(boost::filesystem::path(resources_dir()) / "/web/image/printer/") /
+                         cover_file)
+                            .make_preferred();
+                }
+                OneModel["cover"] = cover_path.string();
 
-            // wxString strCoverPath = wxString::Format("%s\\%s\\%s_cover.png", strFolder, strVendor, std::string(s1.mb_str()));
-            std::string             cover_file = s1 + "_cover.png";
-            boost::filesystem::path cover_path = boost::filesystem::absolute(boost::filesystem::path(resources_dir()) / "/profiles/" / strVendor / cover_file).make_preferred();
-            if (!boost::filesystem::exists(cover_path)) {
-                cover_path =
-                    (boost::filesystem::absolute(boost::filesystem::path(resources_dir()) / "/web/image/printer/") /
-                     cover_file)
-                        .make_preferred();
-            }
-            OneModel["cover"]                  = cover_path.string();
+                OneModel["nozzle_selected"] = "";
 
-            OneModel["nozzle_selected"] = "";
-
-            m_ProfileJson["model"].push_back(OneModel);
+                slot = std::move(OneModel);
+            }, [this](json &item) { m_ProfileJson["model"].push_back(std::move(item)); });
+            if (m_destroy) return 0;
         }
 
         // BBS:Machine
         json pmachine = jLocal["machine_list"];
         nsize         = pmachine.size();
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(",  got %1% machines") % nsize;
-        for (int n = 0; n < nsize; n++) {
-            json OneMachine = pmachine.at(n);
+        {
+            const json &pmachine_ro = pmachine;
+            load_section(nsize, m_destroy, [&](int n, json &slot) {
+                json OneMachine = pmachine_ro.at(n);
 
-            std::string s1 = OneMachine["name"];
-            std::string s2 = OneMachine["sub_path"];
+                // Validate here: the serial merge below reads slot["name"]
+                // unguarded, so a malformed entry must drop only itself.
+                if (!OneMachine.is_object() || !OneMachine["name"].is_string() || !OneMachine["sub_path"].is_string()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: machine " << n << " of vendor " << strVendor << " malformed, skipped";
+                    return;
+                }
 
-            // wxString ModelFilePath = wxString::Format("%s\\%s\\%s", strFolder, strVendor, s2);
-            boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
-            if (!boost::filesystem::exists(sub_path)) continue;
+                std::string s2 = OneMachine["sub_path"];
 
-            std::string             sub_file = sub_path.string();
-            LoadFile(sub_file, contents);
-            json pm = json::parse(contents);
+                boost::system::error_code ec;
+                boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
+                if (!boost::filesystem::exists(sub_path, ec) || ec) return;
 
-            std::string strInstant = pm["instantiation"];
-            if (strInstant.compare("true") == 0) {
-                OneMachine["model"] = pm["printer_model"];
-                OneMachine["nozzle"] = pm["nozzle_diameter"][0];
+                std::string sub_file = sub_path.string();
+                std::string contents;
+                LoadFile(sub_file, contents);
+                json pm = json::parse(contents, nullptr, false);
+                if (pm.is_discarded() || !pm.is_object()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: machine file " << sub_file << " malformed, skipped";
+                    return;
+                }
 
-                m_ProfileJson["machine"][s1]=OneMachine;
-            }
+                // json == const char* never throws: a missing or non-string
+                // "instantiation" simply compares unequal.
+                if (pm["instantiation"] == "true") {
+                    const json &nd = pm["nozzle_diameter"];
+                    if (!nd.is_array() && !nd.is_null()) {
+                        BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: machine file " << sub_file << " has malformed nozzle_diameter, skipped";
+                        return;
+                    }
+                    OneMachine["model"]  = pm["printer_model"];
+                    OneMachine["nozzle"] = (nd.is_array() && !nd.empty()) ? nd[0] : json();
+
+                    slot = std::move(OneMachine);
+                }
+            }, [this](json &item) {
+                std::string s1 = item["name"];
+                m_ProfileJson["machine"][s1] = std::move(item);
+            });
+            if (m_destroy) return 0;
         }
 
         // BBS:Filament
@@ -1315,78 +1361,92 @@ int GuideFrame::LoadProfileFamily(std::string strVendor, std::string strFilePath
 
         for (int n = 0; n < nsize; n++) {
             json OneFF = pFilament.at(n);
+            if (!OneFF.is_object() || !OneFF["name"].is_string()) continue;
 
-            std::string s1    = OneFF["name"];
-            std::string s2    = OneFF["sub_path"];
+            std::string s1 = OneFF["name"];
 
             tFilaList[s1] = OneFF;
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << "Vendor: " << strVendor <<", tFilaList Add: " << s1;
         }
 
-        int nFalse  = 0;
-        int nModel  = 0;
-        int nFinish = 0;
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(",  got %1% filaments") % nsize;
-        for (int n = 0; n < nsize; n++) {
-            json OneFF = pFilament.at(n);
-
-            std::string s1 = OneFF["name"];
-            std::string s2 = OneFF["sub_path"];
-
-            if (!m_ProfileJson["filament"].contains(s1)) {
-                // wxString ModelFilePath = wxString::Format("%s\\%s\\%s", strFolder, strVendor, s2);
-                boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
-                if (!boost::filesystem::exists(sub_path)) continue;
-
-                std::string             sub_file = sub_path.string();
-                LoadFile(sub_file, contents);
-                if (contents == "") {
-                    continue;
+        {
+            const json &pFilament_ro        = pFilament;
+            const json &tFilaList_ro        = tFilaList;
+            const json &machines_ro         = m_ProfileJson["machine"];
+            const json &loaded_filaments_ro = m_ProfileJson["filament"];
+            load_section(nsize, m_destroy, [&](int n, json &slot) {
+                json OneFF = pFilament_ro.at(n);
+                if (!OneFF.is_object() || !OneFF["name"].is_string() || !OneFF["sub_path"].is_string()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: filament " << n << " of vendor " << strVendor << " malformed, skipped";
+                    return;
                 }
-                json pm = json::parse(contents);
 
-                std::string strInstant = pm["instantiation"];
-                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << "Load Filament:" << s1 << ",Path:" << sub_file << ",instantiation?" << strInstant;
+                std::string s1 = OneFF["name"];
+                std::string s2 = OneFF["sub_path"];
 
-                if (strInstant == "true") {
-                    std::string sV;
-                    std::string sT;
+                if (loaded_filaments_ro.contains(s1)) return;
 
-                    int nRet = GetFilamentInfo(vendor_dir.string(),tFilaList, sub_file, sV, sT);
-                    if (nRet != 0) {
-                        BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << "Load Filament:" << s1 << ",GetFilamentInfo Failed, Vendor:" << sV << ",Type:"<< sT;
-                        continue;
+                boost::system::error_code ec;
+                boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
+                if (!boost::filesystem::exists(sub_path, ec) || ec) return;
+
+                std::string sub_file = sub_path.string();
+                std::string contents;
+                LoadFile(sub_file, contents);
+                if (contents == "") return;
+                json pm = json::parse(contents, nullptr, false);
+                if (pm.is_discarded() || !pm.is_object()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: filament file " << sub_file << " malformed, skipped";
+                    return;
+                }
+
+                bool instant = (pm["instantiation"] == "true");
+                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << "Load Filament:" << s1 << ",Path:" << sub_file << ",instantiation?" << (instant ? "true" : "false");
+
+                if (!instant) return;
+
+                std::string sV;
+                std::string sT;
+
+                int nRet = GetFilamentInfo(vendor_dir.string(), tFilaList_ro, sub_file, sV, sT);
+                if (nRet != 0) {
+                    BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "Load Filament:" << s1 << ",GetFilamentInfo Failed, Vendor:" << sV << ",Type:"<< sT;
+                    return;
+                }
+
+                OneFF["vendor"] = sV;
+                OneFF["type"]   = sT;
+
+                OneFF["models"]   = "";
+
+                const json &pPrinters = pm["compatible_printers"];
+                std::string ModelList = "";
+                if (pPrinters.is_array()) {
+                    for (const json &printer : pPrinters) {
+                        if (!printer.is_string()) continue;
+                        std::string sP = printer;
+                        if (!machines_ro.contains(sP)) continue;
+                        const json &m = machines_ro.at(sP);
+                        if (!m.contains("model") || !m["model"].is_string() || !m.contains("nozzle") || !m["nozzle"].is_string()) continue;
+                        std::string mModel  = m["model"];
+                        std::string mNozzle = m["nozzle"];
+
+                        ModelList += "[" + mModel + "++" + mNozzle + "]";
                     }
+                }
 
-                    OneFF["vendor"] = sV;
-                    OneFF["type"]   = sT;
+                OneFF["models"]    = ModelList;
+                OneFF["selected"] = 0;
 
-                    OneFF["models"]   = "";
-
-                    json pPrinters = pm["compatible_printers"];
-                    int nPrinter   = pPrinters.size();
-                    std::string ModelList = "";
-                    for (int i = 0; i < nPrinter; i++)
-                    {
-                        std::string sP = pPrinters.at(i);
-                        if (m_ProfileJson["machine"].contains(sP))
-                        {
-                            std::string mModel = m_ProfileJson["machine"][sP]["model"];
-                            std::string mNozzle = m_ProfileJson["machine"][sP]["nozzle"];
-                            std::string NewModel = mModel + "++" + mNozzle;
-
-                            ModelList = (boost::format("%1%[%2%]") % ModelList % NewModel).str();
-                        }
-                    }
-
-                    OneFF["models"]    = ModelList;
-                    OneFF["selected"] = 0;
-
-                    m_ProfileJson["filament"][s1] = OneFF;
-                } else
-                    continue;
-
-            }
+                slot = std::move(OneFF);
+            }, [this](json &item) {
+                std::string s1 = item["name"];
+                // first occurrence wins, matching the old serial semantics
+                if (!m_ProfileJson["filament"].contains(s1))
+                    m_ProfileJson["filament"][s1] = std::move(item);
+            });
+            if (m_destroy) return 0;
         }
         if(strVendor == PresetBundle::ORCA_FILAMENT_LIBRARY)
             m_OrcaFilaList = tFilaList;
@@ -1395,20 +1455,32 @@ int GuideFrame::LoadProfileFamily(std::string strVendor, std::string strFilePath
         json pProcess = jLocal["process_list"];
         nsize         = pProcess.size();
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(",  got %1% processes") % nsize;
-        for (int n = 0; n < nsize; n++) {
-            json OneProcess = pProcess.at(n);
+        {
+            const json &pProcess_ro = pProcess;
+            load_section(nsize, m_destroy, [&](int n, json &slot) {
+                json OneProcess = pProcess_ro.at(n);
+                if (!OneProcess.is_object() || !OneProcess["sub_path"].is_string()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: process " << n << " of vendor " << strVendor << " malformed, skipped";
+                    return;
+                }
 
-            std::string s2 = OneProcess["sub_path"];
-            // wxString ModelFilePath = wxString::Format("%s\\%s\\%s", strFolder, strVendor, s2);
-            boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
-            if (!boost::filesystem::exists(sub_path)) continue;
+                std::string s2 = OneProcess["sub_path"];
+                boost::system::error_code ec;
+                boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
+                if (!boost::filesystem::exists(sub_path, ec) || ec) return;
 
-            std::string             sub_file = sub_path.string();
-            LoadFile(sub_file, contents);
-            json pm = json::parse(contents);
+                std::string sub_file = sub_path.string();
+                std::string contents;
+                LoadFile(sub_file, contents);
+                json pm = json::parse(contents, nullptr, false);
+                if (pm.is_discarded() || !pm.is_object()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: process file " << sub_file << " malformed, skipped";
+                    return;
+                }
 
-            std::string bInstall = pm["instantiation"];
-            if (bInstall == "true") { m_ProfileJson["process"].push_back(OneProcess); }
+                if (pm["instantiation"] == "true") slot = std::move(OneProcess);
+            }, [this](json &item) { m_ProfileJson["process"].push_back(std::move(item)); });
+            if (m_destroy) return 0;
         }
 
     } catch (nlohmann::detail::parse_error &err) {

--- a/src/slic3r/GUI/WebGuideDialog.hpp
+++ b/src/slic3r/GUI/WebGuideDialog.hpp
@@ -31,6 +31,7 @@
 #include "slic3r/Utils/PresetUpdater.hpp"
 
 #include <nlohmann/json.hpp>
+#include <atomic>
 
 namespace Slic3r { namespace GUI {
 
@@ -77,7 +78,7 @@ public:
     int SaveProfileData();
     int LoadProfileFamily(std::string strVendor, std::string strFilePath);
     int SaveProfile();
-    int GetFilamentInfo( std::string VendorDirectory,json & pFilaList, std::string filepath, std::string &sVendor, std::string &sType);
+    int GetFilamentInfo( std::string VendorDirectory, const json & pFilaList, std::string filepath, std::string &sVendor, std::string &sType);
 
 
     bool apply_config(AppConfig *app_config, PresetBundle *preset_bundle, const PresetUpdater *updater, bool& apply_keeped_changes);
@@ -110,7 +111,7 @@ private:
 
     //First Load
     bool bFirstComplete{false};
-    bool m_destroy{false};
+    std::atomic<bool> m_destroy{false};
     boost::thread* m_load_task{ nullptr };
 
     // User Config

--- a/src/slic3r/GUI/WebPresetDialog.cpp
+++ b/src/slic3r/GUI/WebPresetDialog.cpp
@@ -32,6 +32,10 @@
 #include "slic3r/GUI/Tab.hpp"
 #include <mutex>
 #include <atomic>
+#include <vector>
+#include <tbb/parallel_for.h>
+#include <tbb/blocked_range.h>
+#include "ProfileLoadUtil.hpp"
 
 using namespace nlohmann;
 
@@ -1080,7 +1084,7 @@ bool WebPresetDialog::run()
         return false;
 }
 
-int WebPresetDialog::GetFilamentInfo(std::string VendorDirectory, json& pFilaList, std::string filepath, std::string& sVendor, std::string& sType)
+int WebPresetDialog::GetFilamentInfo(std::string VendorDirectory, const json& pFilaList, std::string filepath, std::string& sVendor, std::string& sType)
 {
     // GetStardardFilePath(filepath);
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " GetFilamentInfo:VendorDirectory - " << VendorDirectory << ", Filepath - " << filepath;
@@ -1088,7 +1092,6 @@ int WebPresetDialog::GetFilamentInfo(std::string VendorDirectory, json& pFilaLis
     try {
         std::string contents;
         LoadFile(filepath, contents);
-        BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": Json Contents: " << contents;
         json jLocal = json::parse(contents);
 
         if (sVendor == "") {
@@ -1116,7 +1119,12 @@ int WebPresetDialog::GetFilamentInfo(std::string VendorDirectory, json& pFilaLis
                     return -1;
                 }
 
-                std::string FPath = pFilaList[FName]["sub_path"];
+                const json &inherited = pFilaList.at(FName);
+                if (!inherited.contains("sub_path") || !inherited["sub_path"].is_string()) {
+                    BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "inherits filament " << FName << " has no sub_path";
+                    return -1;
+                }
+                std::string FPath = inherited["sub_path"];
                 BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " Before Format Inherits Path: VendorDirectory - " << VendorDirectory
                                         << ", sub_path - " << FPath;
                 wxString                strNewFile = wxString::Format("%s%c%s", wxString(VendorDirectory.c_str(), wxConvUTF8),
@@ -1238,6 +1246,7 @@ int WebPresetDialog::LoadProfile()
                 if (w2s(strVendor) == PresetBundle::SM_BUNDLE && strExtension.CmpNoCase("json") == 0)
                     LoadProfileFamily(w2s(strVendor), iter->path().string());
             }
+            if (m_destroy.load(std::memory_order_acquire)) return 0;
         }
 
         // string                                others_targetPath = rsrc_vendor_dir.string();
@@ -1257,6 +1266,7 @@ int WebPresetDialog::LoadProfile()
                 if (w2s(strVendor) != PresetBundle::SM_BUNDLE && strExtension.CmpNoCase("json") == 0)
                     LoadProfileFamily(w2s(strVendor), iter->path().string());
             }
+            if (m_destroy.load(std::memory_order_acquire)) return 0;
         }
 
         // LoadProfileFamily(PresetBundle::BBL_BUNDLE, bbl_bundle_path.string());
@@ -1324,9 +1334,6 @@ int WebPresetDialog::LoadProfile()
         //  wxMessageBox(e.what(), "", MB_OK);
         BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ", error: " << e.what() << std::endl;
     }
-
-    std::string strAll = m_ProfileJson.dump(-1, ' ', false, json::error_handler_t::ignore);
-    // wxLogMessage("GUIDE: profile_json_s2  %s ", m_ProfileJson.dump(-1, ' ', false, json::error_handler_t::ignore));
     lock.unlock(); // release before marking ready / scheduling UI work
 
     m_profile_ready.store(true, std::memory_order_release);
@@ -1335,10 +1342,13 @@ int WebPresetDialog::LoadProfile()
             FlushPendingProfileRequest();
         });
 
-    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ", finished, json contents: " << std::endl << strAll;
     return 0;
 }
 
+// Precondition: the caller (LoadProfile) holds m_ProfileJson_mutex for the
+// whole load. The TBB workers below read the shared m_ProfileJson via const
+// references without locking; that is only race-free because every other
+// accessor of the global locks the same mutex and this thread owns it here.
 int WebPresetDialog::LoadProfileFamily(std::string strVendor, std::string strFilePath)
 {
     // wxString strFolder = strFilePath.BeforeLast(boost::filesystem::path::preferred_separator);
@@ -1348,11 +1358,13 @@ int WebPresetDialog::LoadProfileFamily(std::string strVendor, std::string strFil
     try {
         // wxLogMessage("GUIDE: json_path1  %s", w2s(strFilePath));
 
-        std::string contents;
-        LoadFile(strFilePath, contents);
-        // wxLogMessage("GUIDE: json_path1 content: %s", contents);
-        json jLocal = json::parse(contents);
-        // wxLogMessage("GUIDE: json_path1 Loaded");
+        std::string vendor_contents;
+        LoadFile(strFilePath, vendor_contents);
+        json jLocal = json::parse(vendor_contents, nullptr, false);
+        if (jLocal.is_discarded() || !jLocal.is_object()) {
+            BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": vendor index " << strFilePath << " malformed, skipped";
+            return -1;
+        }
 
         // BBS:models
         json pmodels = jLocal["machine_model_list"];
@@ -1360,69 +1372,104 @@ int WebPresetDialog::LoadProfileFamily(std::string strVendor, std::string strFil
 
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(",  got %1% machine models") % nsize;
 
-        for (int n = 0; n < nsize; n++) {
-            json OneModel = pmodels.at(n);
+        {
+            const json &pmodels_ro = pmodels;
+            load_section(nsize, m_destroy, [&](int n, json &slot) {
+                json OneModel = pmodels_ro.at(n);
+                if (!OneModel.is_object() || !OneModel["name"].is_string() || !OneModel["sub_path"].is_string()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: machine model " << n << " of vendor " << strVendor << " malformed, skipped";
+                    return;
+                }
 
-            OneModel["model"] = OneModel["name"];
-            OneModel.erase("name");
+                OneModel["model"] = OneModel["name"];
+                OneModel.erase("name");
 
-            std::string s1 = OneModel["model"];
-            std::string s2 = OneModel["sub_path"];
+                std::string s1 = OneModel["model"];
+                std::string s2 = OneModel["sub_path"];
 
-            boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
-            std::string             sub_file = sub_path.string();
+                boost::system::error_code ec;
+                boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
+                if (!boost::filesystem::exists(sub_path, ec) || ec) return;
+                std::string sub_file = sub_path.string();
 
-            // wxLogMessage("GUIDE: json_path2  %s", w2s(ModelFilePath));
-            LoadFile(sub_file, contents);
-            // wxLogMessage("GUIDE: json_path2 content: %s", contents);
-            json pm = json::parse(contents);
-            // wxLogMessage("GUIDE: json_path2  loaded");
+                std::string contents;
+                LoadFile(sub_file, contents);
+                json pm = json::parse(contents, nullptr, false);
+                if (pm.is_discarded() || !pm.is_object() || !pm["nozzle_diameter"].is_string()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: model file " << sub_file << " malformed, skipped";
+                    return;
+                }
 
-            OneModel["vendor"]    = strVendor;
-            std::string NozzleOpt = pm["nozzle_diameter"];
-            StringReplace(NozzleOpt, " ", "");
-            OneModel["nozzle_diameter"] = NozzleOpt;
-            OneModel["materials"]       = pm["default_materials"];
+                OneModel["vendor"]    = strVendor;
+                std::string NozzleOpt = pm["nozzle_diameter"];
+                StringReplace(NozzleOpt, " ", "");
+                OneModel["nozzle_diameter"] = NozzleOpt;
+                OneModel["materials"]       = pm["default_materials"];
 
-            // wxString strCoverPath = wxString::Format("%s\\%s\\%s_cover.png", strFolder, strVendor, std::string(s1.mb_str()));
-            std::string             cover_file = s1 + "_cover.png";
-            boost::filesystem::path cover_path = boost::filesystem::absolute(boost::filesystem::path(resources_dir()) / "/profiles/" /
-                                                                             strVendor / cover_file)
-                                                     .make_preferred();
-            if (!boost::filesystem::exists(cover_path)) {
-                cover_path = (boost::filesystem::absolute(boost::filesystem::path(resources_dir()) / "/web/image/printer/") / cover_file)
-                                 .make_preferred();
-            }
-            OneModel["cover"] = cover_path.string();
+                std::string             cover_file = s1 + "_cover.png";
+                boost::filesystem::path cover_path = boost::filesystem::absolute(boost::filesystem::path(resources_dir()) / "/profiles/" /
+                                                                                 strVendor / cover_file)
+                                                         .make_preferred();
+                if (!boost::filesystem::exists(cover_path, ec) || ec) {
+                    cover_path = (boost::filesystem::absolute(boost::filesystem::path(resources_dir()) / "/web/image/printer/") / cover_file)
+                                     .make_preferred();
+                }
+                OneModel["cover"] = cover_path.string();
 
-            OneModel["nozzle_selected"] = "";
+                OneModel["nozzle_selected"] = "";
 
-            m_ProfileJson["model"].push_back(OneModel);
+                slot = std::move(OneModel);
+            }, [this](json &item) { m_ProfileJson["model"].push_back(std::move(item)); });
+            if (m_destroy.load(std::memory_order_acquire)) return 0;
         }
 
         // BBS:Machine
         json pmachine = jLocal["machine_list"];
         nsize         = pmachine.size();
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(",  got %1% machines") % nsize;
-        for (int n = 0; n < nsize; n++) {
-            json OneMachine = pmachine.at(n);
+        {
+            const json &pmachine_ro = pmachine;
+            load_section(nsize, m_destroy, [&](int n, json &slot) {
+                json OneMachine = pmachine_ro.at(n);
 
-            std::string s1 = OneMachine["name"];
-            std::string s2 = OneMachine["sub_path"];
+                // Validate here: the serial merge below reads slot["name"]
+                // unguarded, so a malformed entry must drop only itself.
+                if (!OneMachine.is_object() || !OneMachine["name"].is_string() || !OneMachine["sub_path"].is_string()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: machine " << n << " of vendor " << strVendor << " malformed, skipped";
+                    return;
+                }
 
-            // wxString ModelFilePath = wxString::Format("%s\\%s\\%s", strFolder, strVendor, s2);
-            boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
-            std::string             sub_file = sub_path.string();
-            LoadFile(sub_file, contents);
-            json pm = json::parse(contents);
+                std::string s2 = OneMachine["sub_path"];
 
-            std::string strInstant = pm["instantiation"];
-            if (strInstant.compare("true") == 0) {
-                OneMachine["model"]  = pm["printer_model"];
-                OneMachine["nozzle"] = pm["nozzle_diameter"][0];
+                boost::system::error_code ec;
+                boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
+                if (!boost::filesystem::exists(sub_path, ec) || ec) return;
+                std::string sub_file = sub_path.string();
 
-                m_ProfileJson["machine"][s1] = OneMachine;
-            }
+                std::string contents;
+                LoadFile(sub_file, contents);
+                json pm = json::parse(contents, nullptr, false);
+                if (pm.is_discarded() || !pm.is_object()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: machine file " << sub_file << " malformed, skipped";
+                    return;
+                }
+
+                if (pm["instantiation"] == "true") {
+                    const json &nd = pm["nozzle_diameter"];
+                    if (!nd.is_array() && !nd.is_null()) {
+                        BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: machine file " << sub_file << " has malformed nozzle_diameter, skipped";
+                        return;
+                    }
+                    OneMachine["model"]  = pm["printer_model"];
+                    OneMachine["nozzle"] = (nd.is_array() && !nd.empty()) ? nd[0] : json();
+
+                    slot = std::move(OneMachine);
+                }
+            }, [this](json &item) {
+                std::string s1 = item["name"];
+                m_ProfileJson["machine"][s1] = std::move(item);
+            });
+            if (m_destroy.load(std::memory_order_acquire)) return 0;
         }
 
         // BBS:Filament
@@ -1432,92 +1479,125 @@ int WebPresetDialog::LoadProfileFamily(std::string strVendor, std::string strFil
 
         for (int n = 0; n < nsize; n++) {
             json OneFF = pFilament.at(n);
+            if (!OneFF.is_object() || !OneFF["name"].is_string()) continue;
 
             std::string s1 = OneFF["name"];
-            std::string s2 = OneFF["sub_path"];
 
             tFilaList[s1] = OneFF;
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << "Vendor: " << strVendor << ", tFilaList Add: " << s1;
         }
 
-        int nFalse  = 0;
-        int nModel  = 0;
-        int nFinish = 0;
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(",  got %1% filaments") % nsize;
-        for (int n = 0; n < nsize; n++) {
-            json OneFF = pFilament.at(n);
+        {
+            const json &pFilament_ro        = pFilament;
+            const json &tFilaList_ro        = tFilaList;
+            const json &machines_ro         = m_ProfileJson["machine"];
+            const json &loaded_filaments_ro = m_ProfileJson["filament"];
+            load_section(nsize, m_destroy, [&](int n, json &slot) {
+                json OneFF = pFilament_ro.at(n);
+                if (!OneFF.is_object() || !OneFF["name"].is_string() || !OneFF["sub_path"].is_string()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: filament " << n << " of vendor " << strVendor << " malformed, skipped";
+                    return;
+                }
 
-            std::string s1 = OneFF["name"];
-            std::string s2 = OneFF["sub_path"];
+                std::string s1 = OneFF["name"];
+                std::string s2 = OneFF["sub_path"];
 
-            if (!m_ProfileJson["filament"].contains(s1)) {
-                // wxString ModelFilePath = wxString::Format("%s\\%s\\%s", strFolder, strVendor, s2);
+                if (loaded_filaments_ro.contains(s1)) return;
+
+                boost::system::error_code ec;
                 boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
-                std::string             sub_file = sub_path.string();
+                if (!boost::filesystem::exists(sub_path, ec) || ec) return;
+                std::string sub_file = sub_path.string();
+
+                std::string contents;
                 LoadFile(sub_file, contents);
-                json pm = json::parse(contents);
+                if (contents == "") return;
+                json pm = json::parse(contents, nullptr, false);
+                if (pm.is_discarded() || !pm.is_object()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: filament file " << sub_file << " malformed, skipped";
+                    return;
+                }
 
-                std::string strInstant = pm["instantiation"];
-                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << "Load Filament:" << s1 << ",Path:" << sub_file << ",instantiation?"
-                                        << strInstant;
+                bool instant = (pm["instantiation"] == "true");
+                BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << "Load Filament:" << s1 << ",Path:" << sub_file << ",instantiation?" << (instant ? "true" : "false");
 
-                if (strInstant == "true") {
-                    std::string sV;
-                    std::string sT;
+                if (!instant) return;
 
-                    int nRet = GetFilamentInfo(vendor_dir.string(), tFilaList, sub_file, sV, sT);
-                    if (nRet != 0) {
-                        BOOST_LOG_TRIVIAL(info)
-                            << __FUNCTION__ << "Load Filament:" << s1 << ",GetFilamentInfo Failed, Vendor:" << sV << ",Type:" << sT;
-                        continue;
+                std::string sV;
+                std::string sT;
+
+                int nRet = GetFilamentInfo(vendor_dir.string(), tFilaList_ro, sub_file, sV, sT);
+                if (nRet != 0) {
+                    BOOST_LOG_TRIVIAL(error)
+                        << __FUNCTION__ << "Load Filament:" << s1 << ",GetFilamentInfo Failed, Vendor:" << sV << ",Type:" << sT;
+                    return;
+                }
+
+                OneFF["vendor"] = sV;
+                OneFF["type"]   = sT;
+
+                OneFF["models"] = "";
+
+                const json &pPrinters = pm["compatible_printers"];
+                std::string ModelList = "";
+                if (pPrinters.is_array()) {
+                    for (const json &printer : pPrinters) {
+                        if (!printer.is_string()) continue;
+                        std::string sP = printer;
+                        if (!machines_ro.contains(sP)) continue;
+                        const json &m = machines_ro.at(sP);
+                        if (!m.contains("model") || !m["model"].is_string() || !m.contains("nozzle") || !m["nozzle"].is_string()) continue;
+                        std::string mModel  = m["model"];
+                        std::string mNozzle = m["nozzle"];
+
+                        ModelList += "[" + mModel + "++" + mNozzle + "]";
                     }
+                }
 
-                    OneFF["vendor"] = sV;
-                    OneFF["type"]   = sT;
+                OneFF["models"]   = ModelList;
+                OneFF["selected"] = 0;
 
-                    OneFF["models"] = "";
-
-                    json        pPrinters = pm["compatible_printers"];
-                    int         nPrinter  = pPrinters.size();
-                    std::string ModelList = "";
-                    for (int i = 0; i < nPrinter; i++) {
-                        std::string sP = pPrinters.at(i);
-                        if (m_ProfileJson["machine"].contains(sP)) {
-                            std::string mModel   = m_ProfileJson["machine"][sP]["model"];
-                            std::string mNozzle  = m_ProfileJson["machine"][sP]["nozzle"];
-                            std::string NewModel = mModel + "++" + mNozzle;
-
-                            ModelList = (boost::format("%1%[%2%]") % ModelList % NewModel).str();
-                        }
-                    }
-
-                    OneFF["models"]   = ModelList;
-                    OneFF["selected"] = 0;
-
-                    m_ProfileJson["filament"][s1] = OneFF;
-                } else
-                    continue;
-            }
+                slot = std::move(OneFF);
+            }, [this](json &item) {
+                std::string s1 = item["name"];
+                // first occurrence wins, matching the old serial semantics
+                if (!m_ProfileJson["filament"].contains(s1))
+                    m_ProfileJson["filament"][s1] = std::move(item);
+            });
+            if (m_destroy.load(std::memory_order_acquire)) return 0;
         }
 
         // process
         json pProcess = jLocal["process_list"];
         nsize         = pProcess.size();
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(",  got %1% processes") % nsize;
-        for (int n = 0; n < nsize; n++) {
-            json OneProcess = pProcess.at(n);
+        {
+            const json &pProcess_ro = pProcess;
+            load_section(nsize, m_destroy, [&](int n, json &slot) {
+                json OneProcess = pProcess_ro.at(n);
+                if (!OneProcess.is_object() || !OneProcess["sub_path"].is_string()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: process " << n << " of vendor " << strVendor << " malformed, skipped";
+                    return;
+                }
 
-            std::string s2 = OneProcess["sub_path"];
-            // wxString ModelFilePath = wxString::Format("%s\\%s\\%s", strFolder, strVendor, s2);
-            boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
-            std::string             sub_file = sub_path.string();
-            LoadFile(sub_file, contents);
-            json pm = json::parse(contents);
+                std::string s2 = OneProcess["sub_path"];
+                boost::system::error_code ec;
+                boost::filesystem::path sub_path = boost::filesystem::absolute(vendor_dir / s2).make_preferred();
+                if (!boost::filesystem::exists(sub_path, ec) || ec) return;
+                std::string sub_file = sub_path.string();
 
-            std::string bInstall = pm["instantiation"];
-            if (bInstall == "true") {
-                m_ProfileJson["process"].push_back(OneProcess);
-            }
+                std::string contents;
+                LoadFile(sub_file, contents);
+                json pm = json::parse(contents, nullptr, false);
+                if (pm.is_discarded() || !pm.is_object()) {
+                    BOOST_LOG_TRIVIAL(warning) << "LoadProfileFamily: process file " << sub_file << " malformed, skipped";
+                    return;
+                }
+
+                if (pm["instantiation"] == "true") slot = std::move(OneProcess);
+            }, [this](json &item) { m_ProfileJson["process"].push_back(std::move(item)); });
+            if (m_destroy.load(std::memory_order_acquire)) return 0;
         }
 
     } catch (nlohmann::detail::parse_error& err) {

--- a/src/slic3r/GUI/WebPresetDialog.hpp
+++ b/src/slic3r/GUI/WebPresetDialog.hpp
@@ -72,7 +72,7 @@ public:
     int LoadProfile();
     int LoadProfileFamily(std::string strVendor, std::string strFilePath);
     int SaveProfile();
-    int GetFilamentInfo(std::string VendorDirectory, json& pFilaList, std::string filepath, std::string& sVendor, std::string& sType);
+    int GetFilamentInfo(std::string VendorDirectory, const json& pFilaList, std::string filepath, std::string& sVendor, std::string& sType);
 
     bool apply_config(AppConfig* app_config, PresetBundle* preset_bundle, const PresetUpdater* updater, bool& apply_keeped_changes);
     bool run();

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(${_TEST_NAME}_tests
 	test_local_z_order_optimizer.cpp
 	test_placeholder_parser.cpp
 	test_polygon.cpp
+	test_profile_load_util.cpp
 	test_mutable_polygon.cpp
 	test_mutable_priority_queue.cpp
 	test_stl.cpp

--- a/tests/libslic3r/test_profile_load_util.cpp
+++ b/tests/libslic3r/test_profile_load_util.cpp
@@ -1,0 +1,147 @@
+#include <catch2/catch.hpp>
+#include <atomic>
+#include <string>
+#include <vector>
+
+// Header under test lives in the GUI layer but has no GUI/wx dependencies -
+// only nlohmann::json + TBB, both available transitively via libslic3r.
+#include "../../src/slic3r/GUI/ProfileLoadUtil.hpp"
+
+using namespace nlohmann;
+using namespace Slic3r::GUI;
+
+// Catch2 v2 assertions are NOT thread-safe. The `work` lambdas here run on TBB
+// workers, so they only WRITE their slot (never assert); every check runs on
+// the main thread after parallel_load_items / load_section returns (both block
+// until the parallel pass completes, and load_section's merge loop runs on the
+// calling thread).
+
+TEST_CASE("parallel_load_items fills every slot indexed by n", "[ProfileLoadUtil]")
+{
+    const int n = 64;
+    std::atomic<bool> destroy{false};
+    auto slots = parallel_load_items(n, destroy, [](int i, json &slot) {
+        slot = i;
+    });
+    REQUIRE((int) slots.size() == n);
+    for (int i = 0; i < n; ++i) {
+        REQUIRE(slots[i].is_number_integer());
+        REQUIRE(slots[i].get<int>() == i);
+    }
+}
+
+TEST_CASE("parallel_load_items leaves skipped slots null", "[ProfileLoadUtil]")
+{
+    const int n = 32;
+    std::atomic<bool> destroy{false};
+    auto slots = parallel_load_items(n, destroy, [](int i, json &slot) {
+        if (i % 2 == 0) return;  // even indices skipped (slot stays null)
+        slot = i;
+    });
+    REQUIRE((int) slots.size() == n);
+    for (int i = 0; i < n; ++i) {
+        if (i % 2 == 0) {
+            REQUIRE(slots[i].is_null());
+        } else {
+            REQUIRE(slots[i].get<int>() == i);
+        }
+    }
+}
+
+TEST_CASE("parallel_load_items handles an empty range", "[ProfileLoadUtil]")
+{
+    std::atomic<bool> destroy{false};
+    auto slots = parallel_load_items(0, destroy, [](int, json &) {
+        FAIL("work must not run for an empty range");
+    });
+    REQUIRE(slots.empty());
+}
+
+TEST_CASE("parallel_load_items with destroy already set writes no slot", "[ProfileLoadUtil]")
+{
+    // destroy is checked before work() each iteration, so a flag that is already
+    // true makes every worker bail without writing. This is the dialog-torn-down
+    // teardown path.
+    const int n = 16;
+    std::atomic<bool> destroy{true};
+    auto slots = parallel_load_items(n, destroy, [](int i, json &slot) {
+        slot = i;
+    });
+    REQUIRE((int) slots.size() == n);
+    for (int i = 0; i < n; ++i)
+        REQUIRE(slots[i].is_null());
+}
+
+TEST_CASE("load_section merges non-null slots in list order", "[ProfileLoadUtil]")
+{
+    const int n = 48;
+    std::vector<int> collected;
+    std::atomic<bool> destroy{false};
+    load_section(n, destroy,
+        [](int i, json &slot) { slot = i; },
+        [&](json &item) { collected.push_back(item.get<int>()); });
+
+    REQUIRE((int) collected.size() == n);
+    for (int i = 0; i < n; ++i)
+        REQUIRE(collected[i] == i);
+}
+
+TEST_CASE("load_section skips null slots and keeps the rest in order", "[ProfileLoadUtil]")
+{
+    const int n = 40;
+    int expected = 0;
+    for (int i = 0; i < n; ++i)
+        if (i % 3 != 0) ++expected;
+
+    std::vector<int> collected;
+    std::atomic<bool> destroy{false};
+    load_section(n, destroy,
+        [](int i, json &slot) { if (i % 3 != 0) slot = i; },  // drop multiples of 3
+        [&](json &item) { collected.push_back(item.get<int>()); });
+
+    REQUIRE((int) collected.size() == expected);
+    for (int v : collected)
+        REQUIRE(v % 3 != 0);
+    for (size_t i = 1; i < collected.size(); ++i)
+        REQUIRE(collected[i] > collected[i - 1]);
+}
+
+TEST_CASE("load_section performs no merge when destroy is set", "[ProfileLoadUtil]")
+{
+    std::vector<int> collected;
+    std::atomic<bool> destroy{true};
+    load_section(16, destroy,
+        [](int i, json &slot) { slot = i; },
+        [&](json &item) { collected.push_back(item.get<int>()); });
+    REQUIRE(collected.empty());
+}
+
+TEST_CASE("load_section handles an empty range", "[ProfileLoadUtil]")
+{
+    std::vector<int> collected;
+    std::atomic<bool> destroy{false};
+    load_section(0, destroy,
+        [](int, json &) { FAIL("work must not run for an empty range"); },
+        [&](json &)      { FAIL("merge must not run for an empty range"); });
+    REQUIRE(collected.empty());
+}
+
+TEST_CASE("worker pattern: malformed JSON drops only itself, no throw", "[ProfileLoadUtil]")
+{
+    // Mirrors the no-throw contract used in LoadProfileFamily: parse with the
+    // exception-free overload, leave the slot null on failure, and load_section
+    // skips it - the rest of the family is unaffected and nothing is thrown.
+    const std::vector<std::string> inputs = {"1", "2", "{ broken", "3", "4"};
+    std::vector<int> collected;
+    std::atomic<bool> destroy{false};
+    load_section((int) inputs.size(), destroy,
+        [&](int i, json &slot) {
+            json j = json::parse(inputs[i], nullptr, false);
+            if (j.is_discarded()) return;  // malformed -> drop only this item
+            slot = j;
+        },
+        [&](json &item) { collected.push_back(item.get<int>()); });
+
+    std::vector<int> expected = {1, 2, 3, 4};  // index 2 dropped
+    REQUIRE(collected == expected);
+}


### PR DESCRIPTION
# Description

GuideFrame::LoadProfileData() (setup wizard / "configure selectable filaments") and WebPresetDialog::LoadProfile() (constructed at every app startup for SSWCP; also the web UI's switch-model flow) read ~8000 profile JSON files strictly serially, stalling for seconds on first use.

Measured on a real run: 383 ms for 326 models / 796 machines / 2660 filaments / 2167 processes (previously a multi-second serial load).