### PR TITLE
fix: hide support transition speed from UI

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2605,7 +2605,6 @@ void TabPrint::build()
         optgroup->append_single_option_line("ironing_speed", "speed_settings_other_layers_speed#ironing-speed");
         optgroup->append_single_option_line("support_speed", "speed_settings_other_layers_speed#support");
         optgroup->append_single_option_line("support_interface_speed", "speed_settings_other_layers_speed#support-interface");
-        optgroup->append_single_option_line("support_transition_speed", "speed_settings_other_layers_speed#support-transition");
         optgroup = page->new_optgroup(L("Overhang speed"), L"param_overhang_speed", 15);
         optgroup->append_single_option_line("enable_overhang_speed", "speed_settings_overhang_speed#slow-down-for-overhang");
         optgroup->append_single_option_line("slowdown_for_curled_perimeters", "speed_settings_overhang_speed#slow-down-for-curled-perimeters");


### PR DESCRIPTION
## Summary

Remove the  + "" + support_transition_speed + "" + @ UI registration from the Speed tab while keeping the underlying engine logic intact (def entry, config struct member, and GCode/Flow references unchanged).

## Changes

-  + "" + src/slic3r/GUI/Tab.cpp + "" + @: Remove the UI option line from the Speed settings section

## Background

The tree support transition layer feature (PR #556) introduced four UI parameters. Three of them were already hidden in commit d9b87a2, but  + "" + support_transition_speed + "" + @ was missed. The engine default (50 mm/s) is sufficient.

## Verification

- [x] def entry preserved at PrintConfig.cpp:5604
- [x] struct member preserved at PrintConfig.hpp:936
- [x] GCode.cpp / Flow.cpp runtime references unaffected
