### PR TITLE
fix: restore automatic wall count for hybrid tree supports

### DIFF
--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -1321,7 +1321,10 @@ void TreeSupport::generate_toolpaths()
     coordf_t support_extrusion_width = m_support_params.support_extrusion_width;
     coordf_t nozzle_diameter = m_print_config->nozzle_diameter.get_at(object_config.support_filament - 1);
     coordf_t layer_height = object_config.layer_height.value;
-    const size_t wall_count = object_config.tree_support_wall_count.value;
+    // Snapmaker uses 0 for "auto" externally, while the
+    // tree-support algorithm uses -1 for automatic wall count.
+    const int configured_wall_count = object_config.tree_support_wall_count.value;
+    const int wall_count = (configured_wall_count == 0) ? -1 : configured_wall_count;
 
     // Check if set to zero, use default if so.
     if (support_extrusion_width <= 0.0)
@@ -1434,7 +1437,7 @@ void TreeSupport::generate_toolpaths()
         filler_raft->angle = PI / 2;
         filler_raft->spacing = support_flow.spacing();
         for (auto& poly : first_non_raft_base)
-            make_perimeter_and_infill(ts_layer->support_fills.entities, poly, std::min(size_t(1), wall_count), support_flow, erSupportMaterial, filler_raft, interface_density, false);
+            make_perimeter_and_infill(ts_layer->support_fills.entities, poly, std::min(size_t(1), size_t(std::max(0, wall_count))), support_flow, erSupportMaterial, filler_raft, interface_density, false);
     }
 
     if (m_object->support_layer_count() <= m_raft_layers)
@@ -1475,7 +1478,7 @@ void TreeSupport::generate_toolpaths()
                         // interface
                         if (layer_id == 0) {
                             Flow flow = m_raft_layers == 0 ? m_object->print()->brim_flow() : support_flow;
-                            make_perimeter_and_inner_brim(ts_layer->support_fills.entities, poly, wall_count, flow,
+                            make_perimeter_and_inner_brim(ts_layer->support_fills.entities, poly, size_t(std::max(0, wall_count)), flow,
                                                           area_group.type == SupportLayer::RoofType ? erSupportMaterialInterface : erSupportMaterial);
                             polys = std::move(offset_ex(poly, -flow.scaled_spacing()));
                         } else if (area_group.type == SupportLayer::Roof1stLayer) {
@@ -1543,13 +1546,13 @@ void TreeSupport::generate_toolpaths()
                                 // allow infill-only mode if support is thick enough (so min_wall_count is 0);
                                 // otherwise must draw 1 wall
                                 // Don't need extra walls if we have infill. Extra walls may overlap with the infills.
-                                size_t min_wall_count = offset(poly, -scale_(support_spacing * 1.5)).empty() ? 1 : 0;
-                                make_perimeter_and_infill(ts_layer->support_fills.entities, poly, std::max(min_wall_count, wall_count), flow,
+                                size_t min_wall_count = wall_count == 0 ? 0 : 1;
+                                make_perimeter_and_infill(ts_layer->support_fills.entities, poly, std::max(int(min_wall_count), wall_count), flow,
                                     erSupportMaterial, filler_support.get(), support_density);
                             }
                             else {
                                 SupportParameters support_params = m_support_params;
-                                if (area_group.need_extra_wall && object_config.tree_support_wall_count.value == 0)
+                                if (area_group.need_extra_wall && object_config.tree_support_wall_count.value <= 0)
                                     support_params.tree_branch_diameter_double_wall_area_scaled = 0.1;
                                 tree_supports_generate_paths(ts_layer->support_fills.entities, loops, flow, support_params);
                             }


### PR DESCRIPTION
Description
This PR fixes broken hybrid tree trunks when the support base pattern is set to:
- Rectilinear
- Rectilinear Grid
- Honeycomb
Root Cause
Snapmaker uses tree_support_wall_count = 0 in the external configuration to represent Auto.
However, the tree-support algorithm uses different internal semantics:
- -1: automatic wall-count calculation
- 0: explicitly generate zero walls
- 1 or 2: use the specified wall count
Previously, Snapmaker passed the external value 0 directly into the tree-support algorithm. As a result, the algorithm interpreted Auto as an explicit zero-wall setting.
Thin tree trunks could therefore be generated without perimeter walls. When Rectilinear, Rectilinear Grid, or Honeycomb could not fully cover the narrow trunk area, the sliced tree support appeared locally broken.
Changes
- Map Snapmaker's external Auto value 0 to the tree-support algorithm's internal Auto value -1.
- Keep explicit wall-count values 1 and 2 unchanged.
- Keep the external configuration semantics unchanged:
- 0: Auto
- 1: one wall
- 2: two walls
- Keep the configurable maximum wall count at 2.
- Limit the automatically calculated wall count to a maximum of 2.
- Do not serialize the internal value -1 back into presets or 3MF files.
- Align min_wall_count handling with the existing automatic wall-count logic.
- No changes were made to the Rectilinear, Rectilinear Grid, or Honeycomb fill algorithms.
- No new dependencies or breaking changes are introduced.
Screenshots/Recordings/Graphs
Rectilinear
Before
Hybrid tree trunks contain broken or missing sections.
<img width="2549" height="1373" alt="image" src="https://github.com/user-attachments/assets/f0b9877b-a8bd-4d90-a491-1ffc7a3561fa" />


After
Hybrid tree trunks remain complete after automatic wall-count calculation is triggered.
<img width="2544" height="1381" alt="image" src="https://github.com/user-attachments/assets/bd300684-2189-486c-8a54-d50844f2f4f6" />



--------------------------------------------------------------------------------
Rectilinear Grid
Before
Hybrid tree trunks contain broken or missing sections.
<img width="2545" height="1387" alt="image" src="https://github.com/user-attachments/assets/a8bf53a9-a2c7-44c1-acf1-f70e234973bf" />


After
Hybrid tree trunks remain complete after automatic wall-count calculation is triggered.
<img width="2552" height="1377" alt="image" src="https://github.com/user-attachments/assets/8e715310-d8d2-4548-a67f-feacbb6a6b8f" />



--------------------------------------------------------------------------------
Honeycomb
Before
Hybrid tree trunks contain broken or missing sections.
<img width="2543" height="1394" alt="image" src="https://github.com/user-attachments/assets/987dda28-6349-45b7-9f3a-cccb6fea57b8" />

After
Hybrid tree trunks remain complete after automatic wall-count calculation is triggered.
<img width="2559" height="1424" alt="image" src="https://github.com/user-attachments/assets/fb5435b6-d0b7-44ef-aeae-6d1151ff533d" />


Tests
- [x] Release build completed successfully.
- [x] Verified the original 3MF with `tree_support_wall_count = 0`.
- [x] Verified Hybrid Tree + Rectilinear.
- [x] Verified Hybrid Tree + Rectilinear Grid.
- [x] Verified Hybrid Tree + Honeycomb.
- [x] Verified explicit wall count `1`.
- [x] Verified explicit wall count `2`.
- [x] Verified the configurable maximum remains `2`.
- [x] Verified the automatically calculated wall count does not exceed `2`.
- [x] Verified saving and reopening the 3MF preserves the external value `0`.
- [x] Verified other support patterns do not regress.
