### PR TITLE
feat: add support_interface_min_area 

### DIFF
--- a/doc/print_settings/support/support_settings_advanced.md
+++ b/doc/print_settings/support/support_settings_advanced.md
@@ -8,6 +8,7 @@
 - [Interface layers](#interface-layers)
 - [Interface pattern](#interface-pattern)
 - [Interface spacing](#interface-spacing)
+- [Interface min area](#interface-min-area)
 - [Normal support expansion](#normal-support-expansion)
 - [Support/object XY distance](#supportobject-xy-distance)
 - [Support/object first layer gap](#supportobject-first-layer-gap)
@@ -45,6 +46,10 @@ The pattern used for the support interface.
 ## Interface spacing
 
 Spacing of interface lines. Zero means solid interface.
+
+## Interface min area
+
+Minimum area for support contact surfaces, in square millimeters. Roof polygons smaller than this value fall back to normal support instead of being generated as interface. Lower values generate more contact surfaces; higher values consolidate them. Set to 0 to disable filtering.
 
 ## Normal support expansion
 

--- a/localization/i18n/Snapmaker_Orca.pot
+++ b/localization/i18n/Snapmaker_Orca.pot
@@ -12931,6 +12931,12 @@ msgstr ""
 msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr ""
 
+msgid "Minimum Support Contact Area"
+msgstr ""
+
+msgid "Lower values generate more support contact surfaces."
+msgstr ""
+
 msgid "Speed of support interface."
 msgstr ""
 

--- a/localization/i18n/ca/Snapmaker_Orca_ca.po
+++ b/localization/i18n/ca/Snapmaker_Orca_ca.po
@@ -14917,6 +14917,12 @@ msgstr ""
 "Espaiat de les línies inferiors de la interfície. Zero significa interfície "
 "sòlida"
 
+msgid "Minimum Support Contact Area"
+msgstr "Àrea mínima de contacte del suport"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Els valors més baixos generen més superfícies de contacte del suport."
+
 msgid "Speed of support interface."
 msgstr "Velocitat de la interfície de suport"
 

--- a/localization/i18n/cs/Snapmaker_Orca_cs.po
+++ b/localization/i18n/cs/Snapmaker_Orca_cs.po
@@ -13908,6 +13908,12 @@ msgstr "Spodní rozestup"
 msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr "Rozestup linek spodního. Nula znamená plné rozhraní"
 
+msgid "Minimum Support Contact Area"
+msgstr "Minimální kontaktní plocha podpěr"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Nižší hodnoty generují více kontaktních ploch podpěr."
+
 msgid "Speed of support interface."
 msgstr "Rychlost pro kontaktní vrstvy podpěr"
 

--- a/localization/i18n/de/Snapmaker_Orca_de.po
+++ b/localization/i18n/de/Snapmaker_Orca_de.po
@@ -15197,6 +15197,12 @@ msgstr ""
 "Abstand der unteren Trennschichtlinien der Stützstrukturen. Null bedeutet "
 "eine solide Schnittstelle."
 
+msgid "Minimum Support Contact Area"
+msgstr "Minimale Kontaktfläche der Stützstruktur"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Niedrigere Werte erzeugen mehr Kontaktflächen der Stützstruktur."
+
 msgid "Speed of support interface."
 msgstr "Geschwindigkeit der Stützstruktur-Schnittstellen."
 

--- a/localization/i18n/en/Snapmaker_Orca_en.po
+++ b/localization/i18n/en/Snapmaker_Orca_en.po
@@ -13312,6 +13312,12 @@ msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr ""
 "This is the spacing of bottom interface lines. 0 means solid interface."
 
+msgid "Minimum Support Contact Area"
+msgstr ""
+
+msgid "Lower values generate more support contact surfaces."
+msgstr ""
+
 msgid "Speed of support interface."
 msgstr "This is the speed for support interfaces."
 

--- a/localization/i18n/es/Snapmaker_Orca_es.po
+++ b/localization/i18n/es/Snapmaker_Orca_es.po
@@ -14786,6 +14786,12 @@ msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr ""
 "Espaciado de las líneas de interfaz. Cero significa que la interfaz es sólida"
 
+msgid "Minimum Support Contact Area"
+msgstr "Área mínima de contacto del soporte"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Los valores más bajos generan más superficies de contacto del soporte."
+
 msgid "Speed of support interface."
 msgstr "Velocidad de la interfaz de soporte"
 

--- a/localization/i18n/fr/Snapmaker_Orca_fr.po
+++ b/localization/i18n/fr/Snapmaker_Orca_fr.po
@@ -15110,6 +15110,12 @@ msgstr ""
 "Espacement des lignes d'interface inférieures. Zéro signifie une interface "
 "solide"
 
+msgid "Minimum Support Contact Area"
+msgstr "Surface de contact minimale du support"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Des valeurs plus basses génèrent davantage de surfaces de contact du support."
+
 msgid "Speed of support interface."
 msgstr "Vitesse pour l'interface des supports"
 

--- a/localization/i18n/hu/Snapmaker_Orca_hu.po
+++ b/localization/i18n/hu/Snapmaker_Orca_hu.po
@@ -13642,6 +13642,12 @@ msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr ""
 "Az érintkező réteg vonalai közötti távolság. A nulla szilárd kitöltést jelent"
 
+msgid "Minimum Support Contact Area"
+msgstr "Támasz minimális érintkezési felülete"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Az alacsonyabb értékek több érintkezési felületet hoznak létre."
+
 msgid "Speed of support interface."
 msgstr "Támasz érintkező felületek sebessége"
 

--- a/localization/i18n/it/Snapmaker_Orca_it.po
+++ b/localization/i18n/it/Snapmaker_Orca_it.po
@@ -15027,6 +15027,12 @@ msgstr ""
 "Spaziatura delle linee dell'interfaccia inferiore. 0 equivale ad "
 "un'interfaccia solida."
 
+msgid "Minimum Support Contact Area"
+msgstr "Area minima di contatto del supporto"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Valori più bassi generano più superfici di contatto del supporto."
+
 msgid "Speed of support interface."
 msgstr "Velocità per le interfacce di supporto."
 

--- a/localization/i18n/ja/Snapmaker_Orca_ja.po
+++ b/localization/i18n/ja/Snapmaker_Orca_ja.po
@@ -13315,6 +13315,12 @@ msgstr "底部接触面間隔"
 msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr "底部接触面を造形時に線の距離です。0はソリッド接触面です。"
 
+msgid "Minimum Support Contact Area"
+msgstr "サポート接触面積の最小値"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "値を小さくすると、より多くのサポート接触面が生成されます。"
+
 msgid "Speed of support interface."
 msgstr "サポート接触面の造形速度です。"
 

--- a/localization/i18n/ko/Snapmaker_Orca_ko.po
+++ b/localization/i18n/ko/Snapmaker_Orca_ko.po
@@ -14263,6 +14263,12 @@ msgstr "하단 접점 선 간격"
 msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr "하단 접점 선의 간격. 0은 꽉찬 접점을 의미합니다"
 
+msgid "Minimum Support Contact Area"
+msgstr "서포트 최소 접촉 면적"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "값이 작을수록 더 많은 서포트 접촉면이 생성됩니다."
+
 msgid "Speed of support interface."
 msgstr "서포트 접점 속도"
 

--- a/localization/i18n/lt/Snapmaker_Orca_lt.po
+++ b/localization/i18n/lt/Snapmaker_Orca_lt.po
@@ -14728,6 +14728,12 @@ msgstr "Apatinės sąsajos tarpas"
 msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr "Atstumas tarp apatinių sąsajos linijų. 0 reiškia vientisą sąsają"
 
+msgid "Minimum Support Contact Area"
+msgstr "Minimalus atramos kontaktinis plotas"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Mažesnės reikšmės sukuria daugiau atramos kontaktinių paviršių."
+
 msgid "Speed of support interface."
 msgstr "Atramų sąsajų greitis"
 

--- a/localization/i18n/nl/Snapmaker_Orca_nl.po
+++ b/localization/i18n/nl/Snapmaker_Orca_nl.po
@@ -13839,6 +13839,12 @@ msgstr ""
 "Dit is de afstand tussen de onderste interfacelijnen. 0 betekent solide "
 "interface."
 
+msgid "Minimum Support Contact Area"
+msgstr "Minimale contactoppervlak van support"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Lagere waarden genereren meer contactoppervlakken van de support."
+
 msgid "Speed of support interface."
 msgstr "Dit is de snelheid voor het printen van de support interfaces."
 

--- a/localization/i18n/pl/Snapmaker_Orca_pl.po
+++ b/localization/i18n/pl/Snapmaker_Orca_pl.po
@@ -14838,6 +14838,12 @@ msgstr ""
 "Odstęp między liniami dolnej powierzchni warstwy łączącej. Wartość zero "
 "oznacza, że warstwa łącząca jest jednolita i bez przerw"
 
+msgid "Minimum Support Contact Area"
+msgstr "Minimalna powierzchnia kontaktu podpory"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Niższe wartości generują więcej powierzchni kontaktowych podpory."
+
 msgid "Speed of support interface."
 msgstr "Prędkość dla warstw łączących"
 

--- a/localization/i18n/pt_BR/Snapmaker_Orca_pt_BR.po
+++ b/localization/i18n/pt_BR/Snapmaker_Orca_pt_BR.po
@@ -15015,6 +15015,12 @@ msgstr ""
 "Espaçamento das linhas de interface inferior. Zero significa interface "
 "sólida."
 
+msgid "Minimum Support Contact Area"
+msgstr "Área mínima de contato do suporte"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Valores menores geram mais superfícies de contato do suporte."
+
 msgid "Speed of support interface."
 msgstr "Velocidade da interface de suporte."
 

--- a/localization/i18n/ru/Snapmaker_Orca_ru.po
+++ b/localization/i18n/ru/Snapmaker_Orca_ru.po
@@ -15136,6 +15136,12 @@ msgstr ""
 "Расстояние между линиями связующего слоя снизу. Установите 0, чтобы получить "
 "сплошной слой."
 
+msgid "Minimum Support Contact Area"
+msgstr "Минимальная площадь контакта поддержки"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Меньшие значения создают больше площадей контакта поддержки."
+
 msgid "Speed of support interface."
 msgstr "Скорость печати связующего слоя поддержки."
 

--- a/localization/i18n/sv/Snapmaker_Orca_sv.po
+++ b/localization/i18n/sv/Snapmaker_Orca_sv.po
@@ -13538,6 +13538,12 @@ msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr ""
 "Mellanrummet på botten gränssnittets linjer. 0 betyder solid gränssnitt"
 
+msgid "Minimum Support Contact Area"
+msgstr "Supportens minsta kontaktyta"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Lägre värden genererar fler kontaktytor för supporten."
+
 msgid "Speed of support interface."
 msgstr "Support gränssnittets hastighet"
 

--- a/localization/i18n/tr/Snapmaker_Orca_tr.po
+++ b/localization/i18n/tr/Snapmaker_Orca_tr.po
@@ -14819,6 +14819,12 @@ msgstr "Alt arayüz aralığı"
 msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr "Alt arayüz çizgilerinin aralığı. Sıfır, sağlam arayüz anlamına gelir."
 
+msgid "Minimum Support Contact Area"
+msgstr "Minimum destek temas alanı"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Daha düşük değerler daha fazla destek temas yüzeyi oluşturur."
+
 msgid "Speed of support interface."
 msgstr "Destek arayüzünün hızı."
 

--- a/localization/i18n/uk/Snapmaker_Orca_uk.po
+++ b/localization/i18n/uk/Snapmaker_Orca_uk.po
@@ -14826,6 +14826,12 @@ msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr ""
 "Відстань між нижніми інтерфейсними лініями. Нуль означає суцільнийінтерфейс"
 
+msgid "Minimum Support Contact Area"
+msgstr "Мінімальна площа контакту підтримки"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "Нижчі значення створюють більше контактних поверхонь підтримки."
+
 msgid "Speed of support interface."
 msgstr "Швидкість друку підтримки"
 

--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -11980,6 +11980,12 @@ msgstr "底部接触面线距"
 msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr "底部接触面走线的线距。0表示实心接触面。"
 
+msgid "Minimum Support Contact Area"
+msgstr "最小支撑接触面面积"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "阈值越小，生成的支撑接触面越多。"
+
 msgid "Speed of support interface."
 msgstr "支撑面速度"
 

--- a/localization/i18n/zh_TW/Snapmaker_Orca_zh_TW.po
+++ b/localization/i18n/zh_TW/Snapmaker_Orca_zh_TW.po
@@ -13753,6 +13753,12 @@ msgstr "底部接觸面間距"
 msgid "Spacing of bottom interface lines. Zero means solid interface."
 msgstr "底部接觸面走線的線距。0 表示實心接觸面"
 
+msgid "Minimum Support Contact Area"
+msgstr "最小支撐接觸面積"
+
+msgid "Lower values generate more support contact surfaces."
+msgstr "數值越小，生成的支撐接觸面越多。"
+
 msgid "Speed of support interface."
 msgstr "支撐面速度"
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -891,6 +891,7 @@ static std::vector<std::string> s_Preset_print_options {
     "independent_support_layer_height",
     "support_angle", "support_interface_top_layers", "support_interface_bottom_layers",
     "support_interface_pattern", "support_interface_spacing", "support_interface_loop_pattern",
+    "support_interface_min_area",
     "support_top_z_distance", "support_on_build_plate_only","support_critical_regions_only", "bridge_no_support", "thick_bridges", "thick_internal_bridges","dont_filter_internal_bridges","enable_extra_bridge_layer", "max_bridge_length", "print_sequence", "print_order", "support_remove_small_overhang",
     "filename_format", "wall_filament", "support_bottom_z_distance",
     "sparse_infill_filament", "solid_infill_filament", "support_filament", "support_interface_filament","support_interface_not_for_body",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5397,6 +5397,24 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0.5));
 
+    def = this->add("support_interface_min_area", coFloat);
+    def->gui_type = ConfigOptionDef::GUIType::f_enum_open;
+    def->label    = L("Minimum Support Contact Area");
+    def->category = L("Support");
+    def->tooltip  = L("Lower values generate more support contact surfaces.");
+    def->sidetext = "mm²";	// square milimeters, don't need translation
+    def->min      = 0;
+    def->enum_values.push_back("0");
+    def->enum_values.push_back("0.25");
+    def->enum_values.push_back("0.64");
+    def->enum_values.push_back("1");
+    def->enum_labels.push_back("0");
+    def->enum_labels.push_back("0.25");
+    def->enum_labels.push_back("0.64");
+    def->enum_labels.push_back("1");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0.25));
+
     //BBS
     def = this->add("support_bottom_interface_spacing", coFloat);
     def->label = L("Bottom interface spacing");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -868,6 +868,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionInt,                 support_interface_bottom_layers))
     // Spacing between interface lines (the hatching distance). Set zero to get a solid interface.
     ((ConfigOptionFloat,               support_interface_spacing))
+    ((ConfigOptionFloat,               support_interface_min_area))
     ((ConfigOptionFloat,               support_interface_speed))
     ((ConfigOptionEnum<SupportMaterialPattern>, support_base_pattern))
     ((ConfigOptionEnum<SupportMaterialInterfacePattern>, support_interface_pattern))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1027,6 +1027,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "support_interface_filament"
             || opt_key == "support_interface_not_for_body"
             || opt_key == "support_interface_spacing"
+            || opt_key == "support_interface_min_area"
             || opt_key == "support_bottom_interface_spacing" //BBS
             || opt_key == "support_base_pattern"
             || opt_key == "support_style"

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -629,6 +629,7 @@ TreeSupport::TreeSupport(PrintObject& object, const SlicingParameters &slicing_p
     // align with the centered object in current plate (may not be the 1st plate, so need to add the plate offset)
     m_machine_border.translate(Point(scale_(plate_offset(0)), scale_(plate_offset(1))) - m_object->instances().front().shift);
     top_z_distance                            = m_object_config->support_top_z_distance.value;
+    minimum_roof_area                         = scaled<double>(scaled<double>(m_object_config->support_interface_min_area.value));
     if (top_z_distance > EPSILON) top_z_distance = std::max(top_z_distance, float(m_slicing_params.min_layer_height));
 #ifdef SUPPORT_TREE_DEBUG_TO_SVG
     SVG svg(debug_out_path("machine_boarder.svg"), m_object->bounding_box());

--- a/src/libslic3r/Support/TreeSupport.hpp
+++ b/src/libslic3r/Support/TreeSupport.hpp
@@ -438,8 +438,8 @@ private:
     const coordf_t MAX_BRANCH_RADIUS_FIRST_LAYER = 12.0;
     const coordf_t MIN_BRANCH_RADIUS_FIRST_LAYER = 2.0;
     double diameter_angle_scale_factor = tan(5.0*M_PI/180.0);
-    // minimum roof area (1 mm^2), area smaller than this value will not have interface
-    const double minimum_roof_area{SQ(scaled<double>(1.))};
+    // minimum roof area (default 0.25 mm^2), area smaller than this value will not have interface.
+    double minimum_roof_area = scaled<double>(scaled<double>(0.25));
     float        top_z_distance = 0.0;
 
     bool  is_strong = false;

--- a/src/libslic3r/Support/TreeSupportCommon.hpp
+++ b/src/libslic3r/Support/TreeSupportCommon.hpp
@@ -89,6 +89,7 @@ struct TreeSupportMeshGroupSettings {
         this->support_tree_branch_diameter = scaled<coord_t>(config.tree_support_branch_diameter_organic.value);
         this->support_tree_branch_diameter_angle  = std::clamp<double>(config.tree_support_branch_diameter_angle * M_PI / 180., 0., 0.5 * M_PI - EPSILON);
         this->support_tree_top_rate       = config.tree_support_top_rate.value; // percent
+        this->minimum_roof_area           = scaled<double>(scaled<double>(config.support_interface_min_area.value));
     //    this->support_tree_tip_diameter = this->support_line_width;
         this->support_tree_tip_diameter = std::clamp(scaled<coord_t>(config.tree_support_tip_diameter.value), (coord_t)0, this->support_tree_branch_diameter);
     }
@@ -160,7 +161,7 @@ struct TreeSupportMeshGroupSettings {
     coord_t                         support_floor_layers                    { 2 };
     // Minimum Support Roof Area
     // Minimum area size for the roofs of the support. Polygons which have an area smaller than this value will be printed as normal support.
-    double                          minimum_roof_area                       { scaled<double>(scaled<double>(1.)) };
+    double                          minimum_roof_area                       { scaled<double>(scaled<double>(0.25)) };
     // A list of integer line directions to use. Elements from the list are used sequentially as the layers progress 
     // and when the end of the list is reached, it starts at the beginning again. The list items are separated
     // by commas and the whole list is contained in square brackets. Default is an empty list which means

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -680,7 +680,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
         "support_interface_pattern", "support_interface_top_layers", "support_interface_bottom_layers",
         "bridge_no_support", "max_bridge_length", "support_top_z_distance", "support_bottom_z_distance",
         "support_type", "support_on_build_plate_only", "support_critical_regions_only", "support_interface_not_for_body",
-        "support_object_xy_distance", "support_object_first_layer_gap"/*, "independent_support_layer_height"*/})
+        "support_object_xy_distance", "support_object_first_layer_gap",
+        "support_interface_min_area"/*, "independent_support_layer_height"*/})
         toggle_field(el, have_support_material);
     toggle_field("support_threshold_angle", have_support_material && is_auto(support_type));
     toggle_field("support_threshold_overlap", config->opt_int("support_threshold_angle") == 0 && have_support_material && is_auto(support_type));

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -1314,7 +1314,7 @@ void Choice::BUILD()
         opt_height = (double) temp->GetTextCtrl()->GetSize().GetHeight() / m_em_unit;
 
     // BBS
-    temp->SetTextLabel(m_opt.sidetext);
+    temp->SetTextLabel(_L(m_opt.sidetext));
     m_combine_side_text = true;
 
 #ifdef __WXGTK3__

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -132,7 +132,7 @@ std::map<std::string, std::vector<SimpleSettingData>>  SettingsFactory::OBJECT_C
                     {"support_filament", "",8},{"support_interface_filament", "",9},{"support_expansion", "",24},{"support_style", "",25},
                     {"tree_support_brim_width", "",26}, {"tree_support_branch_angle", "",10},{"tree_support_branch_angle_organic","",10}, {"tree_support_wall_count", "",11},{"tree_support_branch_diameter_angle", "",11},//tree support
                     {"support_top_z_distance", "",13},{"support_bottom_z_distance", "",12},{"support_base_pattern", "",14},{"support_base_pattern_spacing", "",15},
-                    {"support_interface_top_layers", "",16},{"support_interface_bottom_layers", "",17},{"support_interface_spacing", "",18},{"support_bottom_interface_spacing", "",19},
+                    {"support_interface_top_layers", "",16},{"support_interface_bottom_layers", "",17},{"support_interface_spacing", "",18},{"support_interface_min_area", "",30},{"support_bottom_interface_spacing", "",19},
                     {"support_object_xy_distance", "",20}, {"bridge_no_support", "",21},{"max_bridge_length", "",22},{"support_critical_regions_only", "",23},{"support_remove_small_overhang","",27},
                     {"support_object_first_layer_gap","",28}
                             }},
@@ -197,7 +197,7 @@ std::vector<SimpleSettingData> SettingsFactory::get_visible_options(const std::s
         //tree support
         "tree_support_wall_count",
         //support
-        "support_top_z_distance", "support_base_pattern", "support_base_pattern_spacing", "support_interface_top_layers", "support_interface_bottom_layers", "support_interface_spacing", "support_bottom_interface_spacing", "support_object_xy_distance",
+        "support_top_z_distance", "support_base_pattern", "support_base_pattern_spacing", "support_interface_top_layers", "support_interface_bottom_layers", "support_interface_spacing", "support_interface_min_area", "support_bottom_interface_spacing", "support_object_xy_distance",
         "support_object_first_layer_gap",
         //adhesion
         "brim_type", "brim_width", "brim_object_gap", "raft_layers"

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2523,6 +2523,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("support_interface_bottom_layers", "support_settings_advanced#interface-layers");
         optgroup->append_single_option_line("support_interface_pattern", "support_settings_advanced#interface-pattern");
         optgroup->append_single_option_line("support_interface_spacing", "support_settings_advanced#interface-spacing");
+        optgroup->append_single_option_line("support_interface_min_area", "support_settings_advanced#interface-min-area");
         optgroup->append_single_option_line("support_bottom_interface_spacing", "support_settings_advanced#interface-spacing");
         optgroup->append_single_option_line("support_expansion", "support_settings_advanced#normal-support-expansion");
         //optgroup->append_single_option_line("support_interface_loop_pattern", "support_settings_advanced");


### PR DESCRIPTION
### Summary
Introduces a user-configurable option `support_interface_min_area` (minimum support contact area) that exposes the `minimum_roof_area` threshold — previously **hardcoded to 1 mm²** in the tree support paths — and lowers its default to **0.25 mm²**.

### Background / Motivation
Tree supports tend to generate many tiny roof / interface fragments under small overhangs. These fragments extrude unstably, give poor support performance, and add slicing noise. The area threshold was previously hardcoded (1 mm²) in both the node-based and organic tree implementations, with no way to tune it per machine / material / use case. This PR promotes it to a visible setting, letting users balance *keeping more precise small contact patches* against *dropping fragmented contacts in favor of normal support*.

### Option details

| Field | Value |
|---|---|
| Key | `support_interface_min_area` |
| Type | `coFloat` (`f_enum_open` — preset values + free input) |
| Unit | mm² |
| Default | **0.25** (was hardcoded 1.0) |
| Presets | `0` / `0.25` / `0.64` / `1` |
| Min | `0` (0 = no filtering, keep all contact surfaces) |
| Mode | Advanced |
| Category | Support |
| Meaning | Roof polygons smaller than this value are not generated as interface and fall back to normal support. **Lower value → more (and more fragmented) contact surfaces; higher value → fewer, more consolidated contact surfaces.** |

### Changes

**1. Definition & propagation**
- [PrintConfig.hpp](src/libslic3r/PrintConfig.hpp) / [PrintConfig.cpp](src/libslic3r/PrintConfig.cpp): declare and define `support_interface_min_area` (label / tooltip / sidetext / enum / default).
- Node-based tree [TreeSupport.cpp](src/libslic3r/Support/TreeSupport.cpp) / [TreeSupport.hpp](src/libslic3r/Support/TreeSupport.hpp): `minimum_roof_area` changed from `const 1.0` to a value read from config.
- Organic tree [TreeSupportCommon.hpp](src/libslic3r/Support/TreeSupportCommon.hpp): `TreeSupportMeshGroupSettings::minimum_roof_area` is read from config; default 1.0 → 0.25.

**2. Full UI / config integration**
- [Preset.cpp](src/libslic3r/Preset.cpp): added to the print preset options whitelist (ensures save/load).
- [PrintObject.cpp](src/libslic3r/PrintObject.cpp): added to `invalidate_state_by_config_options` so changing the value triggers a re-slice.
- [Tab.cpp](src/slic3r/GUI/Tab.cpp): added to the *Support → Advanced → Interface* settings page.
- [ConfigManipulation.cpp](src/slic3r/GUI/ConfigManipulation.cpp): show/hide the field with the support toggle.
- [GUI_Factories.cpp](src/slic3r/GUI/GUI_Factories.cpp): added to the per-object settings list and visible options.
- [Field.cpp](src/slic3r/GUI/Field.cpp): wrapped sidetext in `_L()` so it is localizable.

**3. Localization**: `.pot` template + all 20 language `.po` files translated (one label + one tooltip each); verified with `msgfmt --check-format`.

### Scope & behavior change ⚠️
- This option **only affects tree supports** (organic / slim / strong / hybrid) roof/contact filtering; the normal (grid) support path is not affected.
- **Default lowered from 1.0 mm² to 0.25 mm²**: existing tree-support presets will slice differently after upgrade (more small contact surfaces are retained by default). To fully preserve old behavior, set the value to `1` (or `0` to disable filtering entirely).
- Backward compatible with existing project files: when the key is absent, the default (0.25) is used.

### Verification
- ✅ Builds cleanly (deps + slicer).
- ✅ All `.po` files compiled to `.mo` via `scripts/run_gettext.bat`; `--check-format` passes.
- Suggested regression: compare tree-support generation for `0 / 0.25 / 1` on models with fine overhangs (e.g. Benchy mast/chimney, cantilever test parts) and check removability.

### Files (32)
- 10 C++ files (option definition + tree threshold wiring + UI/config integration)
- 22 localization files (`.pot` + 20 `.po`; `zh_CN.po` includes context lines)


https://github.com/user-attachments/assets/d6903c19-a47a-4bc8-a0cb-e539644a9936

