### PR TITLE
feat(mixed-filament): phase 2 hardening — ratio cap, recipe dedupe, cancel-aware rematch

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -15302,6 +15302,12 @@ msgstr "\n合并该耗材将导致这些混色耗材配置失效。是否继续�
 msgid "Filament %d ratio is too high. Mix may be affected."
 msgstr "耗材%d参与混色的比例过高，可能会影响混色效果。"
 
+msgid ""
+"The mix ratios for %s in the Color Mapping list are outside the recommended %d"
+"%%–%d%% range. Adjust the mix ratios manually for better results."
+msgstr ""
+"Color Mapping 列表中 {%s} 的混色比例超出推荐范围 %d%%–%d%%。请手动调整混色比例以获得更好效果。"
+
 msgid "Cannot enable both Variable Layer Height and Subdivide Mix Layer."
 msgstr "可变层高与混色细分层高功能互斥，请勿同时开启。"
 
@@ -15365,9 +15371,6 @@ msgstr "未检测到模型，请先导入多色模型。"
 msgid "Filament Setup"
 msgstr "耗材配置"
 
-msgid "Filament Setup (CMYW)"
-msgstr "耗材配置（CMYW）"
-
 msgid "Original"
 msgstr "原模型"
 
@@ -15398,8 +15401,8 @@ msgstr "开始匹配"
 msgid "Rematch"
 msgstr "重新匹配"
 
-msgid "Automatically uses official CMYW filaments for color mixing. The mix ratio for each color is limited to X%–Y%."
-msgstr "自动选择官方 CMYW 耗材进行混色匹配。单色混色比例范围：X%–Y%。"
+msgid "Automatically uses official Full Spectrum filaments for color mixing. The mix ratio for each color is limited to X%–Y%."
+msgstr "自动选择官方全光谱耗材进行混色匹配。单色混色比例范围：X%–Y%。"
 
 msgid "Manually select filaments from the current list for color mixing."
 msgstr "手动选择当前列表中的耗材进行混色匹配。"

--- a/src/libslic3r/MixedFilament.cpp
+++ b/src/libslic3r/MixedFilament.cpp
@@ -1957,8 +1957,8 @@ void MixedFilamentManager::add_batch_custom_filaments(
             continue;
         }
 
-        unsigned int a = std::max<unsigned int>(1, std::min<unsigned int>(e.component_a, (unsigned int)n));
-        unsigned int b = std::max<unsigned int>(1, std::min<unsigned int>(e.component_b, (unsigned int)n));
+        unsigned int a = std::max<unsigned int>(1, std::min<unsigned int>(e.component_a, static_cast<unsigned int>(n)));
+        unsigned int b = std::max<unsigned int>(1, std::min<unsigned int>(e.component_b, static_cast<unsigned int>(n)));
         if (a == b) {
             b = (a == 1) ? 2u : 1u;
             if (a == b) {
@@ -1971,7 +1971,7 @@ void MixedFilamentManager::add_batch_custom_filaments(
         mf.component_a     = a;
         mf.component_b     = b;
         mf.stable_id       = allocate_stable_id();
-        mf.mix_b_percent   = e.mix_b_percent;
+        mf.mix_b_percent   = std::clamp(e.mix_b_percent, 0, 100);
         mf.ratio_a         = 1;
         mf.ratio_b         = 1;
         mf.manual_pattern  = e.manual_pattern;

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13)
 project(libslic3r_gui)
 
 include(PrecompiledHeader)

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1,5 +1,6 @@
 #include "MixedColorMatchHelpers.hpp"
 #include "MixedGradientSelector.hpp"
+#include <unordered_map>
 #include <unordered_set>
 #include <ColorSpaceConvert.hpp>
 #include "MixedFilamentColorMapPanel.hpp"
@@ -513,7 +514,7 @@ MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std:
                 if (!compat[a - 1][b - 1] || !compat[b - 1][c - 1] || !compat[a - 1][c - 1]) continue;
 
                 for (int wa = loop_min_weight; wa <= std::min(100 - 2 * loop_min_weight, max_component_percent); wa += k_triple_coarse_step) {
-                    for (int wb = loop_min_weight; wa + wb <= 100 - loop_min_weight; wb += k_triple_coarse_step) {
+                    for (int wb = loop_min_weight; wb <= std::min(100 - wa - loop_min_weight, max_component_percent); wb += k_triple_coarse_step) {
                         int wc = 100 - wa - wb;
                         if (wc < loop_min_weight || wc > max_component_percent) continue;
                         CIELab blended = blend_weighted_lab_accurate(palette, {a, b, c}, {wa, wb, wc});
@@ -1449,6 +1450,87 @@ void assign_batch_virtual_filament_ids(
             mapping.target_filament_id = next_virtual_id++;
         }
     }
+}
+
+std::vector<ColorMappingEntry> merge_duplicate_recipe_mappings(
+    const std::vector<ColorMappingEntry>& mappings)
+{
+    if (mappings.size() < 2) return mappings;
+
+    // Fingerprint: the recipe fields that define which physical filaments are mixed and in
+    // what ratio. Two recipes with the same fingerprint produce the same blend, so they must
+    // share one virtual slot. Derived fields (preview_color, delta_e, display_color) are
+    // excluded — they are deterministic functions of the identity fields.
+    auto fingerprint = [](const MixedColorMatchRecipeResult& r) {
+        std::ostringstream oss;
+        // Use '|' as a field separator so (a=1,b=12) != (a=11,b=2); the ints alone would
+        // collide if concatenated without a delimiter.
+        oss << r.component_a << '|' << r.component_b << '|' << r.mix_b_percent << '|'
+            << r.manual_pattern << '|' << r.gradient_component_ids << '|'
+            << r.gradient_component_weights;
+        return oss.str();
+    };
+
+    std::vector<ColorMappingEntry> result;
+    result.reserve(mappings.size());
+    // recipe fingerprint → index into result. Only non-pure mappings are tracked: pure
+    // recipes target existing physical IDs and never allocate a new slot, so deduping them
+    // is both unnecessary and semantically wrong (two pure recipes hitting the same physical
+    // is the normal, expected case — they share the ID already).
+    std::unordered_map<std::string, size_t> seen;
+
+    for (const ColorMappingEntry& m : mappings) {
+        if (m.is_pure_recipe) {
+            result.push_back(m);
+            continue;
+        }
+        const std::string key = fingerprint(m.recipe);
+        auto it = seen.find(key);
+        if (it != seen.end()) {
+            // Merge into the first occurrence: union source_extruder_ids (so apply still
+            // remaps every source extruder to this target) and accumulate merged_model_indices
+            // for traceability. The survivor keeps its own target_filament_id — the merged-in
+            // mapping's target is discarded (it was a duplicate slot allocation).
+            ColorMappingEntry& survivor = result[it->second];
+            survivor.source_extruder_ids.insert(survivor.source_extruder_ids.end(),
+                                                m.source_extruder_ids.begin(),
+                                                m.source_extruder_ids.end());
+            survivor.merged_model_indices.insert(survivor.merged_model_indices.end(),
+                                                 m.merged_model_indices.begin(),
+                                                 m.merged_model_indices.end());
+        } else {
+            seen.emplace(key, result.size());
+            result.push_back(m);
+        }
+    }
+
+    // The merge above unions source_extruder_ids / merged_model_indices by appending.
+    // The two are normally disjoint across merged mappings (extract_model_colors
+    // aggregates extruders by unique color), but sort+unique defensively so
+    // survivor.source_extruder_ids stays idempotent for apply_batch_match_to_model
+    // (unordered_map) and merged_model_indices doesn't double-count in traceability.
+    // Only runs when a merge actually happened; the common no-merge path is untouched.
+    if (result.size() != mappings.size()) {
+        for (ColorMappingEntry& e : result) {
+            if (e.is_pure_recipe) continue;
+            std::sort(e.source_extruder_ids.begin(), e.source_extruder_ids.end());
+            e.source_extruder_ids.erase(
+                std::unique(e.source_extruder_ids.begin(), e.source_extruder_ids.end()),
+                e.source_extruder_ids.end());
+            std::sort(e.merged_model_indices.begin(), e.merged_model_indices.end());
+            e.merged_model_indices.erase(
+                std::unique(e.merged_model_indices.begin(), e.merged_model_indices.end()),
+                e.merged_model_indices.end());
+        }
+    }
+
+    if (result.size() != mappings.size()) {
+        BOOST_LOG_TRIVIAL(info)
+            << "merge_duplicate_recipe_mappings: " << mappings.size()
+            << " -> " << result.size() << " (merged " << (mappings.size() - result.size())
+            << " duplicate recipe mappings)";
+    }
+    return result;
 }
 
 BatchMatchResult batch_match_model_colors(

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1314,6 +1314,14 @@ std::vector<ModelColorEntry> extract_model_colors(const Print& print)
     // it only at the virtual-lookup call site; the physical-colour path does not
     // depend on preset_bundle at all.
     auto* pb = wxGetApp().preset_bundle;
+    // Log the null-preset_bundle condition ONCE here (not per virtual-ID iteration
+    // inside the loop below) — otherwise a model with N virtual-painted faces would
+    // emit N identical warnings. pb is loop-invariant, so the inner check can stay
+    // a silent `continue`.
+    if (pb == nullptr) {
+        BOOST_LOG_TRIVIAL(warning)
+            << "extract_model_colors: preset_bundle null; virtual filament colors will be skipped";
+    }
 
     for (const PrintObject* obj : print.objects()) {
         if (!obj) continue;
@@ -1333,11 +1341,8 @@ std::vector<ModelColorEntry> extract_model_colors(const Print& print)
                     color_hex = filament_colours[idx];
                 } else {
                     // Virtual mixed filament — look up its display_color.
-                    // Early startup or rare call paths may have no preset_bundle;
-                    // skip virtual-colour resolution then rather than dereference null.
+                    // pb null is already logged once above the loop; skip silently here.
                     if (pb == nullptr) {
-                        BOOST_LOG_TRIVIAL(warning)
-                            << "extract_model_colors: preset_bundle null, skipping virtual filament " << eid;
                         continue;
                     }
                     const MixedFilament* mf = pb->mixed_filaments.mixed_filament_from_id(

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -356,7 +356,8 @@ double color_delta_e00(const wxColour& lhs, const wxColour& rhs)
 MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std::string>& physical_colors,
                                                           const wxColour&                 target_color,
                                                           int                             min_component_percent,
-                                                          int                             max_component_percent)
+                                                          int                             max_component_percent,
+                                                          bool                            check_compatible)
 {
     MixedColorMatchRecipeResult best;
     if (!target_color.IsOk() || physical_colors.size() < 2)
@@ -389,7 +390,19 @@ MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std:
     const CIELab target_lab = sRGB_to_CIELab(target_color);
 
     const int  loop_min_weight      = std::max(1, std::clamp(min_component_percent, 0, 50));
-    const auto compat                = build_compatibility_matrix(n);
+
+    // check_compatible=false (manual batch mode) bypasses the category filter so
+    // cross-type mixes (e.g. PLA+PETG) can be computed and stored. The downstream
+    // slice gate (Plater::has_incompatible_mixed_filament_in_use) still blocks
+    // incompatible mixes at slice time — this only widens the candidate pool during
+    // recipe search. All `if (!compat[i][j]) continue;` sites below stay unchanged;
+    // an all-true matrix makes them no-ops.
+    std::vector<std::vector<bool>> compat;
+    if (check_compatible) {
+        compat = build_compatibility_matrix(n);
+    } else {
+        compat.assign(n, std::vector<bool>(n, true));
+    }
 
     // Helper: encode filament IDs as gradient_component_ids string.
     // Legacy format (all IDs ≤ 9): concatenated single chars, e.g. "123".
@@ -1544,7 +1557,8 @@ BatchMatchResult batch_match_model_colors(
     int                                          min_component_percent,
     int                                          max_component_percent,
     std::shared_ptr<std::atomic<bool>>           cancel_token,
-    std::function<void(int,int)>                 progress_callback)
+    std::function<void(int,int)>                 progress_callback,
+    bool                                         check_compatible)
 {
     BatchMatchResult result;
     result.success = true;
@@ -1568,15 +1582,18 @@ BatchMatchResult batch_match_model_colors(
     const int total_count = static_cast<int>(model_colors.size());
     for (size_t i = 0; i < model_colors.size(); ++i) {
         if (cancel_token && cancel_token->load()) {
-            result.success = false;
-            result.error_message = "Cancelled by user";
+            // User cancellation (Stop Matching) — not an error. error_message is intentionally
+            // empty: handle_batch_match_result treats error_code==2 as a silent rollback and
+            // never displays it. See BatchMatchResult.error_code docs.
+            result.success    = false;
             result.error_code = 2;
             return result;
         }
 
         const auto& entry = model_colors[i];
         MixedColorMatchRecipeResult recipe =
-            build_best_color_match_recipe(physical_colors, entry.color, min_component_percent, max_component_percent);
+            build_best_color_match_recipe(physical_colors, entry.color, min_component_percent, max_component_percent,
+                                          check_compatible);
 
         if (!recipe.valid) {
             BOOST_LOG_TRIVIAL(warning)

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -354,11 +354,25 @@ double color_delta_e00(const wxColour& lhs, const wxColour& rhs)
 
 MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std::string>& physical_colors,
                                                           const wxColour&                 target_color,
-                                                          int                             min_component_percent)
+                                                          int                             min_component_percent,
+                                                          int                             max_component_percent)
 {
     MixedColorMatchRecipeResult best;
     if (!target_color.IsOk() || physical_colors.size() < 2)
         return best;
+
+    // Validate max_component_percent symmetrically with batch_match_model_colors's
+    // min check. Range [50, 100]: the floor matches loop_min_weight's clamp ceiling
+    // (a max < the effective min makes the search window empty and silently yields no
+    // recipe); 100 is the physical cap. Out-of-range input returns an invalid result
+    // rather than letting the search loops run with nonsensical bounds (e.g. a value
+    // >100 would widen the upper bound past 100% and silently bypass the cap).
+    if (max_component_percent < 50 || max_component_percent > 100) {
+        BOOST_LOG_TRIVIAL(warning)
+            << "build_best_color_match_recipe: max_component_percent=" << max_component_percent
+            << " out of [50, 100]; returning invalid recipe";
+        return best;
+    }
 
     // ---- Step 1: build palette & pre-convert to Lab ----
     const size_t n = physical_colors.size();
@@ -424,7 +438,7 @@ MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std:
     for (size_t a = 0; a < n; ++a) {
         for (size_t b = a + 1; b < n; ++b) {
             if (!compat[a][b]) continue;
-            for (int pct = loop_min_weight; pct <= 100 - loop_min_weight; pct += k_coarse_step) {
+            for (int pct = std::max(loop_min_weight, 100 - max_component_percent); pct <= std::min(100 - loop_min_weight, max_component_percent); pct += k_coarse_step) {
                 const CIELab& blended_lab = lut.get(a, b, pct);
                 double de = delta_e_lab(target_lab, blended_lab);
                 update_best_pair(unsigned(a + 1), unsigned(b + 1), pct, de);
@@ -442,8 +456,8 @@ MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std:
     while (!heap.empty()) {
         auto [de, a, b, coarse_pct] = heap.top();
         heap.pop();
-        int fine_min = std::max(loop_min_weight, coarse_pct - k_coarse_step + 1);
-        int fine_max = std::min(100 - loop_min_weight, coarse_pct + k_coarse_step - 1);
+        int fine_min = std::max(std::max(loop_min_weight, 100 - max_component_percent), coarse_pct - k_coarse_step + 1);
+        int fine_max = std::min(std::min(100 - loop_min_weight, max_component_percent), coarse_pct + k_coarse_step - 1);
         for (int pct = fine_min; pct <= fine_max; ++pct) {
             if ((pct - loop_min_weight) % k_coarse_step == 0) continue; // already evaluated in coarse
             const CIELab& blended_lab = lut.get(a - 1, b - 1, pct);
@@ -498,10 +512,10 @@ MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std:
                 unsigned int a = candidate_pool[fi], b = candidate_pool[fj], c = candidate_pool[fk];
                 if (!compat[a - 1][b - 1] || !compat[b - 1][c - 1] || !compat[a - 1][c - 1]) continue;
 
-                for (int wa = loop_min_weight; wa <= 100 - 2 * loop_min_weight; wa += k_triple_coarse_step) {
+                for (int wa = loop_min_weight; wa <= std::min(100 - 2 * loop_min_weight, max_component_percent); wa += k_triple_coarse_step) {
                     for (int wb = loop_min_weight; wa + wb <= 100 - loop_min_weight; wb += k_triple_coarse_step) {
                         int wc = 100 - wa - wb;
-                        if (wc < loop_min_weight) continue;
+                        if (wc < loop_min_weight || wc > max_component_percent) continue;
                         CIELab blended = blend_weighted_lab_accurate(palette, {a, b, c}, {wa, wb, wc});
                         double  de      = delta_e_lab(target_lab, blended);
                         // Update best triple
@@ -535,15 +549,15 @@ MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std:
         TripleEntry te = triple_heap.top();
         triple_heap.pop();
         int wa_min = std::max(loop_min_weight, te.wa - k_triple_coarse_step + 1);
-        int wa_max = std::min(100 - 2 * loop_min_weight, te.wa + k_triple_coarse_step - 1);
+        int wa_max = std::min(std::min(100 - 2 * loop_min_weight, max_component_percent), te.wa + k_triple_coarse_step - 1);
         for (int wa = wa_min; wa <= wa_max; ++wa) {
             if ((wa - loop_min_weight) % k_triple_coarse_step == 0) continue;
             int wb_min = std::max(loop_min_weight, te.wb - k_triple_coarse_step + 1);
-            int wb_max = std::min(100 - wa - loop_min_weight, te.wb + k_triple_coarse_step - 1);
+            int wb_max = std::min(std::min(100 - wa - loop_min_weight, max_component_percent), te.wb + k_triple_coarse_step - 1);
             for (int wb = wb_min; wb <= wb_max; ++wb) {
                 if ((wb - loop_min_weight) % k_triple_coarse_step == 0) continue;
                 int wc = 100 - wa - wb;
-                if (wc < loop_min_weight) continue;
+                if (wc < loop_min_weight || wc > max_component_percent) continue;
                 CIELab blended = blend_weighted_lab_accurate(palette, {te.a, te.b, te.c}, {wa, wb, wc});
                 double  de2    = delta_e_lab(target_lab, blended);
                 if (!best.valid || de2 + 1e-6 < best.delta_e) {
@@ -1292,9 +1306,13 @@ std::vector<ModelColorEntry> extract_model_colors(const Print& print)
 
     auto& filament_colours = print.config().filament_colour.values;
 
-    // Also read mixed-filament display colors for virtual ID lookup
+    // Also read mixed-filament display colors for virtual ID lookup.
+    // NOTE: Do NOT bind a reference via a ternary with a temporary on one branch —
+    // the temporary would be destroyed at the end of the full expression, leaving
+    // a dangling reference (use-after-scope UB). Use the raw pointer and null-check
+    // it only at the virtual-lookup call site; the physical-colour path does not
+    // depend on preset_bundle at all.
     auto* pb = wxGetApp().preset_bundle;
-    auto& mgr = pb ? pb->mixed_filaments : (MixedFilamentManager&)MixedFilamentManager();
 
     for (const PrintObject* obj : print.objects()) {
         if (!obj) continue;
@@ -1313,8 +1331,15 @@ std::vector<ModelColorEntry> extract_model_colors(const Print& print)
                     // Physical filament color
                     color_hex = filament_colours[idx];
                 } else {
-                    // Virtual mixed filament — look up its display_color
-                    const MixedFilament* mf = mgr.mixed_filament_from_id(
+                    // Virtual mixed filament — look up its display_color.
+                    // Early startup or rare call paths may have no preset_bundle;
+                    // skip virtual-colour resolution then rather than dereference null.
+                    if (pb == nullptr) {
+                        BOOST_LOG_TRIVIAL(warning)
+                            << "extract_model_colors: preset_bundle null, skipping virtual filament " << eid;
+                        continue;
+                    }
+                    const MixedFilament* mf = pb->mixed_filaments.mixed_filament_from_id(
                         static_cast<unsigned int>(eid), filament_colours.size());
                     if (mf && !mf->display_color.empty())
                         color_hex = mf->display_color;
@@ -1407,7 +1432,7 @@ void assign_batch_virtual_filament_ids(
             << "assign_batch_virtual_filament_ids: invalid num_physical=" << num_physical;
         return;
     }
-    unsigned int next_virtual_id = unsigned(num_physical + existing_mixed_count + 1);
+    unsigned int next_virtual_id = static_cast<unsigned int>(num_physical + existing_mixed_count + 1);
 
     for (auto& mapping : result.mappings) {
         if (mapping.is_pure_recipe) {
@@ -1430,6 +1455,7 @@ BatchMatchResult batch_match_model_colors(
     const std::vector<ModelColorEntry>&          model_colors,
     const std::vector<std::string>&             physical_colors,
     int                                          min_component_percent,
+    int                                          max_component_percent,
     std::shared_ptr<std::atomic<bool>>           cancel_token,
     std::function<void(int,int)>                 progress_callback)
 {
@@ -1452,8 +1478,8 @@ BatchMatchResult batch_match_model_colors(
         return result;
     }
 
-    const int total = int(model_colors.size());
-    for (int i = 0; i < total; ++i) {
+    const int total_count = static_cast<int>(model_colors.size());
+    for (size_t i = 0; i < model_colors.size(); ++i) {
         if (cancel_token && cancel_token->load()) {
             result.success = false;
             result.error_message = "Cancelled by user";
@@ -1463,7 +1489,7 @@ BatchMatchResult batch_match_model_colors(
 
         const auto& entry = model_colors[i];
         MixedColorMatchRecipeResult recipe =
-            build_best_color_match_recipe(physical_colors, entry.color, min_component_percent);
+            build_best_color_match_recipe(physical_colors, entry.color, min_component_percent, max_component_percent);
 
         if (!recipe.valid) {
             BOOST_LOG_TRIVIAL(warning)
@@ -1485,7 +1511,7 @@ BatchMatchResult batch_match_model_colors(
         result.mappings.push_back(mapping);
 
         if (progress_callback)
-            progress_callback(i + 1, total);
+            progress_callback(static_cast<int>(i) + 1, total_count);
     }
 
     if (result.mappings.empty()) {
@@ -1509,7 +1535,7 @@ BatchMatchResult batch_match_model_colors(
         result.selected_physical_ids.push_back(static_cast<unsigned int>(i));
 
     BOOST_LOG_TRIVIAL(info)
-        << "batch_match: " << total << " model colors -> "
+        << "batch_match: " << total_count << " model colors -> "
         << result.mappings.size() << " unique recipes, avg DeltaE=" << result.avg_delta_e;
     return result;
 }
@@ -1550,6 +1576,7 @@ std::vector<std::string> recommend_best_filament_combo(
     const std::vector<ModelColorEntry>&  model_colors,
     const std::vector<std::string>&      all_preset_colors,
     int                                  min_component_percent,
+    int                                  max_component_percent,
     std::shared_ptr<std::atomic<bool>>   cancel_token)
 {
     if (model_colors.empty() || all_preset_colors.size() < 4)
@@ -1595,7 +1622,7 @@ std::vector<std::string> recommend_best_filament_combo(
                     double sum_de = 0.0;
                     int matched = 0;
                     for (const auto& mc : model_colors) {
-                        auto recipe = build_best_color_match_recipe(combo_colors, mc.color, min_component_percent);
+                        auto recipe = build_best_color_match_recipe(combo_colors, mc.color, min_component_percent, max_component_percent);
                         if (recipe.valid) {
                             sum_de += recipe.delta_e;
                             ++matched;
@@ -1699,3 +1726,4 @@ void apply_batch_match_to_model(const BatchMatchResult& result, Print& print)
 }
 
 }} // namespace Slic3r::GUI
+

--- a/src/slic3r/GUI/MixedColorMatchHelpers.hpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.hpp
@@ -226,6 +226,20 @@ void assign_batch_virtual_filament_ids(
     size_t             num_physical,
     size_t             existing_mixed_count = 0);
 
+/// Merge mappings whose NON-PURE recipes are byte-identical (same components + ratio +
+/// gradient) into a single entry, so identical recipes share one virtual slot instead of
+/// each creating a duplicate mixed-filament row. Pure-recipe mappings (is_pure_recipe)
+/// are passed through untouched — they target existing physical IDs and never allocate a
+/// new slot. The surviving mapping keeps the FIRST occurrence's target_filament_id and
+/// accumulates the union of source_extruder_ids (so apply_batch_match_to_model still
+/// remaps every source extruder) plus merged_model_indices. Order is preserved.
+///
+/// Identity fingerprint: {component_a, component_b, mix_b_percent, gradient_component_ids,
+/// gradient_component_weights, manual_pattern}. Derived fields (preview_color, delta_e,
+/// display_color) are excluded — identical recipes produce identical blends by construction.
+std::vector<ColorMappingEntry> merge_duplicate_recipe_mappings(
+    const std::vector<ColorMappingEntry>& mappings);
+
 /// Populate result.mixed_filaments from result.mappings.
 void populate_mixed_filaments_from_mappings(
     BatchMatchResult&                           result,

--- a/src/slic3r/GUI/MixedColorMatchHelpers.hpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.hpp
@@ -104,7 +104,8 @@ MixedColorMatchRecipeResult build_best_color_match_recipe(
     const std::vector<std::string> &physical_colors,
     const wxColour                 &target_color,
     int                             min_component_percent = 0,
-    int                             max_component_percent = 100);
+    int                             max_component_percent = 100,
+    bool                            check_compatible = true);
 
 // ---- display context helpers ----
 MixedFilamentDisplayContext build_mixed_filament_display_context(
@@ -209,7 +210,8 @@ BatchMatchResult batch_match_model_colors(
     int                                          min_component_percent,
     int                                          max_component_percent = 100,
     std::shared_ptr<std::atomic<bool>>           cancel_token = nullptr,
-    std::function<void(int,int)>                 progress_callback = nullptr);
+    std::function<void(int,int)>                 progress_callback = nullptr,
+    bool                                         check_compatible = true);
 
 #if 0 // Dead code — no deduplication is performed (explicit policy since phase2)
 /// Deduplicate mappings where matched colors are visually close (ΔE < 1.5).

--- a/src/slic3r/GUI/MixedColorMatchHelpers.hpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.hpp
@@ -20,6 +20,14 @@ namespace Slic3r { class Print; }
 
 namespace Slic3r { namespace GUI {
 
+// ---- Shared constants ----
+
+// Canonical preset name for the Full Spectrum (formerly "CMYW") recommended-mode
+// palette. Single source of truth shared by MixedFilamentBatchDialog (palette load +
+// swatch label) and Plater (auto-assign slots after batch match). Inline so multiple
+// translation units can include this header without ODR violations.
+inline const std::string kFullSpectrumPresetName = "Snapmaker PLA Full Spectrum @U1 0.4 nozzle";
+
 // ---- CIELAB color space types ----
 
 struct CIELab {
@@ -95,7 +103,8 @@ CIELab blend_weighted_lab_accurate(const std::vector<wxColour>& palette,
 MixedColorMatchRecipeResult build_best_color_match_recipe(
     const std::vector<std::string> &physical_colors,
     const wxColour                 &target_color,
-    int                             min_component_percent = 0);
+    int                             min_component_percent = 0,
+    int                             max_component_percent = 100);
 
 // ---- display context helpers ----
 MixedFilamentDisplayContext build_mixed_filament_display_context(
@@ -198,6 +207,7 @@ BatchMatchResult batch_match_model_colors(
     const std::vector<ModelColorEntry>&          model_colors,
     const std::vector<std::string>&             physical_colors,
     int                                          min_component_percent,
+    int                                          max_component_percent = 100,
     std::shared_ptr<std::atomic<bool>>           cancel_token = nullptr,
     std::function<void(int,int)>                 progress_callback = nullptr);
 
@@ -234,6 +244,7 @@ std::vector<std::string> recommend_best_filament_combo(
     const std::vector<ModelColorEntry>&  model_colors,
     const std::vector<std::string>&      all_preset_colors,
     int                                  min_component_percent = 15,
+    int                                  max_component_percent = 100,
     std::shared_ptr<std::atomic<bool>>   cancel_token = nullptr);
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -5,6 +5,8 @@
 #include "I18N.hpp"
 #include "PresetBundle.hpp"
 #include "libslic3r/Preset.hpp"
+#include "libslic3r/Model.hpp"
+#include "libslic3r/libslic3r.h"
 #include "Widgets/ComboBox.hpp"
 #include "Widgets/StaticBox.hpp"
 #include "Widgets/Button.hpp"
@@ -625,25 +627,93 @@ void MixedFilamentBatchDialog::load_model_colors()
     auto* plater = wxGetApp().plater();
     if (!plater) return;
 
-    const auto all_colors = plater->get_extruder_colors_from_plater_config(nullptr, true);
+    PresetBundle* pb = wxGetApp().preset_bundle;
+    if (!pb) return;
 
-    for (size_t i = 0; i < all_colors.size(); ++i) {
-        const std::string& hex = all_colors[i];
-        if (hex.empty()) continue;
+    const size_t num_physical = pb->filament_presets.size();
+    ConfigOptionStrings* co = pb->project_config.option<ConfigOptionStrings>("filament_colour");
+    if (!co || co->values.empty()) return;
+
+    // Collect all extruder IDs actually painted on the model's volumes,
+    // NOT the palette index.  load_model_colors used to enumerate the
+    // get_extruder_colors_from_plater_config() palette and use its array
+    // index as the extruder_id, which misses (a) config-level extruder
+    // assignments on volumes with no MMU paint, and (b) old mixed-filament
+    // virtual IDs that are still painted on triangles but whose display
+    // color may have been deduplicated against the physical palette.
+    //
+    // We now walk every MODEL_PART volume's get_extruders() (MMU paint
+    // chunked facet data + config extruder_id), look up each extruder's
+    // hex colour from the physical palette or the mixed-filament
+    // display_color table, deduplicate by hex, and ACCUMULATE extruder
+    // IDs per colour so every extruder that a given colour is painted with
+    // lands in source_extruder_ids.  This guarantees that
+    // apply_batch_match_to_model can remap every painted extruder,
+    // including virtual mixed IDs from a prior batch match.
+
+    // Map hex → accumulated extruder_ids (unordered, insert-order for log stability)
+    std::vector<std::pair<std::string, std::vector<unsigned int>>> hex_to_eids;
+
+    for (const ModelObject* mo : wxGetApp().model().objects) {
+        for (const ModelVolume* mv : mo->volumes) {
+            if (!mv || mv->type() != ModelVolumeType::MODEL_PART) continue;
+
+            for (int eid : mv->get_extruders()) {
+                if (eid < 1 || eid > int(MAXIMUM_EXTRUDER_NUMBER)) continue;
+
+                std::string color_hex;
+                if (size_t(eid - 1) < co->values.size()) {
+                    // Physical filament colour
+                    color_hex = co->values[size_t(eid - 1)];
+                } else {
+                    // Virtual mixed filament — look up its display_color
+                    const MixedFilament* mf = pb->mixed_filaments.mixed_filament_from_id(
+                        static_cast<unsigned int>(eid), num_physical);
+                    if (mf && !mf->display_color.empty())
+                        color_hex = mf->display_color;
+                }
+                if (color_hex.empty()) continue;
+
+                // Normalize hex for dedup
+                wxColour c;
+                if (!try_parse_color_match_hex(color_hex, c)) continue;
+                const wxString hex_norm = normalize_color_match_hex(color_hex);
+
+                // Accumulate extruder IDs per (normalized) hex value
+                auto it = std::find_if(hex_to_eids.begin(), hex_to_eids.end(),
+                    [&](const auto& p) { return p.first == hex_norm; });
+                if (it != hex_to_eids.end()) {
+                    it->second.push_back(static_cast<unsigned int>(eid));
+                } else {
+                    hex_to_eids.push_back({hex_norm.ToStdString(), {static_cast<unsigned int>(eid)}});
+                }
+            }
+        }
+    }
+
+    // If no model volumes provided extruders, fall back to the palette-index
+    // enumeration so the dialog still opens with a useful colour list.
+    if (hex_to_eids.empty()) {
+        const auto all_colors = plater->get_extruder_colors_from_plater_config(nullptr, true);
+        for (size_t i = 0; i < all_colors.size(); ++i) {
+            const std::string& hex = all_colors[i];
+            if (hex.empty()) continue;
+            wxColour c;
+            if (!try_parse_color_match_hex(hex, c)) continue;
+            hex_to_eids.push_back({normalize_color_match_hex(hex).ToStdString(), {static_cast<unsigned int>(i + 1)}});
+        }
+    }
+
+    for (size_t idx = 0; idx < hex_to_eids.size(); ++idx) {
+        const std::string& hex = hex_to_eids[idx].first;
+        const auto& eids      = hex_to_eids[idx].second;
         wxColour c;
-        if (!try_parse_color_match_hex(hex, c)) continue;
+        try_parse_color_match_hex(hex, c); // already validated above
 
-        // all_colors is indexed by filament_id-1: [physical colors..., then mixed
-        // display colors]. filament_id = i+1 for every slot — physical OR mixed.
-        // For a mixed slot, i+1 is the virtual id its regions are painted with, so
-        // binding it here lets apply_batch_match_to_model re-match and re-map
-        // existing mixed-painted regions to the new target. Leaving it empty (the
-        // old behavior) stranded those regions: never re-matched, then erased by
-        // cleanup when a component physical was dropped.
         m_model_colors.push_back({
             static_cast<unsigned int>(m_model_colors.size() + 1),
             c, hex,
-            std::vector<unsigned int>{static_cast<unsigned int>(i + 1)}
+            eids
         });
     }
 }

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -13,6 +13,7 @@
 #include "Widgets/Button.hpp"
 #include "Widgets/Label.hpp"
 #include "wxExtensions.hpp"
+#include "MsgDialog.hpp"
 #include "Plater.hpp"
 #include "PartPlate.hpp"
 #include "BitmapCache.hpp"
@@ -20,6 +21,8 @@
 #include <unordered_map>
 #include <set>
 #include <algorithm>
+#include <cctype>
+#include <thread>
 
 #include <wx/scrolwin.h>
 #include <wx/dcbuffer.h>
@@ -54,6 +57,32 @@ static constexpr int kMaxComponentPercent = 70;  // recommended mode cap; also t
 // Product spec: a model is capped at 64 distinct filament colors. Colors past the cap are
 // dropped (see load_model_colors) and a deferred warning is shown once build_ui is up.
 static constexpr size_t kMaxColors = 64;
+
+// Recommended-mode (Full Spectrum) per-color transmittance-density (TD) values. These are NOT
+// in the filament data model (filaments_colours.json carries no TD field), so they are pinned
+// here as product constants — provided by product spec (snapshot in code per request).
+//
+// KEYED BY COLOR FAMILY (canonical color name), NOT by palette position. The recommended card's
+// swatch order is normally preset-order (C/M/Y/G), but a match's ΔE fallback path
+// (launch_background_match) can reorder the palette, so positional indexing would bind the
+// wrong TD to a color after reorder. Looking up by the color's identity avoids that.
+//
+// Each entry: {substring-to-match-against-English-name, TD-label, TD-value}. The match is
+// case-insensitive substring on the EN color name (which is always present in FilamentColorItem
+// .colorNames regardless of UI locale — it's the SKU's canonical name in filaments_colours.json).
+// White (W:8.8) is included per spec; Full Spectrum has no White SKU today, so it only surfaces
+// if a White-named color is ever added to the preset.
+// Each entry: {substring-to-match, TD-value}. The substring IS the family display name —
+// tooltip shows it verbatim (e.g. "cyan 5.5"), no separate label/abbreviation needed.
+struct TdEntry { const char* family; double value; };
+static const std::vector<TdEntry> FULL_SPECTRUM_TD = {
+    {"cyan",    5.5},
+    {"magenta", 5.5},
+    {"yellow",  9.5},
+    {"white",   8.8},
+    {"gray",    6.5},
+    {"grey",    6.5}, // spelling variant, defensive
+};
 
 // Card geometry (DIP). CARD_WIDTH_DIP leaves room for a vertical scrollbar inside the
 // 500-wide dialog: 500 − 2×12(margin) − 17(scrollbar) = 459. FILAMENT_COL_WIDTH_DIP pins
@@ -771,12 +800,11 @@ void MixedFilamentBatchDialog::load_model_colors()
 // color varies. Falls back to the raw name when the preset bundle is unavailable.
 static wxString get_full_spectrum_preset_label()
 {
-    static const std::string kPresetName = "Snapmaker PLA Full Spectrum @U1 0.4 nozzle";
     if (auto* pb = wxGetApp().preset_bundle) {
-        if (auto* p = pb->filaments.find_preset(kPresetName))
+        if (auto* p = pb->filaments.find_preset(kFullSpectrumPresetName))
             return wxString::FromUTF8(p->label(false));
     }
-    return wxString::FromUTF8(kPresetName);
+    return wxString::FromUTF8(kFullSpectrumPresetName);
 }
 
 // Load the real recommended-mode palette colors from the Full Spectrum filament preset
@@ -796,13 +824,12 @@ static wxString get_full_spectrum_preset_label()
 //   - (HIGH) distinct logging: each failure path emits its own BOOST_LOG_TRIVIAL(warning).
 static std::vector<std::string> load_full_spectrum_colors()
 {
-    const std::string kPresetName = "Snapmaker PLA Full Spectrum @U1 0.4 nozzle";
     if (!FilamentColorLibrary::Instance().EnsureLoaded()) {
         BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: FilamentColorLibrary not loaded, fallback to canonical palette";
         return {};
     }
     FilamentColorInfo info;
-    if (!FilamentColorLibrary::Instance().FindFilamentByName(kPresetName, info)) {
+    if (!FilamentColorLibrary::Instance().FindFilamentByName(kFullSpectrumPresetName, info)) {
         BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: Full Spectrum preset not found in color library, fallback";
         return {};
     }
@@ -827,6 +854,105 @@ static std::vector<std::string> load_full_spectrum_colors()
     return result;
 }
 
+// Full Spectrum palette as raw FilamentColorItems — same single-color-SKU filter and hex
+// re-validation as load_full_spectrum_colors(), but keeps each item's colorNames map so the
+// caller (build_recommended_card's tooltip) can show the localized per-color name. Returns
+// empty on any failure; callers fall back to positional defaults. NOT thread-safe beyond the
+// EnsureLoaded warm-up done in the ctor (see load_full_spectrum_colors's safety note).
+static std::vector<FilamentColorItem> load_full_spectrum_items()
+{
+    if (!FilamentColorLibrary::Instance().EnsureLoaded()) return {};
+    FilamentColorInfo info;
+    if (!FilamentColorLibrary::Instance().FindFilamentByName(kFullSpectrumPresetName, info)) return {};
+
+    std::vector<FilamentColorItem> result;
+    for (const FilamentColorItem& item : info.colors) {
+        if (item.colorData.colors.size() != 1) continue;
+        wxColour parsed;
+        if (!try_parse_color_match_hex(wxString::FromUTF8(item.colorData.colors[0].c_str()), parsed))
+            continue;
+        result.push_back(item);
+    }
+    return result;
+}
+
+// Look up a name from a FilamentColorItem's colorNames map for a specific language key.
+// On hit, writes the decoded name into `out` and returns true; on miss, returns false and
+// leaves `out` untouched. The JSON keys are short codes ("zh_CN","en"); callers try the full
+// locale, then the base language, then a fallback.
+//
+// NOTE: must NOT return `&wxString::FromUTF8(...)` — that yields a pointer to a temporary
+// wxString, which is destroyed at the semicolon, leaving a dangling pointer (UB / crash on
+// deref). The bool+out-param form keeps ownership with the caller.
+static bool color_name_for_lang(const FilamentColorItem& item, const wxString& key, wxString& out)
+{
+    auto it = item.colorNames.find(into_u8(key));
+    if (it == item.colorNames.end()) return false;
+    out = wxString::FromUTF8(it->second.c_str());
+    return true;
+}
+
+// The ENGLISH color name — always present in colorNames (it's the SKU's canonical name in
+// filaments_colours.json) regardless of UI locale. Used as a STABLE identity for TD family
+// matching (FULL_SPECTRUM_TD is keyed by EN substrings: cyan/magenta/yellow/...). Falls back
+// to whatever name is present, then to a positional "F<n>" label.
+static wxString english_color_name(const FilamentColorItem& item, int position)
+{
+    wxString s;
+    if (color_name_for_lang(item, "en", s)) return s;
+    if (!item.colorNames.empty())
+        return wxString::FromUTF8(item.colorNames.begin()->second.c_str());
+    return wxString::Format("F%d", position + 1);
+}
+
+// Pick a localized color name from a FilamentColorItem's colorNames map, honouring the app's
+// current language. Falls back to English, then to the SKU, then to the positional label.
+static wxString localized_color_name(const FilamentColorItem& item, int position)
+{
+    // current_language_code() returns e.g. "zh_CN" / "en" / "en_US". Try the exact code first,
+    // then the base language (strip region suffix), then English.
+    const wxString lang = wxGetApp().current_language_code();
+    wxString s;
+    if (color_name_for_lang(item, lang, s)) return s;
+    const wxString base = lang.BeforeFirst('_');
+    if (color_name_for_lang(item, base, s)) return s;
+    if (color_name_for_lang(item, wxString("en"), s)) return s;
+    return english_color_name(item, position);
+}
+
+// Resolve the TD family for a filament color by matching the ENGLISH color name against the
+// canonical-family substrings in FULL_SPECTRUM_TD (e.g. "Semi-Translucent Cyan" → family "C").
+// Returns nullptr if no family matches. Case-insensitive substring match on the EN name so it
+// tolerates adjectives ("Semi-Translucent") and prefix/suffix variation.
+//
+// Why English: the EN name is the SKU's canonical identity in filaments_colours.json and is
+// always present regardless of UI locale, so family detection is locale-independent and stable.
+static const TdEntry* resolve_td_family(const wxString& english_name)
+{
+    wxString lower = english_name.Lower();
+    for (const TdEntry& e : FULL_SPECTRUM_TD)
+        if (lower.find(e.family) != wxString::npos) return &e;
+    return nullptr;
+}
+
+// Build the hover tooltip string for one recommended-mode row. Two lines:
+//   <preset label>          e.g. "Snapmaker PLA Full Spectrum"
+//   <color name> TD : <val> e.g. "Translucent Cyan TD : 5.5"
+// The color name is localized; TD is resolved by the color's family via its English name
+// (see resolve_td_family), NOT by palette position — so the TD stays bound to the right color
+// even when the match reorders the palette. When TD is unknown (color family not in
+// FULL_SPECTRUM_TD) the value shows "-".
+static wxString make_recommended_tooltip(const wxString& localized_name, const wxString& english_name)
+{
+    const TdEntry* td = resolve_td_family(english_name);
+    const wxString td_disp = td ? wxString::Format("%.1f", td->value) : wxString("-");
+    return wxString::Format("%s\n%s %s : %s",
+        get_full_spectrum_preset_label(),
+        localized_name,
+        _L("TD"),
+        td_disp);
+}
+
 void MixedFilamentBatchDialog::update_recommended_card()
 {
     if (!m_recommended_card) return;
@@ -835,7 +961,33 @@ void MixedFilamentBatchDialog::update_recommended_card()
 
     // NOTE: the name column shows the preset label (Snapmaker PLA Full Spectrum …) on every
     // row, NOT the per-color name — per product spec only the swatch color varies per row.
-    // So no hex→name lookup is needed here; just the constant preset label.
+    // So no hex→name lookup is needed for the LABEL; the tooltip, however, shows the per-color
+    // name and DOES need to resolve colors[i] → the right FilamentColorItem.
+
+    // Re-load items and index them by HEX so each row resolves the correct color identity.
+    // This is essential after a match: launch_background_match's ΔE fallback can REORDER the
+    // palette, so colors[i] may not sit at position i in the preset's natural order. Looking
+    // up by hex (rather than positional items[i]) binds the tooltip's name + TD to the actual
+    // color on the swatch, not its grid slot. Hex comparison is case-insensitive to tolerate
+    // "#08abfb" vs "#08ABFB" between config and library.
+    const std::vector<FilamentColorItem> items = load_full_spectrum_items();
+    std::unordered_map<std::string, const FilamentColorItem*> by_hex;
+    by_hex.reserve(items.size());
+    for (const FilamentColorItem& item : items) {
+        if (item.colorData.colors.size() == 1) {
+            std::string h = item.colorData.colors[0];
+            std::transform(h.begin(), h.end(), h.begin(),
+                           [](unsigned char ch) { return std::tolower(ch); });
+            by_hex.emplace(std::move(h), &item);
+        }
+    }
+    auto find_item = [&](const std::string& hex) -> const FilamentColorItem* {
+        std::string h = hex;
+        std::transform(h.begin(), h.end(), h.begin(),
+                       [](unsigned char ch) { return std::tolower(ch); });
+        auto it = by_hex.find(h);
+        return it != by_hex.end() ? it->second : nullptr;
+    };
 
     for (int i = 0; i < 4; ++i) {
         // Update swatch bitmap
@@ -850,6 +1002,22 @@ void MixedFilamentBatchDialog::update_recommended_card()
         // Update label text — the preset name (same on all four rows).
         if (m_recommended_labels[i]) {
             m_recommended_labels[i]->SetLabel(get_full_spectrum_preset_label());
+        }
+
+        // Refresh the row tooltip to reflect the now-rendered swatch color. Resolve the color
+        // identity by HEX (colors[i]) so the name + TD match the actual swatch even if the
+        // palette was reordered by the match. Falls back to a positional label if the hex is
+        // unknown (e.g. library reload failed / a color outside the Full Spectrum preset).
+        if (i < static_cast<int>(colors.size())) {
+            const FilamentColorItem* item = find_item(colors[i]);
+            const wxString ename = item ? english_color_name(*item, i)
+                                        : wxString::Format("F%d", i + 1);
+            const wxString cname = item ? localized_color_name(*item, i) : ename;
+            const wxString tip = make_recommended_tooltip(cname, ename);
+            if (m_recommended_swatches[i]) m_recommended_swatches[i]->SetToolTip(tip);
+            if (m_recommended_labels[i])   m_recommended_labels[i]->SetToolTip(tip);
+            wxWindow* row = m_recommended_swatches[i] ? m_recommended_swatches[i]->GetParent() : nullptr;
+            if (row) row->SetToolTip(tip);
         }
     }
 
@@ -1207,6 +1375,13 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     }
     const int fill_count = std::min<int>(4, static_cast<int>(palette.size()));
 
+    // Also load the raw FilamentColorItems (same filter/validation) so the per-row hover
+    // tooltip can show the localized color NAME. Loaded in lock-step with `palette` (same
+    // preset, same single-color-SKU filter, same order) so palette[i] ↔ items[i]. If the
+    // loader fails (library not loaded / preset missing) items is empty and the tooltip
+    // builder falls back to the positional label "F<i+1>".
+    const std::vector<FilamentColorItem> items = load_full_spectrum_items();
+
     // 2x2 grid: numbered swatch (20x20) + bordered name field. update_recommended_card()
     // refreshes swatches after a match reflects the palette order chosen by
     // recommend_best_filament_combo.
@@ -1214,48 +1389,71 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     grid->AddGrowableCol(0, 1);
     grid->AddGrowableCol(1, 1);
     for (int i = 0; i < 4; ++i) {
-        auto* panel = new wxPanel(card, wxID_ANY);
-        // wxPanel doesn't inherit the card's bg — set white explicitly (see build_manual_card).
-        panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        // Per Figma (node 28325:94417 "Container"): the WHOLE row is a bordered container
+        // (1px #dbdbdb, sharp corners — no rounded-* class, height 30, horizontal padding 9px)
+        // holding swatch + name together. The previous implementation bordered only the name
+        // `field`, leaving the numbered swatch sitting outside the border — the most visible
+        // mismatch with Figma. Sharp corners: the spec shows a plain `border border-[#dbdbdb]`
+        // with no `rounded-*` utility, so SetCornerRadius is 0 (StaticBox's default is 0, but
+        // we set it explicitly for clarity against future edits).
+        auto* panel = new StaticBox(card, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+        panel->SetCornerRadius(FromDIP(0));
+        panel->SetBorderWidth(FromDIP(1));
+        panel->SetBorderColorNormal(StateColor::darkModeColorFor(wxColour("#DBDBDB")));
+        panel->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
         // Pin a fixed column width so the 2×2 slots stay equal — see build_manual_card for
         // the wxFlexGridSizer rationale (keeps recommended + manual rows aligned on switch).
-        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
-        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
+        // Height 30 matches Figma; pinning min+max keeps the four rows visually uniform.
+        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), FromDIP(30)));
+        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), FromDIP(30)));
         auto* r = new wxBoxSizer(wxHORIZONTAL);
-        // Numbered color swatch (stored for later update). Guard with fill_count so a short
-        // palette can never read out of bounds (the fallback above always yields 4).
+        // Numbered color swatch (20×20, stored for later update). Guard with fill_count so a
+        // short palette can never read out of bounds (the fallback above always yields 4).
+        // wxLEFT=9 is the bordered container's left inset (Figma: px=9).
         if (i < fill_count) {
             wxBitmap* icon = get_extruder_color_icon(palette[i], std::to_string(i + 1), FromDIP(20), FromDIP(20));
             if (icon) {
                 auto* sw = new wxStaticBitmap(panel, wxID_ANY, *icon);
-                // §17: wxStaticBitmap does not inherit the panel bg. The icon is
-                // opaque so it covers the control, but set the bg explicitly to
-                // match the card and resist GTK theme override (consistency with
-                // the removed manual-card swatch, which set it too).
+                // §17: wxStaticBitmap does not inherit the panel bg. The icon is opaque so it
+                // covers the control, but set the bg explicitly to match the card and resist
+                // GTK theme override.
                 sw->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
                 m_recommended_swatches[i] = sw;
-                r->Add(sw, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+                r->Add(sw, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(9));
             }
         }
-        // Bordered name field (StaticBox wrapper, border #dbdbdb — same technique as
-        // MixedFilamentDialog's pattern-input wrapper). Name is the preset label (same on
-        // every row), NOT the per-color name — per product spec only the swatch varies.
-        auto* field = new StaticBox(panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
-        field->SetCornerRadius(FromDIP(4));
-        field->SetBorderWidth(FromDIP(1));
-        field->SetBorderColorNormal(StateColor::darkModeColorFor(wxColour("#DBDBDB")));
-        field->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
-        field->SetMinSize(wxSize(-1, FromDIP(24)));
-        auto* fs = new wxBoxSizer(wxHORIZONTAL);
-        auto* name = new wxStaticText(field, wxID_ANY, get_full_spectrum_preset_label());
-        name->SetFont(Label::Body_13);
+        // Name — the preset label (same on every row; only the swatch color varies, per product
+        // spec). 14px per Figma, with wxST_ELLIPSIZE_END so a long preset name ("Snapmaker PLA
+        // Full Spectrum @U1 0.4 nozzle") truncates instead of wrapping and breaking the row.
+        // The name sits directly in the bordered row (no separate bordered `field`); wxLEFT=8
+        // is the swatch→name gap (Figma: gap 8), wxRIGHT=8 the trailing inset (Figma 9 − 1px).
+        auto* name = new wxStaticText(panel, wxID_ANY, get_full_spectrum_preset_label(),
+                                       wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
+        name->SetFont(Label::Body_14);
         name->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         name->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
-        fs->Add(name, 1, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, FromDIP(9));
-        field->SetSizer(fs);
         m_recommended_labels[i] = name;
-        r->Add(field, 1, wxALIGN_CENTER_VERTICAL | wxEXPAND);
+        r->Add(name, 1, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, FromDIP(8));
         panel->SetSizer(r);
+        // Per-row hover tooltip: per-color NAME (localized) + COLOR hex + TD value (product spec).
+        // TD is resolved by the color's ENGLISH family name (cyan→C, magenta→M, ...), NOT by
+        // palette position — so it stays bound to the right color even when a match reorders the
+        // palette. The tooltip is set on the row panel AND its children (swatch, name): wx child
+        // windows do NOT inherit the parent tooltip, so without setting it on each child, hovering
+        // directly over the swatch/name shows nothing. update_recommended_card re-applies it after
+        // a match.
+        if (i < fill_count) {
+            const wxString ename = (i < static_cast<int>(items.size()))
+                ? english_color_name(items[i], i)
+                : wxString::Format("F%d", i + 1);
+            const wxString cname = (i < static_cast<int>(items.size()))
+                ? localized_color_name(items[i], i)
+                : ename;
+            const wxString tip = make_recommended_tooltip(cname, ename);
+            panel->SetToolTip(tip);
+            if (m_recommended_swatches[i]) m_recommended_swatches[i]->SetToolTip(tip);
+            name->SetToolTip(tip);
+        }
         grid->Add(panel, 0, wxEXPAND);
     }
     s->Add(grid, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
@@ -1486,7 +1684,26 @@ void MixedFilamentBatchDialog::build_footer()
     panel_sizer->Add(btn_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(20));
     panel_sizer->AddSpacer(FromDIP(12));
 
-    m_btn_cancel_match->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { EndModal(wxID_CANCEL); });
+    // Cancel shows a "Discard Match" confirmation before closing — but only when there's an
+    // actual match result to lose. The PRD (6.6) secondary check exists so the user doesn't
+    // discard a completed match by accident; "No" returns to the dialog with the current
+    // state (results, preview, legend) intact. When there's no result yet (idle / matching /
+    // failed), closing is lossless, so we skip the prompt and close directly. The gate mirrors
+    // the Confirm-button enable condition (set_match_buttons_state): a discardable result
+    // exists iff m_match_completed && m_result.success.
+    m_btn_cancel_match->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+        if (!m_match_completed || !m_result.success) {
+            EndModal(wxID_CANCEL);
+            return;
+        }
+        RichMessageDialog confirm(this,
+            _L("Are you sure you want to discard this match? The current configuration will not be saved."),
+            _L("Discard Match"),
+            wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
+        confirm.SetYesNoLabels(_L("Discard"), _L("Cancel"));
+        if (confirm.ShowModal() == wxID_YES)
+            EndModal(wxID_CANCEL);
+    });
     m_btn_confirm->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { EndModal(wxID_OK); });
 
     btn_panel->SetSizer(panel_sizer);
@@ -1585,7 +1802,15 @@ void MixedFilamentBatchDialog::set_match_buttons_state(bool matching)
 void MixedFilamentBatchDialog::on_method_changed(wxCommandEvent&)
 {
     int sel = m_method_combo->GetSelection();
-    m_matching_method = (sel == 1) ? MANUAL : RECOMMENDED;
+    MatchingMethod new_method = (sel == 1) ? MANUAL : RECOMMENDED;
+    // No-op if the user re-selected the already-active mode: wxComboBox fires COMBOBOX
+    // even for a re-pick of the current item (notably on wxMSW, clicking the open list's
+    // selected row). Re-running the refresh pipeline here would force needless card
+    // Show/Layout/tooltip updates and briefly hide the error/warning banners even though
+    // nothing actually changed.
+    if (new_method == m_matching_method)
+        return;
+    m_matching_method = new_method;
     // Preserve the previous match result; only Start/Re-match clears it.
     m_error_panel->Hide();
     m_warning_panel->Hide();

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -5,6 +5,7 @@
 #include "I18N.hpp"
 #include "PresetBundle.hpp"
 #include "libslic3r/Preset.hpp"
+#include "libslic3r/FilamentColorLibrary.hpp"
 #include "Widgets/ComboBox.hpp"
 #include "Widgets/StaticBox.hpp"
 #include "Widgets/Button.hpp"
@@ -15,6 +16,7 @@
 #include "BitmapCache.hpp"
 
 #include <unordered_map>
+#include <set>
 #include <algorithm>
 
 #include <wx/scrolwin.h>
@@ -23,10 +25,40 @@
 
 namespace Slic3r { namespace GUI {
 
+// Canonical Full Spectrum palette used as a fallback when load_full_spectrum_colors() fails
+// to read the live preset (library not loaded, preset missing, or <4 validated colors).
+// Mirrors filaments_colours.json's "Snapmaker PLA Full Spectrum @U1" single-color SKUs.
+// Single source of truth for the fallback path in both build_recommended_card and
+// launch_background_match — avoids the old duplicate CMYW_ENTRIES / CMYW_COLORS constants.
+static const std::vector<std::string> FULL_SPECTRUM_FALLBACK_COLORS = {
+    "#08ABFB", // semi-translucent cyan
+    "#D93B90", // semi-translucent magenta
+    "#F9ED3D", // semi-translucent yellow
+    "#9199A4", // semi-translucent gray
+};
+
 // Columns for the Color Mapping legend grid. Fixed (not growable) so each mapping
 // item keeps its natural width and the card height is computed correctly on macOS
 // (same rationale as MixedFilamentDialog's fixed-col swatch grid).
 static constexpr int LEGEND_GRID_COLS = 4;
+
+// Component-weight bounds for recipe generation (see launch_background_match).
+// Recommended mode caps a single component at 70% (product spec); manual mode is
+// unrestricted — an over-70% recipe surfaces as an advisory via check_manual_recipe_ratio
+// instead of being hard-rejected at match time.
+static constexpr int kMinComponentPercent = 0;   // recommended mode floor (near-pure allowed)
+static constexpr int kMaxComponentPercent = 70;  // recommended mode cap; also the advisory threshold
+
+// Product spec: a model is capped at 64 distinct filament colors. Colors past the cap are
+// dropped (see load_model_colors) and a deferred warning is shown once build_ui is up.
+static constexpr size_t kMaxColors = 64;
+
+// Card geometry (DIP). CARD_WIDTH_DIP leaves room for a vertical scrollbar inside the
+// 500-wide dialog: 500 − 2×12(margin) − 17(scrollbar) = 459. FILAMENT_COL_WIDTH_DIP pins
+// each 2×2 grid cell so slots 1/2 and 3/4 stay equal regardless of filament-name length
+// (wxFlexGridSizer otherwise sizes columns by content, so uneven names shift the columns).
+static constexpr int CARD_WIDTH_DIP        = 459;  // 500 − 2×12 − 17
+static constexpr int FILAMENT_COL_WIDTH_DIP = 207; // (459 − 2×16(padding) − 12(gap)) / 2 = 207.5 → floor
 
 // Preview panel design sizes (DIP), kept in sync with the RoundedPreviewPanel ctor args
 // in build_preview_card. Used as the std::max floor when reading GetClientSize() so an
@@ -258,6 +290,12 @@ MixedFilamentBatchDialog::MixedFilamentBatchDialog(wxWindow* parent)
         else
             m_tray_index = 1;
     }
+    // Pre-warm FilamentColorLibrary on the main thread. EnsureLoaded() is NOT thread-safe
+    // (_loaded is an unlocked bool, and it performs file I/O + JSON parse), so it MUST run
+    // before the worker thread in launch_background_match() starts. After warm-up, the
+    // worker's only call into the library is the read-only FindFilamentByName (a map lookup),
+    // which is safe to run concurrently with the main thread. See load_full_spectrum_colors().
+    FilamentColorLibrary::Instance().EnsureLoaded();
     load_model_colors();
     build_ui();
     set_match_buttons_state(false);
@@ -646,6 +684,77 @@ void MixedFilamentBatchDialog::load_model_colors()
             std::vector<unsigned int>{static_cast<unsigned int>(i + 1)}
         });
     }
+
+    // Product spec: cap at 64 distinct colors. This loop is the dedup source (each push is
+    // a unique validated color), so the cap applies to unique colors. Drop the tail beyond
+    // kMaxColors. The warning is deferred to build_ui because m_warning_panel is still null
+    // here — the ctor runs load_model_colors before build_banners/build_ui, so calling
+    // display_warning now would hit the early `if (!m_warning_panel) return` and be lost.
+    while (m_model_colors.size() > kMaxColors) {
+        m_model_colors.pop_back();
+        m_pending_64_color_warning = true;
+    }
+}
+
+// The Full Spectrum preset name shown in the name column of every recommended-card row.
+// Per product spec the name stays the preset label across all four slots; only the swatch
+// color varies. Falls back to the raw name when the preset bundle is unavailable.
+static wxString get_full_spectrum_preset_label()
+{
+    static const std::string kPresetName = "Snapmaker PLA Full Spectrum @U1 0.4 nozzle";
+    if (auto* pb = wxGetApp().preset_bundle) {
+        if (auto* p = pb->filaments.find_preset(kPresetName))
+            return wxString::FromUTF8(p->label(false));
+    }
+    return wxString::FromUTF8(kPresetName);
+}
+
+// Load the real recommended-mode palette colors from the Full Spectrum filament preset
+// (filaments_colours.json via FilamentColorLibrary). Returns the list of validated hex colors
+// (one per single-color SKU); empty on any failure so the caller falls back to the canonical
+// CMYW palette. NOTE: only the swatch COLORS come from here — the name column is the preset
+// label (see get_full_spectrum_preset_label), NOT the per-color name.
+//
+// Safety review closure (harness: input-validation, thread-safety):
+//   - (N) hex validation: every hex is re-checked via try_parse_color_match_hex; invalid
+//     values are skipped with a warning (defense-in-depth on top of FilamentColorLibrary's
+//     own NormalizeFilamentHexColor).
+//   - Thread safety: FilamentColorLibrary::EnsureLoaded() is NOT thread-safe (_loaded is an
+//     unlocked bool). The dialog ctor pre-warms it on the main thread; this function only
+//     does a read-only FindFilamentByName afterwards, so it is safe to call from the worker
+//     thread in launch_background_match. EnsureLoaded() here is a cheap no-op after warm-up.
+//   - (HIGH) distinct logging: each failure path emits its own BOOST_LOG_TRIVIAL(warning).
+static std::vector<std::string> load_full_spectrum_colors()
+{
+    const std::string kPresetName = "Snapmaker PLA Full Spectrum @U1 0.4 nozzle";
+    if (!FilamentColorLibrary::Instance().EnsureLoaded()) {
+        BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: FilamentColorLibrary not loaded, fallback to canonical palette";
+        return {};
+    }
+    FilamentColorInfo info;
+    if (!FilamentColorLibrary::Instance().FindFilamentByName(kPresetName, info)) {
+        BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: Full Spectrum preset not found in color library, fallback";
+        return {};
+    }
+
+    std::vector<std::string> result;
+    for (const FilamentColorItem& item : info.colors) {
+        // Only single-color SKUs qualify as palette candidates; skip dual-color / gradient
+        // entries (e.g. PLA Silk's Sunset Ember) so they don't pollute the palette.
+        if (item.colorData.colors.size() != 1)
+            continue;
+        const std::string& hex = item.colorData.colors[0];
+        // (N) Re-validate hex: FilamentColorLibrary normalises format, but double-check the
+        // color is wxColour-constructible before it flows into get_extruder_color_icon /
+        // recommend_best_filament_combo.
+        wxColour parsed;
+        if (!try_parse_color_match_hex(wxString::FromUTF8(hex.c_str()), parsed)) {
+            BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: invalid hex '" << hex << "' in Full Spectrum, skipped";
+            continue;
+        }
+        result.push_back(hex);
+    }
+    return result;
 }
 
 void MixedFilamentBatchDialog::update_recommended_card()
@@ -654,14 +763,9 @@ void MixedFilamentBatchDialog::update_recommended_card()
     const auto& colors = m_result.recommended_physical_colors;
     if (colors.size() < 4) return;
 
-    // Color name lookup — maps from hex in CMYW palette back to a
-    // human-readable label.  Covers the 4 canonical colors.
-    static const std::unordered_map<std::string, wxString> kColorName = {
-        {"#08ABFB", _L("Blue")},
-        {"#D93B90", _L("Magenta")},
-        {"#F9ED3D", _L("Yellow")},
-        {"#9199A4", _L("Gray")},
-    };
+    // NOTE: the name column shows the preset label (Snapmaker PLA Full Spectrum …) on every
+    // row, NOT the per-color name — per product spec only the swatch color varies per row.
+    // So no hex→name lookup is needed here; just the constant preset label.
 
     for (int i = 0; i < 4; ++i) {
         // Update swatch bitmap
@@ -673,13 +777,9 @@ void MixedFilamentBatchDialog::update_recommended_card()
                 m_recommended_swatches[i]->SetBitmap(*icon);
         }
 
-        // Update label text
+        // Update label text — the preset name (same on all four rows).
         if (m_recommended_labels[i]) {
-            auto it = kColorName.find(colors[i]);
-            m_recommended_labels[i]->SetLabel(
-                it != kColorName.end()
-                    ? it->second
-                    : wxString::Format("F%d", int(i + 1)));
+            m_recommended_labels[i]->SetLabel(get_full_spectrum_preset_label());
         }
     }
 
@@ -745,6 +845,12 @@ void MixedFilamentBatchDialog::build_ui()
     // update_nav_arrow_state is otherwise only called from combo/nav callbacks, so the
     // initial state was never set.
     update_nav_arrow_state();
+
+    // Deferred from load_model_colors: if the model had >64 distinct colors, the extras were
+    // dropped there. m_warning_panel is now created (build_banners ran before build_ui), so
+    // the advisory can finally be shown.
+    if (m_pending_64_color_warning)
+        display_warning(_L("Filament color limit reached (64 colors). Colors over the limit have been removed."));
 }
 
 void MixedFilamentBatchDialog::build_banners()
@@ -871,8 +977,8 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
     card->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
     // All four cards share the same fixed width + centered alignment so their edges line up
     // with consistent margins — mirrors MixedFilamentDialog's fixed-width (325) cards.
-    card->SetMinSize(wxSize(FromDIP(460), -1));
-    card->SetMaxSize(wxSize(FromDIP(460), -1));
+    card->SetMinSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
+    card->SetMaxSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
     card->Hide();
     m_manual_card = card;
     auto* s = new wxBoxSizer(wxVERTICAL);
@@ -937,6 +1043,12 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
         // wxPanel/StaticText don't inherit the card's bg — set white explicitly so the
         // row doesn't show the dialog's #F8F7F7 through (same as MixedFilamentDialog rows).
         panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        // Pin a fixed column width so the 2×2 slots stay equal regardless of how long the
+        // selected filament's name is. wxFlexGridSizer sizes columns by content (best size)
+        // first, then distributes leftover via AddGrowableCol(0/1, 1) — without a pinned
+        // base width, slots 1/2 and 3/4 drift apart when names differ in length.
+        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
+        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
         auto* r = new wxBoxSizer(wxHORIZONTAL);
 
         // §68: read-only selection would normally call for wxChoice, but this
@@ -978,7 +1090,8 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
     s->Add(grid, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     card->SetSizer(s);
     // Horizontal margin only; the card-to-card vertical gap is added at the build_ui call site.
-    parent.Add(card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(20));
+    // 12px pairs with CARD_WIDTH_DIP (459 = 500 − 2×12 − 17 scrollbar) so cards stay centered.
+    parent.Add(card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(12));
 }
 
 void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
@@ -989,15 +1102,16 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     card->SetBorderColorNormal(StateColor::darkModeColorFor(wxColour("#F0F0F0")));
     card->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
     // Same fixed width + centering as the manual card (see build_manual_card).
-    card->SetMinSize(wxSize(FromDIP(460), -1));
-    card->SetMaxSize(wxSize(FromDIP(460), -1));
+    card->SetMinSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
+    card->SetMaxSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
     card->Hide();
     m_recommended_card = card;
     auto* s = new wxBoxSizer(wxVERTICAL);
 
-    // Title
+    // Title — generic "Filament Setup" (no longer "(CMYW)"); colors are now driven by the
+    // Full Spectrum preset, so the title doesn't hardcode a color model.
     {
-        auto* lbl = new wxStaticText(card, wxID_ANY, _L("Filament Setup (CMYW)"));
+        auto* lbl = new wxStaticText(card, wxID_ANY, _L("Filament Setup"));
         lbl->SetFont(Label::Body_14);
         // §17/§81: explicit fg+bg so the label matches the card on wxMSW and
         // resists GTK theme override.
@@ -1010,15 +1124,22 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     // see §137).
     s->AddSpacer(FromDIP(10)); // title-to-grid gap per Figma spec
 
-    // 2x2 grid: numbered CMYW swatch (20x20) + bordered name field. Initially populated
-    // with the canonical CMYW order; update_recommended_card() refreshes swatches/names
-    // after a match reflects the palette order chosen by recommend_best_filament_combo.
-    static const std::vector<std::pair<std::string, wxString>> CMYW_ENTRIES = {
-        {"#08ABFB", _L("Blue")},
-        {"#D93B90", _L("Magenta")},
-        {"#F9ED3D", _L("Yellow")},
-        {"#9199A4", _L("Gray")},
-    };
+    // Load the real palette colors from the Full Spectrum preset (filaments_colours.json).
+    // Falls back to the canonical palette when the preset is missing or yields <4 validated
+    // single-color SKUs. Only the swatch COLORS come from here; the name column is the preset
+    // label (see get_full_spectrum_preset_label). See load_full_spectrum_colors() for the
+    // safety review (hex validation, thread safety, distinct logging).
+    std::vector<std::string> palette = load_full_spectrum_colors();
+    if (palette.size() < 4) {
+        palette.clear();
+        for (const std::string& c : FULL_SPECTRUM_FALLBACK_COLORS)
+            palette.push_back(c);
+    }
+    const int fill_count = std::min<int>(4, static_cast<int>(palette.size()));
+
+    // 2x2 grid: numbered swatch (20x20) + bordered name field. update_recommended_card()
+    // refreshes swatches after a match reflects the palette order chosen by
+    // recommend_best_filament_combo.
     auto* grid = new wxFlexGridSizer(2, FromDIP(12), FromDIP(12));
     grid->AddGrowableCol(0, 1);
     grid->AddGrowableCol(1, 1);
@@ -1026,21 +1147,29 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
         auto* panel = new wxPanel(card, wxID_ANY);
         // wxPanel doesn't inherit the card's bg — set white explicitly (see build_manual_card).
         panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        // Pin a fixed column width so the 2×2 slots stay equal — see build_manual_card for
+        // the wxFlexGridSizer rationale (keeps recommended + manual rows aligned on switch).
+        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
+        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
         auto* r = new wxBoxSizer(wxHORIZONTAL);
-        // Numbered color swatch (stored for later update)
-        wxBitmap* icon = get_extruder_color_icon(CMYW_ENTRIES[i].first, std::to_string(i + 1), FromDIP(20), FromDIP(20));
-        if (icon) {
-            auto* sw = new wxStaticBitmap(panel, wxID_ANY, *icon);
-            // §17: wxStaticBitmap does not inherit the panel bg. The icon is
-            // opaque so it covers the control, but set the bg explicitly to
-            // match the card and resist GTK theme override (consistency with
-            // the removed manual-card swatch, which set it too).
-            sw->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
-            m_recommended_swatches[i] = sw;
-            r->Add(sw, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+        // Numbered color swatch (stored for later update). Guard with fill_count so a short
+        // palette can never read out of bounds (the fallback above always yields 4).
+        if (i < fill_count) {
+            wxBitmap* icon = get_extruder_color_icon(palette[i], std::to_string(i + 1), FromDIP(20), FromDIP(20));
+            if (icon) {
+                auto* sw = new wxStaticBitmap(panel, wxID_ANY, *icon);
+                // §17: wxStaticBitmap does not inherit the panel bg. The icon is
+                // opaque so it covers the control, but set the bg explicitly to
+                // match the card and resist GTK theme override (consistency with
+                // the removed manual-card swatch, which set it too).
+                sw->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+                m_recommended_swatches[i] = sw;
+                r->Add(sw, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+            }
         }
         // Bordered name field (StaticBox wrapper, border #dbdbdb — same technique as
-        // MixedFilamentDialog's pattern-input wrapper)
+        // MixedFilamentDialog's pattern-input wrapper). Name is the preset label (same on
+        // every row), NOT the per-color name — per product spec only the swatch varies.
         auto* field = new StaticBox(panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
         field->SetCornerRadius(FromDIP(4));
         field->SetBorderWidth(FromDIP(1));
@@ -1048,7 +1177,7 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
         field->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
         field->SetMinSize(wxSize(-1, FromDIP(24)));
         auto* fs = new wxBoxSizer(wxHORIZONTAL);
-        auto* name = new wxStaticText(field, wxID_ANY, CMYW_ENTRIES[i].second);
+        auto* name = new wxStaticText(field, wxID_ANY, get_full_spectrum_preset_label());
         name->SetFont(Label::Body_13);
         name->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         name->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
@@ -1062,7 +1191,8 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     s->Add(grid, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     card->SetSizer(s);
     // Horizontal margin only; the card-to-card vertical gap is added at the build_ui call site.
-    parent.Add(card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(20));
+    // 12px pairs with CARD_WIDTH_DIP (459 = 500 − 2×12 − 17 scrollbar) so cards stay centered.
+    parent.Add(card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(12));
 }
 
 void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
@@ -1073,8 +1203,8 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
     m_preview_card->SetBorderColorNormal(StateColor::darkModeColorFor(wxColour("#F0F0F0")));
     m_preview_card->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
     // Same fixed width + centering as the filament-config cards.
-    m_preview_card->SetMinSize(wxSize(FromDIP(460), -1));
-    m_preview_card->SetMaxSize(wxSize(FromDIP(460), -1));
+    m_preview_card->SetMinSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
+    m_preview_card->SetMaxSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
     auto* s = new wxBoxSizer(wxVERTICAL);
 
     // Dual previews: Original (fixed 180x180) + After Match (fixed 227x227), both rounded.
@@ -1171,7 +1301,8 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
     }
 
     m_preview_card->SetSizer(s);
-    parent.Add(m_preview_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(20));
+    // 12px margin pairs with CARD_WIDTH_DIP (see build_manual_card).
+    parent.Add(m_preview_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(12));
 }
 
 void MixedFilamentBatchDialog::build_mapping_card(wxBoxSizer& parent)
@@ -1182,8 +1313,8 @@ void MixedFilamentBatchDialog::build_mapping_card(wxBoxSizer& parent)
     m_mapping_card->SetBorderColorNormal(StateColor::darkModeColorFor(wxColour("#F0F0F0")));
     m_mapping_card->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
     // Same fixed width + centering as the filament-config cards.
-    m_mapping_card->SetMinSize(wxSize(FromDIP(460), -1));
-    m_mapping_card->SetMaxSize(wxSize(FromDIP(460), -1));
+    m_mapping_card->SetMinSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
+    m_mapping_card->SetMaxSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
     auto* cs = new wxBoxSizer(wxVERTICAL);
 
     // Title row: label + info icon
@@ -1209,7 +1340,11 @@ void MixedFilamentBatchDialog::build_mapping_card(wxBoxSizer& parent)
     m_legend_panel->SetSizer(m_legend_sizer);
     cs->Add(m_legend_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     m_mapping_card->SetSizer(cs);
-    parent.Add(m_mapping_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(20));
+    // Horizontal margin 12 (pairs with CARD_WIDTH_DIP); bottom 20 stays as breathing room
+    // above the footer (kept distinct from the L/R margin so the card-to-footer gap is
+    // preserved when the L/R margin narrowed from 20→12).
+    parent.Add(m_mapping_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(12));
+    parent.AddSpacer(FromDIP(20));
 }
 
 void MixedFilamentBatchDialog::build_footer()
@@ -1417,8 +1552,8 @@ void MixedFilamentBatchDialog::update_method_combo_tooltip()
     // adding a permanent subtitle row to the UI.
     m_method_combo->SetToolTip(m_matching_method == MANUAL
         ? _L("Manually select filaments from the current list for color mixing.")
-        : _L("Automatically uses official CMYW filaments for color mixing. "
-             "The mix ratio for each color is limited to X%\u2013Y%."));
+        : _L("Automatically uses official Full Spectrum filaments for color mixing. "
+             "The mix ratio for each color is limited to 0%\u201370%."));
 }
 
 void MixedFilamentBatchDialog::on_manual_selection_changed()
@@ -1468,6 +1603,53 @@ void MixedFilamentBatchDialog::check_manual_filament_ratio()
     display_warning(wxString::Format(_L("Filament %d ratio is too high. Mix may be affected."), max_sel + 1));
 }
 
+void MixedFilamentBatchDialog::check_manual_recipe_ratio()
+{
+    // Post-match complement to check_manual_filament_ratio: that one warns BEFORE a match
+    // (based on how many rows picked the same physical slot). This one warns AFTER a match,
+    // scanning every non-pure recipe for any single component above kMaxComponentPercent and
+    // listing ALL offending filament IDs in one banner (gap doc case 13).
+    if (m_warning_panel) m_warning_panel->Hide();
+    if (m_matching_method != MANUAL) return;
+    if (!m_match_completed || m_result.mappings.empty()) return;
+
+    // NOTE: size by m_physical_colors.size(). In manual mode, launch_background_match's
+    // manual-remap branch rewrites recipe component ids to project-wide 1-based indices, so
+    // expand_color_match_recipe_weights must be sized against the FULL physical palette.
+    // A too-small count reads out-of-range indices as 0 weight and silently misses the
+    // over-threshold component.
+    const size_t num_physical = m_physical_colors.size();
+    if (num_physical == 0) return;
+
+    // Collect offending filament ids (1-based) in a set for de-dup + ascending order.
+    std::set<unsigned int> over_ids;
+    for (const ColorMappingEntry& e : m_result.mappings) {
+        if (e.is_pure_recipe) continue;        // pure = single component, ratio n/a
+        if (!e.recipe.valid) continue;         // nothing to check
+        const auto weights = expand_color_match_recipe_weights(e.recipe, num_physical);
+        for (size_t i = 0; i < weights.size() && i < num_physical; ++i) {
+            if (weights[i] > kMaxComponentPercent)
+                over_ids.insert(static_cast<unsigned int>(i + 1));
+        }
+    }
+    if (over_ids.empty()) return;
+
+    // Build "{x, y, z}" for the %s placeholder.
+    wxString id_list = "{";
+    bool first = true;
+    for (unsigned int id : over_ids) {
+        if (!first) id_list += ", ";
+        id_list << id;
+        first = false;
+    }
+    id_list << "}";
+
+    display_warning(wxString::Format(
+        _L("The mix ratios for %s in the Color Mapping list are outside the recommended %d"
+           "%%\u2013%d%% range. Adjust the mix ratios manually for better results."),
+        id_list, kMinComponentPercent, kMaxComponentPercent));
+}
+
 void MixedFilamentBatchDialog::set_manual_combo_icon(int row, int filament_idx)
 {
     // Compose a single transparent icon holding [drop_down arrow] + [numbered color badge]
@@ -1478,7 +1660,7 @@ void MixedFilamentBatchDialog::set_manual_combo_icon(int row, int filament_idx)
     if (row < 0 || row >= 4) return;
     ComboBox* cb = m_filament_combo[row];
     if (!cb) return;
-    if (filament_idx < 0 || filament_idx >= (int) m_physical_colors.size()) return;
+    if (filament_idx < 0 || filament_idx >= static_cast<int>(m_physical_colors.size())) return;
 
     const int pad = FromDIP(8), arr_w = FromDIP(8), badge_w = FromDIP(20), h = FromDIP(20), gap = FromDIP(8), text_gap = FromDIP(8);
     const int total_w = pad + arr_w + gap + badge_w + text_gap;
@@ -1594,14 +1776,21 @@ void MixedFilamentBatchDialog::launch_background_match()
     const auto all_physical      = m_physical_colors;
 
     const auto matching_method = m_matching_method;
-    // Fixed CMYW palette for recommended mode.
-    static const std::vector<std::string> CMYW_COLORS = {
-        "#08ABFB",  // blue
-        "#D93B90",  // magenta
-        "#F9ED3D",  // yellow
-        "#9199A4",  // gray
-    };
-    const std::vector<std::string> preset_colors = CMYW_COLORS;
+    // Physical palette for recommended mode. Loaded from the real Full Spectrum preset
+    // (filaments_colours.json) on the main thread here, then captured by value into the
+    // worker lambda below — so the worker never touches FilamentColorLibrary. Falls back to
+    // FULL_SPECTRUM_FALLBACK_COLORS when the preset is missing or yields <4 validated colors.
+    // See load_full_spectrum_colors() for hex validation + distinct logging.
+    std::vector<std::string> preset_colors;
+    {
+        std::vector<std::string> palette = load_full_spectrum_colors();
+        if (palette.size() >= 4) {
+            preset_colors = std::move(palette);
+        } else {
+            BOOST_LOG_TRIVIAL(warning) << "launch_background_match: preset colors <4, fallback to canonical palette";
+            preset_colors = FULL_SPECTRUM_FALLBACK_COLORS;
+        }
+    }
     // Use enabled_count() (skips deleted/disabled) to match the virtual ID
     // numbering scheme used by mixed_index_from_filament_id() and
     // add_batch_custom_filaments(), both of which count only enabled entries.
@@ -1623,7 +1812,10 @@ void MixedFilamentBatchDialog::launch_background_match()
             physical_colors = manual_colors;
         } else {
             if (preset_colors.size() >= 4) {
-                auto best = recommend_best_filament_combo(model_colors, preset_colors, 15, cancel_token);
+                // Combo search passes max=100 here: this stage only picks WHICH 4 preset
+                // colors form the palette; the per-component 70% cap is enforced later in
+                // the Pass-2 batch_match_model_colors call (match_max=kMaxComponentPercent).
+                auto best = recommend_best_filament_combo(model_colors, preset_colors, 15, 100, cancel_token);
                 if (best.empty()) {
                     physical_colors.assign(preset_colors.begin(), preset_colors.begin() + std::min<size_t>(4, preset_colors.size()));
                 } else {
@@ -1662,7 +1854,7 @@ void MixedFilamentBatchDialog::launch_background_match()
                 existing_ids.push_back(static_cast<unsigned int>(i + 1));
             }
         }
-        // Recommended mode: only use the recommended CMYW physical colors as the
+        // Recommended mode: only use the recommended Full Spectrum physical colors as the
         // Pass-1 reuse palette. Existing mixed filaments are NOT included because
         // (a) their display_colors reference the old physical palette that is about
         // to be replaced, and (b) a passthrough recipe targeting a virtual filament
@@ -1703,8 +1895,17 @@ void MixedFilamentBatchDialog::launch_background_match()
         // Pass 2: batch-match remaining colors.  batch_match_model_colors uses a
         // return-code model (result.success / error_code) and its whole call chain
         // has no throw sites, so no exception handling is needed here.
+        //
+        // Per-component weight bounds are mode-dependent:
+        //   - RECOMMENDED: [kMinComponentPercent(0), kMaxComponentPercent(70)] — product
+        //     spec forces no single component above 70%.
+        //   - MANUAL: [15, 100] — keep the 15% floor so a mix always has minimum
+        //     participation, but allow >70%; over-70% is surfaced as an advisory by
+        //     check_manual_recipe_ratio after the match, not hard-rejected here.
+        const int match_min = (matching_method == MANUAL) ? 15 : kMinComponentPercent;
+        const int match_max = (matching_method == MANUAL) ? 100 : kMaxComponentPercent;
         if (!unmatched_colors.empty()) {
-            auto sub_result = batch_match_model_colors(unmatched_colors, physical_colors, 15, cancel_token,
+            auto sub_result = batch_match_model_colors(unmatched_colors, physical_colors, match_min, match_max, cancel_token,
                 [progress_bar, destroyed](int done, int total) {
                     if (progress_bar && !destroyed->load()) {
                         wxGetApp().CallAfter([progress_bar, done, total, destroyed]() {
@@ -1836,6 +2037,10 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
     if (result.is_recommended_mode)
         update_recommended_card();
     refresh_previews();
+    // Post-match advisory: scan manual-mode recipes for any single component > 70%. Must run
+    // after refresh_previews (m_match_completed is already true here) and before the button
+    // state flip so the warning banner is in place when Confirm lights up.
+    check_manual_recipe_ratio();
     // Defer the button-state flip until AFTER refresh_previews() has rendered and
     // pushed the After-Match bitmap, so Confirm/Re-match light up in lockstep with
     // the preview — not a frame earlier. m_match_completed stays true throughout so

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -11,6 +11,7 @@
 #include "Widgets/Button.hpp"
 #include "Widgets/Label.hpp"
 #include "wxExtensions.hpp"
+#include "MsgDialog.hpp"
 #include "Plater.hpp"
 #include "PartPlate.hpp"
 #include "BitmapCache.hpp"
@@ -18,6 +19,8 @@
 #include <unordered_map>
 #include <set>
 #include <algorithm>
+#include <cctype>
+#include <thread>
 
 #include <wx/scrolwin.h>
 #include <wx/dcbuffer.h>
@@ -52,6 +55,32 @@ static constexpr int kMaxComponentPercent = 70;  // recommended mode cap; also t
 // Product spec: a model is capped at 64 distinct filament colors. Colors past the cap are
 // dropped (see load_model_colors) and a deferred warning is shown once build_ui is up.
 static constexpr size_t kMaxColors = 64;
+
+// Recommended-mode (Full Spectrum) per-color transmittance-density (TD) values. These are NOT
+// in the filament data model (filaments_colours.json carries no TD field), so they are pinned
+// here as product constants — provided by product spec (snapshot in code per request).
+//
+// KEYED BY COLOR FAMILY (canonical color name), NOT by palette position. The recommended card's
+// swatch order is normally preset-order (C/M/Y/G), but a match's ΔE fallback path
+// (launch_background_match) can reorder the palette, so positional indexing would bind the
+// wrong TD to a color after reorder. Looking up by the color's identity avoids that.
+//
+// Each entry: {substring-to-match-against-English-name, TD-label, TD-value}. The match is
+// case-insensitive substring on the EN color name (which is always present in FilamentColorItem
+// .colorNames regardless of UI locale — it's the SKU's canonical name in filaments_colours.json).
+// White (W:8.8) is included per spec; Full Spectrum has no White SKU today, so it only surfaces
+// if a White-named color is ever added to the preset.
+// Each entry: {substring-to-match, TD-value}. The substring IS the family display name —
+// tooltip shows it verbatim (e.g. "cyan 5.5"), no separate label/abbreviation needed.
+struct TdEntry { const char* family; double value; };
+static const std::vector<TdEntry> FULL_SPECTRUM_TD = {
+    {"cyan",    5.5},
+    {"magenta", 5.5},
+    {"yellow",  9.5},
+    {"white",   8.8},
+    {"gray",    6.5},
+    {"grey",    6.5}, // spelling variant, defensive
+};
 
 // Card geometry (DIP). CARD_WIDTH_DIP leaves room for a vertical scrollbar inside the
 // 500-wide dialog: 500 − 2×12(margin) − 17(scrollbar) = 459. FILAMENT_COL_WIDTH_DIP pins
@@ -701,12 +730,11 @@ void MixedFilamentBatchDialog::load_model_colors()
 // color varies. Falls back to the raw name when the preset bundle is unavailable.
 static wxString get_full_spectrum_preset_label()
 {
-    static const std::string kPresetName = "Snapmaker PLA Full Spectrum @U1 0.4 nozzle";
     if (auto* pb = wxGetApp().preset_bundle) {
-        if (auto* p = pb->filaments.find_preset(kPresetName))
+        if (auto* p = pb->filaments.find_preset(kFullSpectrumPresetName))
             return wxString::FromUTF8(p->label(false));
     }
-    return wxString::FromUTF8(kPresetName);
+    return wxString::FromUTF8(kFullSpectrumPresetName);
 }
 
 // Load the real recommended-mode palette colors from the Full Spectrum filament preset
@@ -726,13 +754,12 @@ static wxString get_full_spectrum_preset_label()
 //   - (HIGH) distinct logging: each failure path emits its own BOOST_LOG_TRIVIAL(warning).
 static std::vector<std::string> load_full_spectrum_colors()
 {
-    const std::string kPresetName = "Snapmaker PLA Full Spectrum @U1 0.4 nozzle";
     if (!FilamentColorLibrary::Instance().EnsureLoaded()) {
         BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: FilamentColorLibrary not loaded, fallback to canonical palette";
         return {};
     }
     FilamentColorInfo info;
-    if (!FilamentColorLibrary::Instance().FindFilamentByName(kPresetName, info)) {
+    if (!FilamentColorLibrary::Instance().FindFilamentByName(kFullSpectrumPresetName, info)) {
         BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: Full Spectrum preset not found in color library, fallback";
         return {};
     }
@@ -757,6 +784,105 @@ static std::vector<std::string> load_full_spectrum_colors()
     return result;
 }
 
+// Full Spectrum palette as raw FilamentColorItems — same single-color-SKU filter and hex
+// re-validation as load_full_spectrum_colors(), but keeps each item's colorNames map so the
+// caller (build_recommended_card's tooltip) can show the localized per-color name. Returns
+// empty on any failure; callers fall back to positional defaults. NOT thread-safe beyond the
+// EnsureLoaded warm-up done in the ctor (see load_full_spectrum_colors's safety note).
+static std::vector<FilamentColorItem> load_full_spectrum_items()
+{
+    if (!FilamentColorLibrary::Instance().EnsureLoaded()) return {};
+    FilamentColorInfo info;
+    if (!FilamentColorLibrary::Instance().FindFilamentByName(kFullSpectrumPresetName, info)) return {};
+
+    std::vector<FilamentColorItem> result;
+    for (const FilamentColorItem& item : info.colors) {
+        if (item.colorData.colors.size() != 1) continue;
+        wxColour parsed;
+        if (!try_parse_color_match_hex(wxString::FromUTF8(item.colorData.colors[0].c_str()), parsed))
+            continue;
+        result.push_back(item);
+    }
+    return result;
+}
+
+// Look up a name from a FilamentColorItem's colorNames map for a specific language key.
+// On hit, writes the decoded name into `out` and returns true; on miss, returns false and
+// leaves `out` untouched. The JSON keys are short codes ("zh_CN","en"); callers try the full
+// locale, then the base language, then a fallback.
+//
+// NOTE: must NOT return `&wxString::FromUTF8(...)` — that yields a pointer to a temporary
+// wxString, which is destroyed at the semicolon, leaving a dangling pointer (UB / crash on
+// deref). The bool+out-param form keeps ownership with the caller.
+static bool color_name_for_lang(const FilamentColorItem& item, const wxString& key, wxString& out)
+{
+    auto it = item.colorNames.find(into_u8(key));
+    if (it == item.colorNames.end()) return false;
+    out = wxString::FromUTF8(it->second.c_str());
+    return true;
+}
+
+// The ENGLISH color name — always present in colorNames (it's the SKU's canonical name in
+// filaments_colours.json) regardless of UI locale. Used as a STABLE identity for TD family
+// matching (FULL_SPECTRUM_TD is keyed by EN substrings: cyan/magenta/yellow/...). Falls back
+// to whatever name is present, then to a positional "F<n>" label.
+static wxString english_color_name(const FilamentColorItem& item, int position)
+{
+    wxString s;
+    if (color_name_for_lang(item, "en", s)) return s;
+    if (!item.colorNames.empty())
+        return wxString::FromUTF8(item.colorNames.begin()->second.c_str());
+    return wxString::Format("F%d", position + 1);
+}
+
+// Pick a localized color name from a FilamentColorItem's colorNames map, honouring the app's
+// current language. Falls back to English, then to the SKU, then to the positional label.
+static wxString localized_color_name(const FilamentColorItem& item, int position)
+{
+    // current_language_code() returns e.g. "zh_CN" / "en" / "en_US". Try the exact code first,
+    // then the base language (strip region suffix), then English.
+    const wxString lang = wxGetApp().current_language_code();
+    wxString s;
+    if (color_name_for_lang(item, lang, s)) return s;
+    const wxString base = lang.BeforeFirst('_');
+    if (color_name_for_lang(item, base, s)) return s;
+    if (color_name_for_lang(item, wxString("en"), s)) return s;
+    return english_color_name(item, position);
+}
+
+// Resolve the TD family for a filament color by matching the ENGLISH color name against the
+// canonical-family substrings in FULL_SPECTRUM_TD (e.g. "Semi-Translucent Cyan" → family "C").
+// Returns nullptr if no family matches. Case-insensitive substring match on the EN name so it
+// tolerates adjectives ("Semi-Translucent") and prefix/suffix variation.
+//
+// Why English: the EN name is the SKU's canonical identity in filaments_colours.json and is
+// always present regardless of UI locale, so family detection is locale-independent and stable.
+static const TdEntry* resolve_td_family(const wxString& english_name)
+{
+    wxString lower = english_name.Lower();
+    for (const TdEntry& e : FULL_SPECTRUM_TD)
+        if (lower.find(e.family) != wxString::npos) return &e;
+    return nullptr;
+}
+
+// Build the hover tooltip string for one recommended-mode row. Two lines:
+//   <preset label>          e.g. "Snapmaker PLA Full Spectrum"
+//   <color name> TD : <val> e.g. "Translucent Cyan TD : 5.5"
+// The color name is localized; TD is resolved by the color's family via its English name
+// (see resolve_td_family), NOT by palette position — so the TD stays bound to the right color
+// even when the match reorders the palette. When TD is unknown (color family not in
+// FULL_SPECTRUM_TD) the value shows "-".
+static wxString make_recommended_tooltip(const wxString& localized_name, const wxString& english_name)
+{
+    const TdEntry* td = resolve_td_family(english_name);
+    const wxString td_disp = td ? wxString::Format("%.1f", td->value) : wxString("-");
+    return wxString::Format("%s\n%s %s : %s",
+        get_full_spectrum_preset_label(),
+        localized_name,
+        _L("TD"),
+        td_disp);
+}
+
 void MixedFilamentBatchDialog::update_recommended_card()
 {
     if (!m_recommended_card) return;
@@ -765,7 +891,33 @@ void MixedFilamentBatchDialog::update_recommended_card()
 
     // NOTE: the name column shows the preset label (Snapmaker PLA Full Spectrum …) on every
     // row, NOT the per-color name — per product spec only the swatch color varies per row.
-    // So no hex→name lookup is needed here; just the constant preset label.
+    // So no hex→name lookup is needed for the LABEL; the tooltip, however, shows the per-color
+    // name and DOES need to resolve colors[i] → the right FilamentColorItem.
+
+    // Re-load items and index them by HEX so each row resolves the correct color identity.
+    // This is essential after a match: launch_background_match's ΔE fallback can REORDER the
+    // palette, so colors[i] may not sit at position i in the preset's natural order. Looking
+    // up by hex (rather than positional items[i]) binds the tooltip's name + TD to the actual
+    // color on the swatch, not its grid slot. Hex comparison is case-insensitive to tolerate
+    // "#08abfb" vs "#08ABFB" between config and library.
+    const std::vector<FilamentColorItem> items = load_full_spectrum_items();
+    std::unordered_map<std::string, const FilamentColorItem*> by_hex;
+    by_hex.reserve(items.size());
+    for (const FilamentColorItem& item : items) {
+        if (item.colorData.colors.size() == 1) {
+            std::string h = item.colorData.colors[0];
+            std::transform(h.begin(), h.end(), h.begin(),
+                           [](unsigned char ch) { return std::tolower(ch); });
+            by_hex.emplace(std::move(h), &item);
+        }
+    }
+    auto find_item = [&](const std::string& hex) -> const FilamentColorItem* {
+        std::string h = hex;
+        std::transform(h.begin(), h.end(), h.begin(),
+                       [](unsigned char ch) { return std::tolower(ch); });
+        auto it = by_hex.find(h);
+        return it != by_hex.end() ? it->second : nullptr;
+    };
 
     for (int i = 0; i < 4; ++i) {
         // Update swatch bitmap
@@ -780,6 +932,22 @@ void MixedFilamentBatchDialog::update_recommended_card()
         // Update label text — the preset name (same on all four rows).
         if (m_recommended_labels[i]) {
             m_recommended_labels[i]->SetLabel(get_full_spectrum_preset_label());
+        }
+
+        // Refresh the row tooltip to reflect the now-rendered swatch color. Resolve the color
+        // identity by HEX (colors[i]) so the name + TD match the actual swatch even if the
+        // palette was reordered by the match. Falls back to a positional label if the hex is
+        // unknown (e.g. library reload failed / a color outside the Full Spectrum preset).
+        if (i < static_cast<int>(colors.size())) {
+            const FilamentColorItem* item = find_item(colors[i]);
+            const wxString ename = item ? english_color_name(*item, i)
+                                        : wxString::Format("F%d", i + 1);
+            const wxString cname = item ? localized_color_name(*item, i) : ename;
+            const wxString tip = make_recommended_tooltip(cname, ename);
+            if (m_recommended_swatches[i]) m_recommended_swatches[i]->SetToolTip(tip);
+            if (m_recommended_labels[i])   m_recommended_labels[i]->SetToolTip(tip);
+            wxWindow* row = m_recommended_swatches[i] ? m_recommended_swatches[i]->GetParent() : nullptr;
+            if (row) row->SetToolTip(tip);
         }
     }
 
@@ -1137,6 +1305,13 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     }
     const int fill_count = std::min<int>(4, static_cast<int>(palette.size()));
 
+    // Also load the raw FilamentColorItems (same filter/validation) so the per-row hover
+    // tooltip can show the localized color NAME. Loaded in lock-step with `palette` (same
+    // preset, same single-color-SKU filter, same order) so palette[i] ↔ items[i]. If the
+    // loader fails (library not loaded / preset missing) items is empty and the tooltip
+    // builder falls back to the positional label "F<i+1>".
+    const std::vector<FilamentColorItem> items = load_full_spectrum_items();
+
     // 2x2 grid: numbered swatch (20x20) + bordered name field. update_recommended_card()
     // refreshes swatches after a match reflects the palette order chosen by
     // recommend_best_filament_combo.
@@ -1144,48 +1319,71 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     grid->AddGrowableCol(0, 1);
     grid->AddGrowableCol(1, 1);
     for (int i = 0; i < 4; ++i) {
-        auto* panel = new wxPanel(card, wxID_ANY);
-        // wxPanel doesn't inherit the card's bg — set white explicitly (see build_manual_card).
-        panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        // Per Figma (node 28325:94417 "Container"): the WHOLE row is a bordered container
+        // (1px #dbdbdb, sharp corners — no rounded-* class, height 30, horizontal padding 9px)
+        // holding swatch + name together. The previous implementation bordered only the name
+        // `field`, leaving the numbered swatch sitting outside the border — the most visible
+        // mismatch with Figma. Sharp corners: the spec shows a plain `border border-[#dbdbdb]`
+        // with no `rounded-*` utility, so SetCornerRadius is 0 (StaticBox's default is 0, but
+        // we set it explicitly for clarity against future edits).
+        auto* panel = new StaticBox(card, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
+        panel->SetCornerRadius(FromDIP(0));
+        panel->SetBorderWidth(FromDIP(1));
+        panel->SetBorderColorNormal(StateColor::darkModeColorFor(wxColour("#DBDBDB")));
+        panel->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
         // Pin a fixed column width so the 2×2 slots stay equal — see build_manual_card for
         // the wxFlexGridSizer rationale (keeps recommended + manual rows aligned on switch).
-        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
-        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
+        // Height 30 matches Figma; pinning min+max keeps the four rows visually uniform.
+        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), FromDIP(30)));
+        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), FromDIP(30)));
         auto* r = new wxBoxSizer(wxHORIZONTAL);
-        // Numbered color swatch (stored for later update). Guard with fill_count so a short
-        // palette can never read out of bounds (the fallback above always yields 4).
+        // Numbered color swatch (20×20, stored for later update). Guard with fill_count so a
+        // short palette can never read out of bounds (the fallback above always yields 4).
+        // wxLEFT=9 is the bordered container's left inset (Figma: px=9).
         if (i < fill_count) {
             wxBitmap* icon = get_extruder_color_icon(palette[i], std::to_string(i + 1), FromDIP(20), FromDIP(20));
             if (icon) {
                 auto* sw = new wxStaticBitmap(panel, wxID_ANY, *icon);
-                // §17: wxStaticBitmap does not inherit the panel bg. The icon is
-                // opaque so it covers the control, but set the bg explicitly to
-                // match the card and resist GTK theme override (consistency with
-                // the removed manual-card swatch, which set it too).
+                // §17: wxStaticBitmap does not inherit the panel bg. The icon is opaque so it
+                // covers the control, but set the bg explicitly to match the card and resist
+                // GTK theme override.
                 sw->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
                 m_recommended_swatches[i] = sw;
-                r->Add(sw, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+                r->Add(sw, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(9));
             }
         }
-        // Bordered name field (StaticBox wrapper, border #dbdbdb — same technique as
-        // MixedFilamentDialog's pattern-input wrapper). Name is the preset label (same on
-        // every row), NOT the per-color name — per product spec only the swatch varies.
-        auto* field = new StaticBox(panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
-        field->SetCornerRadius(FromDIP(4));
-        field->SetBorderWidth(FromDIP(1));
-        field->SetBorderColorNormal(StateColor::darkModeColorFor(wxColour("#DBDBDB")));
-        field->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
-        field->SetMinSize(wxSize(-1, FromDIP(24)));
-        auto* fs = new wxBoxSizer(wxHORIZONTAL);
-        auto* name = new wxStaticText(field, wxID_ANY, get_full_spectrum_preset_label());
-        name->SetFont(Label::Body_13);
+        // Name — the preset label (same on every row; only the swatch color varies, per product
+        // spec). 14px per Figma, with wxST_ELLIPSIZE_END so a long preset name ("Snapmaker PLA
+        // Full Spectrum @U1 0.4 nozzle") truncates instead of wrapping and breaking the row.
+        // The name sits directly in the bordered row (no separate bordered `field`); wxLEFT=8
+        // is the swatch→name gap (Figma: gap 8), wxRIGHT=8 the trailing inset (Figma 9 − 1px).
+        auto* name = new wxStaticText(panel, wxID_ANY, get_full_spectrum_preset_label(),
+                                       wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
+        name->SetFont(Label::Body_14);
         name->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         name->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
-        fs->Add(name, 1, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, FromDIP(9));
-        field->SetSizer(fs);
         m_recommended_labels[i] = name;
-        r->Add(field, 1, wxALIGN_CENTER_VERTICAL | wxEXPAND);
+        r->Add(name, 1, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, FromDIP(8));
         panel->SetSizer(r);
+        // Per-row hover tooltip: per-color NAME (localized) + COLOR hex + TD value (product spec).
+        // TD is resolved by the color's ENGLISH family name (cyan→C, magenta→M, ...), NOT by
+        // palette position — so it stays bound to the right color even when a match reorders the
+        // palette. The tooltip is set on the row panel AND its children (swatch, name): wx child
+        // windows do NOT inherit the parent tooltip, so without setting it on each child, hovering
+        // directly over the swatch/name shows nothing. update_recommended_card re-applies it after
+        // a match.
+        if (i < fill_count) {
+            const wxString ename = (i < static_cast<int>(items.size()))
+                ? english_color_name(items[i], i)
+                : wxString::Format("F%d", i + 1);
+            const wxString cname = (i < static_cast<int>(items.size()))
+                ? localized_color_name(items[i], i)
+                : ename;
+            const wxString tip = make_recommended_tooltip(cname, ename);
+            panel->SetToolTip(tip);
+            if (m_recommended_swatches[i]) m_recommended_swatches[i]->SetToolTip(tip);
+            name->SetToolTip(tip);
+        }
         grid->Add(panel, 0, wxEXPAND);
     }
     s->Add(grid, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
@@ -1416,7 +1614,26 @@ void MixedFilamentBatchDialog::build_footer()
     panel_sizer->Add(btn_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(20));
     panel_sizer->AddSpacer(FromDIP(12));
 
-    m_btn_cancel_match->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { EndModal(wxID_CANCEL); });
+    // Cancel shows a "Discard Match" confirmation before closing — but only when there's an
+    // actual match result to lose. The PRD (6.6) secondary check exists so the user doesn't
+    // discard a completed match by accident; "No" returns to the dialog with the current
+    // state (results, preview, legend) intact. When there's no result yet (idle / matching /
+    // failed), closing is lossless, so we skip the prompt and close directly. The gate mirrors
+    // the Confirm-button enable condition (set_match_buttons_state): a discardable result
+    // exists iff m_match_completed && m_result.success.
+    m_btn_cancel_match->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+        if (!m_match_completed || !m_result.success) {
+            EndModal(wxID_CANCEL);
+            return;
+        }
+        RichMessageDialog confirm(this,
+            _L("Are you sure you want to discard this match? The current configuration will not be saved."),
+            _L("Discard Match"),
+            wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
+        confirm.SetYesNoLabels(_L("Discard"), _L("Cancel"));
+        if (confirm.ShowModal() == wxID_YES)
+            EndModal(wxID_CANCEL);
+    });
     m_btn_confirm->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { EndModal(wxID_OK); });
 
     btn_panel->SetSizer(panel_sizer);
@@ -1515,7 +1732,15 @@ void MixedFilamentBatchDialog::set_match_buttons_state(bool matching)
 void MixedFilamentBatchDialog::on_method_changed(wxCommandEvent&)
 {
     int sel = m_method_combo->GetSelection();
-    m_matching_method = (sel == 1) ? MANUAL : RECOMMENDED;
+    MatchingMethod new_method = (sel == 1) ? MANUAL : RECOMMENDED;
+    // No-op if the user re-selected the already-active mode: wxComboBox fires COMBOBOX
+    // even for a re-pick of the current item (notably on wxMSW, clicking the open list's
+    // selected row). Re-running the refresh pipeline here would force needless card
+    // Show/Layout/tooltip updates and briefly hide the error/warning banners even though
+    // nothing actually changed.
+    if (new_method == m_matching_method)
+        return;
+    m_matching_method = new_method;
     // Preserve the previous match result; only Start/Re-match clears it.
     m_error_panel->Hide();
     m_warning_panel->Hide();

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -591,7 +591,7 @@ void MixedFilamentBatchDialog::render_match_thumb_for_plate(int plate_idx)
 
     auto* plater = wxGetApp().plater();
     if (!plater) return;
-    auto* canvas = plater->canvas3D();
+    auto* canvas = plater->get_view3D_canvas3D();
     if (!canvas) return;
 
     const int match_w = std::max(FromDIP(MATCH_PREVIEW_DIP), m_preview_match_panel->GetClientSize().GetWidth());
@@ -641,7 +641,7 @@ void MixedFilamentBatchDialog::render_original_thumb_for_plate(int plate_idx)
 
     auto* plater = wxGetApp().plater();
     if (!plater) return;
-    auto* canvas = plater->canvas3D();
+    auto* canvas = plater->get_view3D_canvas3D();
     if (!canvas) return;
 
     const int orig_w = std::max(FromDIP(ORIG_PREVIEW_DIP), m_preview_orig_panel->GetClientSize().GetWidth());
@@ -965,8 +965,10 @@ void MixedFilamentBatchDialog::build_ui()
 
     // No in-content title strip: the native OS title bar (set in the ctor via wxCAPTION)
     // already shows "Mixed Color Match". Adding a second header here would duplicate it.
-    build_banners();
     build_mode_row();
+    // Error/warning banners sit BELOW the mode row (between mode row and scrolled content)
+    // so toggling them doesn't shift the mode selector the user just interacted with.
+    build_banners();
 
     // Page-level scroller (mirrors MixedFilamentDialog): spans full dialog width so the
     // scrollbar sits at the right edge; mode row / progress / footer stay fixed.
@@ -1015,8 +1017,8 @@ void MixedFilamentBatchDialog::build_ui()
     update_nav_arrow_state();
 
     // Deferred from load_model_colors: if the model had >64 distinct colors, the extras were
-    // dropped there. m_warning_panel is now created (build_banners ran before build_ui), so
-    // the advisory can finally be shown.
+    // dropped there. m_warning_panel is now created (build_banners ran above in build_ui),
+    // so the advisory can finally be shown.
     if (m_pending_64_color_warning)
         display_warning(_L("Filament color limit reached (64 colors). Colors over the limit have been removed."));
 }
@@ -1035,7 +1037,7 @@ void MixedFilamentBatchDialog::build_banners()
     m_error_text->SetMaxSize(wxSize(FromDIP(480), -1));
     es->Add(m_error_text, 1, wxALL, FromDIP(8));
     m_error_panel->SetSizer(es);
-    m_root->Add(m_error_panel, 0, wxEXPAND);
+    m_root->Add(m_error_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(8));
 
     // Warning banner — mirrors MixedFilamentDialog's banner 1:1 (same bg, icon, margins,
     // tab-traversal flag) so the two dialogs read as the same family.
@@ -1052,7 +1054,10 @@ void MixedFilamentBatchDialog::build_banners()
     m_warning_text->SetMaxSize(wxSize(FromDIP(480), -1));
     ws->Add(m_warning_text, 1, wxALL, FromDIP(8));
     m_warning_panel->SetSizer(ws);
-    m_root->Add(m_warning_panel, 0, wxEXPAND);
+    // wxBOTTOM on each banner so a visible banner gets a gap to the scrolled content below.
+    // wxBoxSizer collapses both the window and its border when the window is hidden, so
+    // idle state (both banners hidden) adds no whitespace.
+    m_root->Add(m_warning_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(8));
 }
 
 void MixedFilamentBatchDialog::build_mode_row()
@@ -1132,8 +1137,9 @@ void MixedFilamentBatchDialog::build_mode_row()
     outer->AddSpacer(FromDIP(10));
     m_mode_row_panel->SetSizer(outer);
     // Full-width like the footer panel (no left/right margin) so the white strip spans the
-    // dialog content area edge-to-edge. No top margin — strip sits flush under the title bar.
-    m_root->Add(m_mode_row_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(10));
+    // dialog content area edge-to-edge. No top/bottom margin — strip sits flush under the
+    // title bar and directly above the error/warning banners (build_banners runs next).
+    m_root->Add(m_mode_row_panel, 0, wxEXPAND);
 }
 
 void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
@@ -1958,11 +1964,10 @@ void MixedFilamentBatchDialog::start_batch_match()
     m_match_running = true;
     m_error_panel->Hide();
     m_warning_panel->Hide();
-    // Clear stale legend from previous match before starting new one
-    m_result = BatchMatchResult{};
+    // Don't clear m_result — preserve it across failed/cancelled matches so the user can
+    // retry without losing context. Only the success branch in handle_batch_match_result
+    // overwrites m_result.
     m_match_completed = false;
-    update_mapping_legend();
-    m_legend_panel->Layout();
     reset_match_preview();
     set_match_buttons_state(true);
     launch_background_match();
@@ -2041,6 +2046,23 @@ void MixedFilamentBatchDialog::launch_background_match()
                 // colors form the palette; the per-component 70% cap is enforced later in
                 // the Pass-2 batch_match_model_colors call (match_max=kMaxComponentPercent).
                 auto best = recommend_best_filament_combo(model_colors, preset_colors, 15, 100, cancel_token);
+                // recommend_best_filament_combo returns {} for BOTH "no valid combo" and
+                // "cancelled" — distinguish here by re-checking the token. On cancel, skip
+                // the fallback palette + Pass-2 match (hundreds of ms of wasted work) and
+                // deliver a cancelled result directly so handle_batch_match_result shows no
+                // error banner and restores the prior result. Mirrors the cancel handling
+                // in batch_match_model_colors (error_code = 2).
+                if (cancel_token->load()) {
+                    BatchMatchResult cancelled;
+                    cancelled.success       = false;
+                    cancelled.error_code    = 2;
+                    cancelled.error_message = "Cancelled by user";
+                    wxGetApp().CallAfter([this, destroyed, result = std::move(cancelled)]() mutable {
+                        if (destroyed->load()) return;
+                        handle_batch_match_result(result);
+                    });
+                    return;  // exit worker lambda — skip Pass-2 match + merge
+                }
                 if (best.empty()) {
                     physical_colors.assign(preset_colors.begin(), preset_colors.begin() + std::min<size_t>(4, preset_colors.size()));
                 } else {
@@ -2205,15 +2227,27 @@ void MixedFilamentBatchDialog::launch_background_match()
             }
         }
 
+        // Merge mappings whose mixed-filament recipes are byte-identical so they share one
+        // virtual slot instead of each creating a duplicate row (e.g. two identical model
+        // colors, or two distinct colors whose recipes happen to match). MUST run after both
+        // ID-assignment phases (assign_batch_virtual_filament_ids + optional manual remap)
+        // so the survivor keeps the final target_filament_id; the manual-remap reassign loop
+        // above unconditionally rewrites target ids, so any earlier merge would be clobbered.
+        // Pure-recipe mappings are skipped by the merge (they target existing physicals and
+        // never allocate a new slot). source_extruder_ids are unioned so apply still covers
+        // every source extruder.
+        result.mappings = merge_duplicate_recipe_mappings(result.mappings);
+
         if (result.success && result.mappings.empty()) {
             result.success = false;
             result.error_message = "No valid recipes found for any model color";
             result.error_code = 1;
         }
         if (result.success) {
-            // Each model color always gets its own mapping entry — no deduplication.
-            // Merging by matched_color would lose distinct model-source colors whose
-            // recipes happen to produce similar output shades.
+            // avg ΔE over the (post-merge) mapping set. We do NOT merge by matched_color
+            // (that would collapse distinct source colors whose recipes produce similar
+            // output shades, losing per-source traceability); merge_duplicate_recipe_mappings
+            // above only collapses byte-identical recipes, which is lossless for ΔE.
             double sum_de = 0.0;
             for (const auto& m : result.mappings) sum_de += m.delta_e;
             result.avg_delta_e = sum_de / double(result.mappings.size());
@@ -2245,10 +2279,30 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
     m_progress_bar->Hide();
 
     if (!result.success) {
-        set_error(wxString::FromUTF8(result.error_message));
-        // Route through set_match_buttons_state so the Start vs Re-match enable mask
-        // follows m_match_completed (false here — Start is enabled, Re-match is not).
-        // Hard-coding both Enable(true) left Re-match clickable with no result to re-match.
+        // User cancellation is not an error — don't show the error banner.
+        const bool cancelled = (result.error_code == 2);
+        if (!cancelled) {
+            set_error(wxString::FromUTF8(result.error_message));
+        }
+        // Restore the prior result ONLY when the user-facing input is unchanged since
+        // that result was produced (same mode + same manual filament selections).
+        // Otherwise we'd surface a preview built for a different input — e.g. after
+        // toggling Recommended↔Manual or changing a combo selection. m_result itself
+        // is preserved across failed matches (start_batch_match no longer clears it),
+        // so this gate is what prevents a stale result from being shown.
+        const bool input_intact = (m_matching_method == m_last_result_method
+            && (m_matching_method != MANUAL
+                || (m_manual_filament_count == m_last_result_manual_count
+                    && std::equal(m_filament_selections,
+                                  m_filament_selections + m_manual_filament_count,
+                                  m_last_result_selections))));
+        if (m_result.success && input_intact) {
+            // rebuild_match_thumb_cache is needed because reset_match_preview already
+            // cleared the thumb buckets at the start of this match attempt.
+            m_match_completed = true;
+            rebuild_match_thumb_cache();
+            refresh_previews();
+        }
         set_match_buttons_state(false);
         Layout();
         return;
@@ -2256,6 +2310,12 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
 
     m_match_completed = false;
     m_result = result;
+    // Record the user-facing input that produced this result, so a later failed/cancelled
+    // re-match can tell whether the prior preview is still valid to restore.
+    m_last_result_method = m_matching_method;
+    m_last_result_manual_count = m_manual_filament_count;
+    for (int i = 0; i < m_manual_filament_count; ++i)
+        m_last_result_selections[i] = m_filament_selections[i];
     m_match_completed = true;
     update_mapping_legend();
     rebuild_match_thumb_cache();

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -593,7 +593,7 @@ void MixedFilamentBatchDialog::render_match_thumb_for_plate(int plate_idx)
 
     auto* plater = wxGetApp().plater();
     if (!plater) return;
-    auto* canvas = plater->canvas3D();
+    auto* canvas = plater->get_view3D_canvas3D();
     if (!canvas) return;
 
     const int match_w = std::max(FromDIP(MATCH_PREVIEW_DIP), m_preview_match_panel->GetClientSize().GetWidth());
@@ -643,7 +643,7 @@ void MixedFilamentBatchDialog::render_original_thumb_for_plate(int plate_idx)
 
     auto* plater = wxGetApp().plater();
     if (!plater) return;
-    auto* canvas = plater->canvas3D();
+    auto* canvas = plater->get_view3D_canvas3D();
     if (!canvas) return;
 
     const int orig_w = std::max(FromDIP(ORIG_PREVIEW_DIP), m_preview_orig_panel->GetClientSize().GetWidth());
@@ -1035,8 +1035,10 @@ void MixedFilamentBatchDialog::build_ui()
 
     // No in-content title strip: the native OS title bar (set in the ctor via wxCAPTION)
     // already shows "Mixed Color Match". Adding a second header here would duplicate it.
-    build_banners();
     build_mode_row();
+    // Error/warning banners sit BELOW the mode row (between mode row and scrolled content)
+    // so toggling them doesn't shift the mode selector the user just interacted with.
+    build_banners();
 
     // Page-level scroller (mirrors MixedFilamentDialog): spans full dialog width so the
     // scrollbar sits at the right edge; mode row / progress / footer stay fixed.
@@ -1085,8 +1087,8 @@ void MixedFilamentBatchDialog::build_ui()
     update_nav_arrow_state();
 
     // Deferred from load_model_colors: if the model had >64 distinct colors, the extras were
-    // dropped there. m_warning_panel is now created (build_banners ran before build_ui), so
-    // the advisory can finally be shown.
+    // dropped there. m_warning_panel is now created (build_banners ran above in build_ui),
+    // so the advisory can finally be shown.
     if (m_pending_64_color_warning)
         display_warning(_L("Filament color limit reached (64 colors). Colors over the limit have been removed."));
 }
@@ -1105,7 +1107,7 @@ void MixedFilamentBatchDialog::build_banners()
     m_error_text->SetMaxSize(wxSize(FromDIP(480), -1));
     es->Add(m_error_text, 1, wxALL, FromDIP(8));
     m_error_panel->SetSizer(es);
-    m_root->Add(m_error_panel, 0, wxEXPAND);
+    m_root->Add(m_error_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(8));
 
     // Warning banner — mirrors MixedFilamentDialog's banner 1:1 (same bg, icon, margins,
     // tab-traversal flag) so the two dialogs read as the same family.
@@ -1122,7 +1124,10 @@ void MixedFilamentBatchDialog::build_banners()
     m_warning_text->SetMaxSize(wxSize(FromDIP(480), -1));
     ws->Add(m_warning_text, 1, wxALL, FromDIP(8));
     m_warning_panel->SetSizer(ws);
-    m_root->Add(m_warning_panel, 0, wxEXPAND);
+    // wxBOTTOM on each banner so a visible banner gets a gap to the scrolled content below.
+    // wxBoxSizer collapses both the window and its border when the window is hidden, so
+    // idle state (both banners hidden) adds no whitespace.
+    m_root->Add(m_warning_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(8));
 }
 
 void MixedFilamentBatchDialog::build_mode_row()
@@ -1202,8 +1207,9 @@ void MixedFilamentBatchDialog::build_mode_row()
     outer->AddSpacer(FromDIP(10));
     m_mode_row_panel->SetSizer(outer);
     // Full-width like the footer panel (no left/right margin) so the white strip spans the
-    // dialog content area edge-to-edge. No top margin — strip sits flush under the title bar.
-    m_root->Add(m_mode_row_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(10));
+    // dialog content area edge-to-edge. No top/bottom margin — strip sits flush under the
+    // title bar and directly above the error/warning banners (build_banners runs next).
+    m_root->Add(m_mode_row_panel, 0, wxEXPAND);
 }
 
 void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
@@ -2028,11 +2034,10 @@ void MixedFilamentBatchDialog::start_batch_match()
     m_match_running = true;
     m_error_panel->Hide();
     m_warning_panel->Hide();
-    // Clear stale legend from previous match before starting new one
-    m_result = BatchMatchResult{};
+    // Don't clear m_result — preserve it across failed/cancelled matches so the user can
+    // retry without losing context. Only the success branch in handle_batch_match_result
+    // overwrites m_result.
     m_match_completed = false;
-    update_mapping_legend();
-    m_legend_panel->Layout();
     reset_match_preview();
     set_match_buttons_state(true);
     launch_background_match();
@@ -2111,6 +2116,23 @@ void MixedFilamentBatchDialog::launch_background_match()
                 // colors form the palette; the per-component 70% cap is enforced later in
                 // the Pass-2 batch_match_model_colors call (match_max=kMaxComponentPercent).
                 auto best = recommend_best_filament_combo(model_colors, preset_colors, 15, 100, cancel_token);
+                // recommend_best_filament_combo returns {} for BOTH "no valid combo" and
+                // "cancelled" — distinguish here by re-checking the token. On cancel, skip
+                // the fallback palette + Pass-2 match (hundreds of ms of wasted work) and
+                // deliver a cancelled result directly so handle_batch_match_result shows no
+                // error banner and restores the prior result. Mirrors the cancel handling
+                // in batch_match_model_colors (error_code = 2).
+                if (cancel_token->load()) {
+                    BatchMatchResult cancelled;
+                    cancelled.success       = false;
+                    cancelled.error_code    = 2;
+                    cancelled.error_message = "Cancelled by user";
+                    wxGetApp().CallAfter([this, destroyed, result = std::move(cancelled)]() mutable {
+                        if (destroyed->load()) return;
+                        handle_batch_match_result(result);
+                    });
+                    return;  // exit worker lambda — skip Pass-2 match + merge
+                }
                 if (best.empty()) {
                     physical_colors.assign(preset_colors.begin(), preset_colors.begin() + std::min<size_t>(4, preset_colors.size()));
                 } else {
@@ -2275,15 +2297,27 @@ void MixedFilamentBatchDialog::launch_background_match()
             }
         }
 
+        // Merge mappings whose mixed-filament recipes are byte-identical so they share one
+        // virtual slot instead of each creating a duplicate row (e.g. two identical model
+        // colors, or two distinct colors whose recipes happen to match). MUST run after both
+        // ID-assignment phases (assign_batch_virtual_filament_ids + optional manual remap)
+        // so the survivor keeps the final target_filament_id; the manual-remap reassign loop
+        // above unconditionally rewrites target ids, so any earlier merge would be clobbered.
+        // Pure-recipe mappings are skipped by the merge (they target existing physicals and
+        // never allocate a new slot). source_extruder_ids are unioned so apply still covers
+        // every source extruder.
+        result.mappings = merge_duplicate_recipe_mappings(result.mappings);
+
         if (result.success && result.mappings.empty()) {
             result.success = false;
             result.error_message = "No valid recipes found for any model color";
             result.error_code = 1;
         }
         if (result.success) {
-            // Each model color always gets its own mapping entry — no deduplication.
-            // Merging by matched_color would lose distinct model-source colors whose
-            // recipes happen to produce similar output shades.
+            // avg ΔE over the (post-merge) mapping set. We do NOT merge by matched_color
+            // (that would collapse distinct source colors whose recipes produce similar
+            // output shades, losing per-source traceability); merge_duplicate_recipe_mappings
+            // above only collapses byte-identical recipes, which is lossless for ΔE.
             double sum_de = 0.0;
             for (const auto& m : result.mappings) sum_de += m.delta_e;
             result.avg_delta_e = sum_de / double(result.mappings.size());
@@ -2315,10 +2349,30 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
     m_progress_bar->Hide();
 
     if (!result.success) {
-        set_error(wxString::FromUTF8(result.error_message));
-        // Route through set_match_buttons_state so the Start vs Re-match enable mask
-        // follows m_match_completed (false here — Start is enabled, Re-match is not).
-        // Hard-coding both Enable(true) left Re-match clickable with no result to re-match.
+        // User cancellation is not an error — don't show the error banner.
+        const bool cancelled = (result.error_code == 2);
+        if (!cancelled) {
+            set_error(wxString::FromUTF8(result.error_message));
+        }
+        // Restore the prior result ONLY when the user-facing input is unchanged since
+        // that result was produced (same mode + same manual filament selections).
+        // Otherwise we'd surface a preview built for a different input — e.g. after
+        // toggling Recommended↔Manual or changing a combo selection. m_result itself
+        // is preserved across failed matches (start_batch_match no longer clears it),
+        // so this gate is what prevents a stale result from being shown.
+        const bool input_intact = (m_matching_method == m_last_result_method
+            && (m_matching_method != MANUAL
+                || (m_manual_filament_count == m_last_result_manual_count
+                    && std::equal(m_filament_selections,
+                                  m_filament_selections + m_manual_filament_count,
+                                  m_last_result_selections))));
+        if (m_result.success && input_intact) {
+            // rebuild_match_thumb_cache is needed because reset_match_preview already
+            // cleared the thumb buckets at the start of this match attempt.
+            m_match_completed = true;
+            rebuild_match_thumb_cache();
+            refresh_previews();
+        }
         set_match_buttons_state(false);
         Layout();
         return;
@@ -2326,6 +2380,12 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
 
     m_match_completed = false;
     m_result = result;
+    // Record the user-facing input that produced this result, so a later failed/cancelled
+    // re-match can tell whether the prior preview is still valid to restore.
+    m_last_result_method = m_matching_method;
+    m_last_result_manual_count = m_manual_filament_count;
+    for (int i = 0; i < m_manual_filament_count; ++i)
+        m_last_result_selections[i] = m_filament_selections[i];
     m_match_completed = true;
     update_mapping_legend();
     rebuild_match_thumb_cache();

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -5,6 +5,7 @@
 #include "I18N.hpp"
 #include "PresetBundle.hpp"
 #include "libslic3r/Preset.hpp"
+#include "libslic3r/FilamentColorLibrary.hpp"
 #include "libslic3r/Model.hpp"
 #include "libslic3r/libslic3r.h"
 #include "Widgets/ComboBox.hpp"
@@ -17,6 +18,7 @@
 #include "BitmapCache.hpp"
 
 #include <unordered_map>
+#include <set>
 #include <algorithm>
 
 #include <wx/scrolwin.h>
@@ -25,10 +27,40 @@
 
 namespace Slic3r { namespace GUI {
 
+// Canonical Full Spectrum palette used as a fallback when load_full_spectrum_colors() fails
+// to read the live preset (library not loaded, preset missing, or <4 validated colors).
+// Mirrors filaments_colours.json's "Snapmaker PLA Full Spectrum @U1" single-color SKUs.
+// Single source of truth for the fallback path in both build_recommended_card and
+// launch_background_match — avoids the old duplicate CMYW_ENTRIES / CMYW_COLORS constants.
+static const std::vector<std::string> FULL_SPECTRUM_FALLBACK_COLORS = {
+    "#08ABFB", // semi-translucent cyan
+    "#D93B90", // semi-translucent magenta
+    "#F9ED3D", // semi-translucent yellow
+    "#9199A4", // semi-translucent gray
+};
+
 // Columns for the Color Mapping legend grid. Fixed (not growable) so each mapping
 // item keeps its natural width and the card height is computed correctly on macOS
 // (same rationale as MixedFilamentDialog's fixed-col swatch grid).
 static constexpr int LEGEND_GRID_COLS = 4;
+
+// Component-weight bounds for recipe generation (see launch_background_match).
+// Recommended mode caps a single component at 70% (product spec); manual mode is
+// unrestricted — an over-70% recipe surfaces as an advisory via check_manual_recipe_ratio
+// instead of being hard-rejected at match time.
+static constexpr int kMinComponentPercent = 0;   // recommended mode floor (near-pure allowed)
+static constexpr int kMaxComponentPercent = 70;  // recommended mode cap; also the advisory threshold
+
+// Product spec: a model is capped at 64 distinct filament colors. Colors past the cap are
+// dropped (see load_model_colors) and a deferred warning is shown once build_ui is up.
+static constexpr size_t kMaxColors = 64;
+
+// Card geometry (DIP). CARD_WIDTH_DIP leaves room for a vertical scrollbar inside the
+// 500-wide dialog: 500 − 2×12(margin) − 17(scrollbar) = 459. FILAMENT_COL_WIDTH_DIP pins
+// each 2×2 grid cell so slots 1/2 and 3/4 stay equal regardless of filament-name length
+// (wxFlexGridSizer otherwise sizes columns by content, so uneven names shift the columns).
+static constexpr int CARD_WIDTH_DIP        = 459;  // 500 − 2×12 − 17
+static constexpr int FILAMENT_COL_WIDTH_DIP = 207; // (459 − 2×16(padding) − 12(gap)) / 2 = 207.5 → floor
 
 // Preview panel design sizes (DIP), kept in sync with the RoundedPreviewPanel ctor args
 // in build_preview_card. Used as the std::max floor when reading GetClientSize() so an
@@ -260,6 +292,12 @@ MixedFilamentBatchDialog::MixedFilamentBatchDialog(wxWindow* parent)
         else
             m_tray_index = 1;
     }
+    // Pre-warm FilamentColorLibrary on the main thread. EnsureLoaded() is NOT thread-safe
+    // (_loaded is an unlocked bool, and it performs file I/O + JSON parse), so it MUST run
+    // before the worker thread in launch_background_match() starts. After warm-up, the
+    // worker's only call into the library is the read-only FindFilamentByName (a map lookup),
+    // which is safe to run concurrently with the main thread. See load_full_spectrum_colors().
+    FilamentColorLibrary::Instance().EnsureLoaded();
     load_model_colors();
     build_ui();
     set_match_buttons_state(false);
@@ -716,6 +754,77 @@ void MixedFilamentBatchDialog::load_model_colors()
             eids
         });
     }
+
+    // Product spec: cap at 64 distinct colors. This loop is the dedup source (each push is
+    // a unique validated color), so the cap applies to unique colors. Drop the tail beyond
+    // kMaxColors. The warning is deferred to build_ui because m_warning_panel is still null
+    // here — the ctor runs load_model_colors before build_banners/build_ui, so calling
+    // display_warning now would hit the early `if (!m_warning_panel) return` and be lost.
+    while (m_model_colors.size() > kMaxColors) {
+        m_model_colors.pop_back();
+        m_pending_64_color_warning = true;
+    }
+}
+
+// The Full Spectrum preset name shown in the name column of every recommended-card row.
+// Per product spec the name stays the preset label across all four slots; only the swatch
+// color varies. Falls back to the raw name when the preset bundle is unavailable.
+static wxString get_full_spectrum_preset_label()
+{
+    static const std::string kPresetName = "Snapmaker PLA Full Spectrum @U1 0.4 nozzle";
+    if (auto* pb = wxGetApp().preset_bundle) {
+        if (auto* p = pb->filaments.find_preset(kPresetName))
+            return wxString::FromUTF8(p->label(false));
+    }
+    return wxString::FromUTF8(kPresetName);
+}
+
+// Load the real recommended-mode palette colors from the Full Spectrum filament preset
+// (filaments_colours.json via FilamentColorLibrary). Returns the list of validated hex colors
+// (one per single-color SKU); empty on any failure so the caller falls back to the canonical
+// CMYW palette. NOTE: only the swatch COLORS come from here — the name column is the preset
+// label (see get_full_spectrum_preset_label), NOT the per-color name.
+//
+// Safety review closure (harness: input-validation, thread-safety):
+//   - (N) hex validation: every hex is re-checked via try_parse_color_match_hex; invalid
+//     values are skipped with a warning (defense-in-depth on top of FilamentColorLibrary's
+//     own NormalizeFilamentHexColor).
+//   - Thread safety: FilamentColorLibrary::EnsureLoaded() is NOT thread-safe (_loaded is an
+//     unlocked bool). The dialog ctor pre-warms it on the main thread; this function only
+//     does a read-only FindFilamentByName afterwards, so it is safe to call from the worker
+//     thread in launch_background_match. EnsureLoaded() here is a cheap no-op after warm-up.
+//   - (HIGH) distinct logging: each failure path emits its own BOOST_LOG_TRIVIAL(warning).
+static std::vector<std::string> load_full_spectrum_colors()
+{
+    const std::string kPresetName = "Snapmaker PLA Full Spectrum @U1 0.4 nozzle";
+    if (!FilamentColorLibrary::Instance().EnsureLoaded()) {
+        BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: FilamentColorLibrary not loaded, fallback to canonical palette";
+        return {};
+    }
+    FilamentColorInfo info;
+    if (!FilamentColorLibrary::Instance().FindFilamentByName(kPresetName, info)) {
+        BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: Full Spectrum preset not found in color library, fallback";
+        return {};
+    }
+
+    std::vector<std::string> result;
+    for (const FilamentColorItem& item : info.colors) {
+        // Only single-color SKUs qualify as palette candidates; skip dual-color / gradient
+        // entries (e.g. PLA Silk's Sunset Ember) so they don't pollute the palette.
+        if (item.colorData.colors.size() != 1)
+            continue;
+        const std::string& hex = item.colorData.colors[0];
+        // (N) Re-validate hex: FilamentColorLibrary normalises format, but double-check the
+        // color is wxColour-constructible before it flows into get_extruder_color_icon /
+        // recommend_best_filament_combo.
+        wxColour parsed;
+        if (!try_parse_color_match_hex(wxString::FromUTF8(hex.c_str()), parsed)) {
+            BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: invalid hex '" << hex << "' in Full Spectrum, skipped";
+            continue;
+        }
+        result.push_back(hex);
+    }
+    return result;
 }
 
 void MixedFilamentBatchDialog::update_recommended_card()
@@ -724,14 +833,9 @@ void MixedFilamentBatchDialog::update_recommended_card()
     const auto& colors = m_result.recommended_physical_colors;
     if (colors.size() < 4) return;
 
-    // Color name lookup — maps from hex in CMYW palette back to a
-    // human-readable label.  Covers the 4 canonical colors.
-    static const std::unordered_map<std::string, wxString> kColorName = {
-        {"#08ABFB", _L("Blue")},
-        {"#D93B90", _L("Magenta")},
-        {"#F9ED3D", _L("Yellow")},
-        {"#9199A4", _L("Gray")},
-    };
+    // NOTE: the name column shows the preset label (Snapmaker PLA Full Spectrum …) on every
+    // row, NOT the per-color name — per product spec only the swatch color varies per row.
+    // So no hex→name lookup is needed here; just the constant preset label.
 
     for (int i = 0; i < 4; ++i) {
         // Update swatch bitmap
@@ -743,13 +847,9 @@ void MixedFilamentBatchDialog::update_recommended_card()
                 m_recommended_swatches[i]->SetBitmap(*icon);
         }
 
-        // Update label text
+        // Update label text — the preset name (same on all four rows).
         if (m_recommended_labels[i]) {
-            auto it = kColorName.find(colors[i]);
-            m_recommended_labels[i]->SetLabel(
-                it != kColorName.end()
-                    ? it->second
-                    : wxString::Format("F%d", int(i + 1)));
+            m_recommended_labels[i]->SetLabel(get_full_spectrum_preset_label());
         }
     }
 
@@ -815,6 +915,12 @@ void MixedFilamentBatchDialog::build_ui()
     // update_nav_arrow_state is otherwise only called from combo/nav callbacks, so the
     // initial state was never set.
     update_nav_arrow_state();
+
+    // Deferred from load_model_colors: if the model had >64 distinct colors, the extras were
+    // dropped there. m_warning_panel is now created (build_banners ran before build_ui), so
+    // the advisory can finally be shown.
+    if (m_pending_64_color_warning)
+        display_warning(_L("Filament color limit reached (64 colors). Colors over the limit have been removed."));
 }
 
 void MixedFilamentBatchDialog::build_banners()
@@ -941,8 +1047,8 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
     card->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
     // All four cards share the same fixed width + centered alignment so their edges line up
     // with consistent margins — mirrors MixedFilamentDialog's fixed-width (325) cards.
-    card->SetMinSize(wxSize(FromDIP(460), -1));
-    card->SetMaxSize(wxSize(FromDIP(460), -1));
+    card->SetMinSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
+    card->SetMaxSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
     card->Hide();
     m_manual_card = card;
     auto* s = new wxBoxSizer(wxVERTICAL);
@@ -1007,6 +1113,12 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
         // wxPanel/StaticText don't inherit the card's bg — set white explicitly so the
         // row doesn't show the dialog's #F8F7F7 through (same as MixedFilamentDialog rows).
         panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        // Pin a fixed column width so the 2×2 slots stay equal regardless of how long the
+        // selected filament's name is. wxFlexGridSizer sizes columns by content (best size)
+        // first, then distributes leftover via AddGrowableCol(0/1, 1) — without a pinned
+        // base width, slots 1/2 and 3/4 drift apart when names differ in length.
+        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
+        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
         auto* r = new wxBoxSizer(wxHORIZONTAL);
 
         // §68: read-only selection would normally call for wxChoice, but this
@@ -1048,7 +1160,8 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
     s->Add(grid, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     card->SetSizer(s);
     // Horizontal margin only; the card-to-card vertical gap is added at the build_ui call site.
-    parent.Add(card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(20));
+    // 12px pairs with CARD_WIDTH_DIP (459 = 500 − 2×12 − 17 scrollbar) so cards stay centered.
+    parent.Add(card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(12));
 }
 
 void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
@@ -1059,15 +1172,16 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     card->SetBorderColorNormal(StateColor::darkModeColorFor(wxColour("#F0F0F0")));
     card->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
     // Same fixed width + centering as the manual card (see build_manual_card).
-    card->SetMinSize(wxSize(FromDIP(460), -1));
-    card->SetMaxSize(wxSize(FromDIP(460), -1));
+    card->SetMinSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
+    card->SetMaxSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
     card->Hide();
     m_recommended_card = card;
     auto* s = new wxBoxSizer(wxVERTICAL);
 
-    // Title
+    // Title — generic "Filament Setup" (no longer "(CMYW)"); colors are now driven by the
+    // Full Spectrum preset, so the title doesn't hardcode a color model.
     {
-        auto* lbl = new wxStaticText(card, wxID_ANY, _L("Filament Setup (CMYW)"));
+        auto* lbl = new wxStaticText(card, wxID_ANY, _L("Filament Setup"));
         lbl->SetFont(Label::Body_14);
         // §17/§81: explicit fg+bg so the label matches the card on wxMSW and
         // resists GTK theme override.
@@ -1080,15 +1194,22 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     // see §137).
     s->AddSpacer(FromDIP(10)); // title-to-grid gap per Figma spec
 
-    // 2x2 grid: numbered CMYW swatch (20x20) + bordered name field. Initially populated
-    // with the canonical CMYW order; update_recommended_card() refreshes swatches/names
-    // after a match reflects the palette order chosen by recommend_best_filament_combo.
-    static const std::vector<std::pair<std::string, wxString>> CMYW_ENTRIES = {
-        {"#08ABFB", _L("Blue")},
-        {"#D93B90", _L("Magenta")},
-        {"#F9ED3D", _L("Yellow")},
-        {"#9199A4", _L("Gray")},
-    };
+    // Load the real palette colors from the Full Spectrum preset (filaments_colours.json).
+    // Falls back to the canonical palette when the preset is missing or yields <4 validated
+    // single-color SKUs. Only the swatch COLORS come from here; the name column is the preset
+    // label (see get_full_spectrum_preset_label). See load_full_spectrum_colors() for the
+    // safety review (hex validation, thread safety, distinct logging).
+    std::vector<std::string> palette = load_full_spectrum_colors();
+    if (palette.size() < 4) {
+        palette.clear();
+        for (const std::string& c : FULL_SPECTRUM_FALLBACK_COLORS)
+            palette.push_back(c);
+    }
+    const int fill_count = std::min<int>(4, static_cast<int>(palette.size()));
+
+    // 2x2 grid: numbered swatch (20x20) + bordered name field. update_recommended_card()
+    // refreshes swatches after a match reflects the palette order chosen by
+    // recommend_best_filament_combo.
     auto* grid = new wxFlexGridSizer(2, FromDIP(12), FromDIP(12));
     grid->AddGrowableCol(0, 1);
     grid->AddGrowableCol(1, 1);
@@ -1096,21 +1217,29 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
         auto* panel = new wxPanel(card, wxID_ANY);
         // wxPanel doesn't inherit the card's bg — set white explicitly (see build_manual_card).
         panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        // Pin a fixed column width so the 2×2 slots stay equal — see build_manual_card for
+        // the wxFlexGridSizer rationale (keeps recommended + manual rows aligned on switch).
+        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
+        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
         auto* r = new wxBoxSizer(wxHORIZONTAL);
-        // Numbered color swatch (stored for later update)
-        wxBitmap* icon = get_extruder_color_icon(CMYW_ENTRIES[i].first, std::to_string(i + 1), FromDIP(20), FromDIP(20));
-        if (icon) {
-            auto* sw = new wxStaticBitmap(panel, wxID_ANY, *icon);
-            // §17: wxStaticBitmap does not inherit the panel bg. The icon is
-            // opaque so it covers the control, but set the bg explicitly to
-            // match the card and resist GTK theme override (consistency with
-            // the removed manual-card swatch, which set it too).
-            sw->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
-            m_recommended_swatches[i] = sw;
-            r->Add(sw, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+        // Numbered color swatch (stored for later update). Guard with fill_count so a short
+        // palette can never read out of bounds (the fallback above always yields 4).
+        if (i < fill_count) {
+            wxBitmap* icon = get_extruder_color_icon(palette[i], std::to_string(i + 1), FromDIP(20), FromDIP(20));
+            if (icon) {
+                auto* sw = new wxStaticBitmap(panel, wxID_ANY, *icon);
+                // §17: wxStaticBitmap does not inherit the panel bg. The icon is
+                // opaque so it covers the control, but set the bg explicitly to
+                // match the card and resist GTK theme override (consistency with
+                // the removed manual-card swatch, which set it too).
+                sw->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+                m_recommended_swatches[i] = sw;
+                r->Add(sw, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(8));
+            }
         }
         // Bordered name field (StaticBox wrapper, border #dbdbdb — same technique as
-        // MixedFilamentDialog's pattern-input wrapper)
+        // MixedFilamentDialog's pattern-input wrapper). Name is the preset label (same on
+        // every row), NOT the per-color name — per product spec only the swatch varies.
         auto* field = new StaticBox(panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
         field->SetCornerRadius(FromDIP(4));
         field->SetBorderWidth(FromDIP(1));
@@ -1118,7 +1247,7 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
         field->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
         field->SetMinSize(wxSize(-1, FromDIP(24)));
         auto* fs = new wxBoxSizer(wxHORIZONTAL);
-        auto* name = new wxStaticText(field, wxID_ANY, CMYW_ENTRIES[i].second);
+        auto* name = new wxStaticText(field, wxID_ANY, get_full_spectrum_preset_label());
         name->SetFont(Label::Body_13);
         name->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         name->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
@@ -1132,7 +1261,8 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     s->Add(grid, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     card->SetSizer(s);
     // Horizontal margin only; the card-to-card vertical gap is added at the build_ui call site.
-    parent.Add(card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(20));
+    // 12px pairs with CARD_WIDTH_DIP (459 = 500 − 2×12 − 17 scrollbar) so cards stay centered.
+    parent.Add(card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(12));
 }
 
 void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
@@ -1143,8 +1273,8 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
     m_preview_card->SetBorderColorNormal(StateColor::darkModeColorFor(wxColour("#F0F0F0")));
     m_preview_card->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
     // Same fixed width + centering as the filament-config cards.
-    m_preview_card->SetMinSize(wxSize(FromDIP(460), -1));
-    m_preview_card->SetMaxSize(wxSize(FromDIP(460), -1));
+    m_preview_card->SetMinSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
+    m_preview_card->SetMaxSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
     auto* s = new wxBoxSizer(wxVERTICAL);
 
     // Dual previews: Original (fixed 180x180) + After Match (fixed 227x227), both rounded.
@@ -1241,7 +1371,8 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
     }
 
     m_preview_card->SetSizer(s);
-    parent.Add(m_preview_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(20));
+    // 12px margin pairs with CARD_WIDTH_DIP (see build_manual_card).
+    parent.Add(m_preview_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(12));
 }
 
 void MixedFilamentBatchDialog::build_mapping_card(wxBoxSizer& parent)
@@ -1252,8 +1383,8 @@ void MixedFilamentBatchDialog::build_mapping_card(wxBoxSizer& parent)
     m_mapping_card->SetBorderColorNormal(StateColor::darkModeColorFor(wxColour("#F0F0F0")));
     m_mapping_card->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
     // Same fixed width + centering as the filament-config cards.
-    m_mapping_card->SetMinSize(wxSize(FromDIP(460), -1));
-    m_mapping_card->SetMaxSize(wxSize(FromDIP(460), -1));
+    m_mapping_card->SetMinSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
+    m_mapping_card->SetMaxSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
     auto* cs = new wxBoxSizer(wxVERTICAL);
 
     // Title row: label + info icon
@@ -1279,7 +1410,11 @@ void MixedFilamentBatchDialog::build_mapping_card(wxBoxSizer& parent)
     m_legend_panel->SetSizer(m_legend_sizer);
     cs->Add(m_legend_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     m_mapping_card->SetSizer(cs);
-    parent.Add(m_mapping_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(20));
+    // Horizontal margin 12 (pairs with CARD_WIDTH_DIP); bottom 20 stays as breathing room
+    // above the footer (kept distinct from the L/R margin so the card-to-footer gap is
+    // preserved when the L/R margin narrowed from 20→12).
+    parent.Add(m_mapping_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(12));
+    parent.AddSpacer(FromDIP(20));
 }
 
 void MixedFilamentBatchDialog::build_footer()
@@ -1487,8 +1622,8 @@ void MixedFilamentBatchDialog::update_method_combo_tooltip()
     // adding a permanent subtitle row to the UI.
     m_method_combo->SetToolTip(m_matching_method == MANUAL
         ? _L("Manually select filaments from the current list for color mixing.")
-        : _L("Automatically uses official CMYW filaments for color mixing. "
-             "The mix ratio for each color is limited to X%\u2013Y%."));
+        : _L("Automatically uses official Full Spectrum filaments for color mixing. "
+             "The mix ratio for each color is limited to 0%\u201370%."));
 }
 
 void MixedFilamentBatchDialog::on_manual_selection_changed()
@@ -1538,6 +1673,53 @@ void MixedFilamentBatchDialog::check_manual_filament_ratio()
     display_warning(wxString::Format(_L("Filament %d ratio is too high. Mix may be affected."), max_sel + 1));
 }
 
+void MixedFilamentBatchDialog::check_manual_recipe_ratio()
+{
+    // Post-match complement to check_manual_filament_ratio: that one warns BEFORE a match
+    // (based on how many rows picked the same physical slot). This one warns AFTER a match,
+    // scanning every non-pure recipe for any single component above kMaxComponentPercent and
+    // listing ALL offending filament IDs in one banner (gap doc case 13).
+    if (m_warning_panel) m_warning_panel->Hide();
+    if (m_matching_method != MANUAL) return;
+    if (!m_match_completed || m_result.mappings.empty()) return;
+
+    // NOTE: size by m_physical_colors.size(). In manual mode, launch_background_match's
+    // manual-remap branch rewrites recipe component ids to project-wide 1-based indices, so
+    // expand_color_match_recipe_weights must be sized against the FULL physical palette.
+    // A too-small count reads out-of-range indices as 0 weight and silently misses the
+    // over-threshold component.
+    const size_t num_physical = m_physical_colors.size();
+    if (num_physical == 0) return;
+
+    // Collect offending filament ids (1-based) in a set for de-dup + ascending order.
+    std::set<unsigned int> over_ids;
+    for (const ColorMappingEntry& e : m_result.mappings) {
+        if (e.is_pure_recipe) continue;        // pure = single component, ratio n/a
+        if (!e.recipe.valid) continue;         // nothing to check
+        const auto weights = expand_color_match_recipe_weights(e.recipe, num_physical);
+        for (size_t i = 0; i < weights.size() && i < num_physical; ++i) {
+            if (weights[i] > kMaxComponentPercent)
+                over_ids.insert(static_cast<unsigned int>(i + 1));
+        }
+    }
+    if (over_ids.empty()) return;
+
+    // Build "{x, y, z}" for the %s placeholder.
+    wxString id_list = "{";
+    bool first = true;
+    for (unsigned int id : over_ids) {
+        if (!first) id_list += ", ";
+        id_list << id;
+        first = false;
+    }
+    id_list << "}";
+
+    display_warning(wxString::Format(
+        _L("The mix ratios for %s in the Color Mapping list are outside the recommended %d"
+           "%%\u2013%d%% range. Adjust the mix ratios manually for better results."),
+        id_list, kMinComponentPercent, kMaxComponentPercent));
+}
+
 void MixedFilamentBatchDialog::set_manual_combo_icon(int row, int filament_idx)
 {
     // Compose a single transparent icon holding [drop_down arrow] + [numbered color badge]
@@ -1548,7 +1730,7 @@ void MixedFilamentBatchDialog::set_manual_combo_icon(int row, int filament_idx)
     if (row < 0 || row >= 4) return;
     ComboBox* cb = m_filament_combo[row];
     if (!cb) return;
-    if (filament_idx < 0 || filament_idx >= (int) m_physical_colors.size()) return;
+    if (filament_idx < 0 || filament_idx >= static_cast<int>(m_physical_colors.size())) return;
 
     const int pad = FromDIP(8), arr_w = FromDIP(8), badge_w = FromDIP(20), h = FromDIP(20), gap = FromDIP(8), text_gap = FromDIP(8);
     const int total_w = pad + arr_w + gap + badge_w + text_gap;
@@ -1664,14 +1846,21 @@ void MixedFilamentBatchDialog::launch_background_match()
     const auto all_physical      = m_physical_colors;
 
     const auto matching_method = m_matching_method;
-    // Fixed CMYW palette for recommended mode.
-    static const std::vector<std::string> CMYW_COLORS = {
-        "#08ABFB",  // blue
-        "#D93B90",  // magenta
-        "#F9ED3D",  // yellow
-        "#9199A4",  // gray
-    };
-    const std::vector<std::string> preset_colors = CMYW_COLORS;
+    // Physical palette for recommended mode. Loaded from the real Full Spectrum preset
+    // (filaments_colours.json) on the main thread here, then captured by value into the
+    // worker lambda below — so the worker never touches FilamentColorLibrary. Falls back to
+    // FULL_SPECTRUM_FALLBACK_COLORS when the preset is missing or yields <4 validated colors.
+    // See load_full_spectrum_colors() for hex validation + distinct logging.
+    std::vector<std::string> preset_colors;
+    {
+        std::vector<std::string> palette = load_full_spectrum_colors();
+        if (palette.size() >= 4) {
+            preset_colors = std::move(palette);
+        } else {
+            BOOST_LOG_TRIVIAL(warning) << "launch_background_match: preset colors <4, fallback to canonical palette";
+            preset_colors = FULL_SPECTRUM_FALLBACK_COLORS;
+        }
+    }
     // Use enabled_count() (skips deleted/disabled) to match the virtual ID
     // numbering scheme used by mixed_index_from_filament_id() and
     // add_batch_custom_filaments(), both of which count only enabled entries.
@@ -1693,7 +1882,10 @@ void MixedFilamentBatchDialog::launch_background_match()
             physical_colors = manual_colors;
         } else {
             if (preset_colors.size() >= 4) {
-                auto best = recommend_best_filament_combo(model_colors, preset_colors, 15, cancel_token);
+                // Combo search passes max=100 here: this stage only picks WHICH 4 preset
+                // colors form the palette; the per-component 70% cap is enforced later in
+                // the Pass-2 batch_match_model_colors call (match_max=kMaxComponentPercent).
+                auto best = recommend_best_filament_combo(model_colors, preset_colors, 15, 100, cancel_token);
                 if (best.empty()) {
                     physical_colors.assign(preset_colors.begin(), preset_colors.begin() + std::min<size_t>(4, preset_colors.size()));
                 } else {
@@ -1732,7 +1924,7 @@ void MixedFilamentBatchDialog::launch_background_match()
                 existing_ids.push_back(static_cast<unsigned int>(i + 1));
             }
         }
-        // Recommended mode: only use the recommended CMYW physical colors as the
+        // Recommended mode: only use the recommended Full Spectrum physical colors as the
         // Pass-1 reuse palette. Existing mixed filaments are NOT included because
         // (a) their display_colors reference the old physical palette that is about
         // to be replaced, and (b) a passthrough recipe targeting a virtual filament
@@ -1773,8 +1965,17 @@ void MixedFilamentBatchDialog::launch_background_match()
         // Pass 2: batch-match remaining colors.  batch_match_model_colors uses a
         // return-code model (result.success / error_code) and its whole call chain
         // has no throw sites, so no exception handling is needed here.
+        //
+        // Per-component weight bounds are mode-dependent:
+        //   - RECOMMENDED: [kMinComponentPercent(0), kMaxComponentPercent(70)] — product
+        //     spec forces no single component above 70%.
+        //   - MANUAL: [15, 100] — keep the 15% floor so a mix always has minimum
+        //     participation, but allow >70%; over-70% is surfaced as an advisory by
+        //     check_manual_recipe_ratio after the match, not hard-rejected here.
+        const int match_min = (matching_method == MANUAL) ? 15 : kMinComponentPercent;
+        const int match_max = (matching_method == MANUAL) ? 100 : kMaxComponentPercent;
         if (!unmatched_colors.empty()) {
-            auto sub_result = batch_match_model_colors(unmatched_colors, physical_colors, 15, cancel_token,
+            auto sub_result = batch_match_model_colors(unmatched_colors, physical_colors, match_min, match_max, cancel_token,
                 [progress_bar, destroyed](int done, int total) {
                     if (progress_bar && !destroyed->load()) {
                         wxGetApp().CallAfter([progress_bar, done, total, destroyed]() {
@@ -1906,6 +2107,10 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
     if (result.is_recommended_mode)
         update_recommended_card();
     refresh_previews();
+    // Post-match advisory: scan manual-mode recipes for any single component > 70%. Must run
+    // after refresh_previews (m_match_completed is already true here) and before the button
+    // state flip so the warning banner is in place when Confirm lights up.
+    check_manual_recipe_ratio();
     // Defer the button-state flip until AFTER refresh_previews() has rendered and
     // pushed the After-Match bitmap, so Confirm/Re-match light up in lockstep with
     // the preview — not a frame earlier. m_match_completed stays true throughout so

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -1107,7 +1107,7 @@ void MixedFilamentBatchDialog::build_banners()
     m_error_text->SetMaxSize(wxSize(FromDIP(480), -1));
     es->Add(m_error_text, 1, wxALL, FromDIP(8));
     m_error_panel->SetSizer(es);
-    m_root->Add(m_error_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(8));
+    m_root->Add(m_error_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(12));
 
     // Warning banner — mirrors MixedFilamentDialog's banner 1:1 (same bg, icon, margins,
     // tab-traversal flag) so the two dialogs read as the same family.
@@ -1127,7 +1127,7 @@ void MixedFilamentBatchDialog::build_banners()
     // wxBOTTOM on each banner so a visible banner gets a gap to the scrolled content below.
     // wxBoxSizer collapses both the window and its border when the window is hidden, so
     // idle state (both banners hidden) adds no whitespace.
-    m_root->Add(m_warning_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(8));
+    m_root->Add(m_warning_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(12));
 }
 
 void MixedFilamentBatchDialog::build_mode_row()
@@ -1207,9 +1207,11 @@ void MixedFilamentBatchDialog::build_mode_row()
     outer->AddSpacer(FromDIP(10));
     m_mode_row_panel->SetSizer(outer);
     // Full-width like the footer panel (no left/right margin) so the white strip spans the
-    // dialog content area edge-to-edge. No top/bottom margin — strip sits flush under the
-    // title bar and directly above the error/warning banners (build_banners runs next).
-    m_root->Add(m_mode_row_panel, 0, wxEXPAND);
+    // dialog content area edge-to-edge. No top margin — strip sits flush under the title bar.
+    // 12px bottom gap to the content below: with banners hidden (the common case) this is the
+    // mode-row → scrolled-content gap; with a banner visible it stacks as mode_row(12) → banner(8)
+    // → scrolled, keeping the mode selector visually separated from whatever appears under it.
+    m_root->Add(m_mode_row_panel, 0, wxEXPAND | wxBOTTOM, FromDIP(12));
 }
 
 void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
@@ -1614,11 +1616,10 @@ void MixedFilamentBatchDialog::build_mapping_card(wxBoxSizer& parent)
     m_legend_panel->SetSizer(m_legend_sizer);
     cs->Add(m_legend_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     m_mapping_card->SetSizer(cs);
-    // Horizontal margin 12 (pairs with CARD_WIDTH_DIP); bottom 20 stays as breathing room
-    // above the footer (kept distinct from the L/R margin so the card-to-footer gap is
-    // preserved when the L/R margin narrowed from 20→12).
+    // Horizontal margin 12 (pairs with CARD_WIDTH_DIP); bottom 12 — same gap as between cards
+    // above, so the last card sits at a uniform distance from the footer.
     parent.Add(m_mapping_card, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT, FromDIP(12));
-    parent.AddSpacer(FromDIP(20));
+    parent.AddSpacer(FromDIP(12));
 }
 
 void MixedFilamentBatchDialog::build_footer()
@@ -1707,8 +1708,18 @@ void MixedFilamentBatchDialog::build_footer()
             _L("Discard Match"),
             wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
         confirm.SetYesNoLabels(_L("Discard"), _L("Cancel"));
-        if (confirm.ShowModal() == wxID_YES)
+        auto result = confirm.ShowModal();
+        if (result == wxID_YES) {
             EndModal(wxID_CANCEL);
+        } else {
+            // The confirm dialog is a modal child: while it ran, Cancel never lost
+            // keyboard focus (mouseDown did SetFocus on click). After dismissal the
+            // focus stays on Cancel, which on Windows renders as a focus indicator
+            // that looks like a stuck "pressed" state. Hand focus to Confirm — it is
+            // enabled in this branch (m_match_completed && m_result.success) — so the
+            // dialog returns to a clean visual.
+            if (m_btn_confirm && m_btn_confirm->IsEnabled()) m_btn_confirm->SetFocus();
+        }
     });
     m_btn_confirm->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { EndModal(wxID_OK); });
 
@@ -2123,10 +2134,12 @@ void MixedFilamentBatchDialog::launch_background_match()
                 // error banner and restores the prior result. Mirrors the cancel handling
                 // in batch_match_model_colors (error_code = 2).
                 if (cancel_token->load()) {
+                    // User cancellation (Stop Matching) — not an error. error_message is
+                    // intentionally empty: handle_batch_match_result treats error_code==2 as a
+                    // silent rollback and never displays it.
                     BatchMatchResult cancelled;
-                    cancelled.success       = false;
-                    cancelled.error_code    = 2;
-                    cancelled.error_message = "Cancelled by user";
+                    cancelled.success    = false;
+                    cancelled.error_code = 2;
                     wxGetApp().CallAfter([this, destroyed, result = std::move(cancelled)]() mutable {
                         if (destroyed->load()) return;
                         handle_batch_match_result(result);
@@ -2213,12 +2226,15 @@ void MixedFilamentBatchDialog::launch_background_match()
         // return-code model (result.success / error_code) and its whole call chain
         // has no throw sites, so no exception handling is needed here.
         //
-        // Per-component weight bounds are mode-dependent:
-        //   - RECOMMENDED: [kMinComponentPercent(0), kMaxComponentPercent(70)] — product
-        //     spec forces no single component above 70%.
-        //   - MANUAL: [15, 100] — keep the 15% floor so a mix always has minimum
-        //     participation, but allow >70%; over-70% is surfaced as an advisory by
-        //     check_manual_recipe_ratio after the match, not hard-rejected here.
+        // Per-component weight bounds AND the compatibility filter are mode-dependent:
+        //   - RECOMMENDED: [kMinComponentPercent(0), kMaxComponentPercent(70)] +
+        //     check_compatible=true (product spec: same-type only).
+        //   - MANUAL: [15, 100] + check_compatible=false — keep the 15% floor so a mix
+        //     always has minimum participation, allow >70% (surfaces as advisory via
+        //     check_manual_recipe_ratio after the match), AND allow cross-type recipes
+        //     (PLA+PETG etc.). The slice gate (Plater::has_incompatible_mixed_filament_in_use)
+        //     still blocks incompatible mixes at slice time — this only lets them be
+        //     created and stored.
         const int match_min = (matching_method == MANUAL) ? 15 : kMinComponentPercent;
         const int match_max = (matching_method == MANUAL) ? 100 : kMaxComponentPercent;
         if (!unmatched_colors.empty()) {
@@ -2230,7 +2246,8 @@ void MixedFilamentBatchDialog::launch_background_match()
                             if (total > 0) progress_bar->SetValue(done * 100 / total);
                         });
                     }
-                });
+                },
+                /*check_compatible=*/ matching_method != MANUAL);
             if (sub_result.success) {
                 // Offset virtual IDs: start after all existing filaments
                 assign_batch_virtual_filament_ids(sub_result, physical_colors.size(), existing_mixed_count);

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
@@ -95,6 +95,15 @@ private:
 
     MatchingMethod                     m_matching_method = RECOMMENDED;
     BatchMatchResult                   m_result;
+    // Snapshot of the user-facing input that produced m_result. On a failed/cancelled
+    // re-match we restore the prior preview ONLY when this still matches the current
+    // input — otherwise we'd show a preview built for a different mode or filament
+    // selection (e.g. after toggling Recommended↔Manual, or changing a combo selection).
+    // m_model_colors and m_physical_colors are immutable for the dialog's lifetime
+    // (set in the ctor), so they are NOT part of the snapshot.
+    MatchingMethod m_last_result_method      = RECOMMENDED;
+    int            m_last_result_selections[4] = {0, 1, 2, 3};
+    int            m_last_result_manual_count  = 0;
     bool                               m_match_completed = false;
     bool                               m_match_running   = false; // UI-thread-only; do not access from worker
     std::shared_ptr<std::atomic<bool>> m_destroyed{std::make_shared<std::atomic<bool>>(false)};

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "GUI_Utils.hpp"
-#include "ThumbnailView.hpp"    // ThumbnailView enum (lightweight; avoids pulling in GLCanvas3D.hpp)
+#include "ThumbnailView.hpp" // ThumbnailView enum (lightweight; avoids pulling in GLCanvas3D.hpp)
 #include "MixedColorMatchHelpers.hpp"
 #include "libslic3r/MixedFilament.hpp"
 
@@ -31,20 +31,20 @@ public:
     ~MixedFilamentBatchDialog() override;
 
     const BatchMatchResult& GetResult() const { return m_result; }
-    void on_dpi_changed(const wxRect& suggested_rect) override;
+    void                    on_dpi_changed(const wxRect& suggested_rect) override;
 
 private:
     // ---- UI construction (build_ui is a thin orchestrator; each helper stays <150 lines) ----
     void build_ui();
     // No build_header(): the native OS title bar (wxCAPTION in ctor) shows "Mixed Color Match".
-    void build_banners();           // error + warning panels
-    void build_mode_row();          // Match Mode combo + segmented Start/Re-match tabs
-    void build_manual_card(wxBoxSizer& parent);       // filament config (manual mode): ComboBox rows + add/remove
-    void build_recommended_card(wxBoxSizer& parent);  // filament config (auto mode): numbered swatches + names
-    void build_preview_card(wxBoxSizer& parent);      // single card: dual previews + badges + plate/view controls
-    void build_mapping_card(wxBoxSizer& parent);      // color mapping card shell (title + info icon + grid host)
+    void build_banners();                            // error + warning panels
+    void build_mode_row();                           // Match Mode combo + segmented Start/Re-match tabs
+    void build_manual_card(wxBoxSizer& parent);      // filament config (manual mode): ComboBox rows + add/remove
+    void build_recommended_card(wxBoxSizer& parent); // filament config (auto mode): numbered swatches + names
+    void build_preview_card(wxBoxSizer& parent);     // single card: dual previews + badges + plate/view controls
+    void build_mapping_card(wxBoxSizer& parent);     // color mapping card shell (title + info icon + grid host)
     // No build_progress(): the progress bar lives inside the footer panel (see build_footer).
-    void build_footer();            // Cancel + Confirm + progress bar (pinned to bottom)
+    void build_footer(); // Cancel + Confirm + progress bar (pinned to bottom)
 
     void on_method_changed(wxCommandEvent&);
     void update_method_combo_tooltip(); // refresh combo tooltip to describe the active mode
@@ -57,17 +57,17 @@ private:
     void set_manual_combo_icon(int row, int filament_idx);
 
     // Preview lifecycle
-    void build_preview_panels();           // create wxStaticBitmaps once + render initial thumbnails
-    void refresh_previews();               // swap cached bitmaps for current tray; lazy-renders match thumb
-    void rebuild_match_thumb_cache();      // build m_match_colors from config + mappings, render current plate
+    void build_preview_panels();                         // create wxStaticBitmaps once + render initial thumbnails
+    void refresh_previews();                             // swap cached bitmaps for current tray; lazy-renders match thumb
+    void rebuild_match_thumb_cache();                    // build m_match_colors from config + mappings, render current plate
     void render_match_thumb_for_plate(int plate_idx);    // render one plate's match thumbnail on demand
     void render_original_thumb_for_plate(int plate_idx); // render original (no color swap) at m_view
 
     // View + plate nav
     void on_view_changed(wxCommandEvent&);
-    void on_tray_nav(int delta);           // -1 prev, +1 next
-    void update_view();                    // re-render both previews for the current plate at m_view
-    void update_nav_arrow_state();         // disable prev at first plate, next at last
+    void on_tray_nav(int delta);   // -1 prev, +1 next
+    void update_view();            // re-render both previews for the current plate at m_view
+    void update_nav_arrow_state(); // disable prev at first plate, next at last
 
     void start_batch_match();
     void cancel_batch_match();
@@ -78,9 +78,13 @@ private:
 
     void display_warning(const wxString& msg);
     void set_error(const wxString& msg);
-    // Manual-mode ratio guard: if a single physical filament is picked by more than
+    // Manual-mode pre-match ratio guard: if a single physical filament is picked by more than
     // kManualDominantRatioPct of the rows, warn that the mix is lopsided.
     void check_manual_filament_ratio();
+    // Manual-mode post-match ratio guard: after a match completes, scan every non-pure
+    // recipe for any component > kMaxComponentPercent and list ALL such over-threshold
+    // colors in the warning banner (gap doc case 13).
+    void check_manual_recipe_ratio();
 
     void set_match_buttons_state(bool matching);
     void update_recommended_card();
@@ -89,42 +93,43 @@ private:
 
     enum MatchingMethod { RECOMMENDED = 0, MANUAL = 1 };
 
-    MatchingMethod m_matching_method = RECOMMENDED;
-    BatchMatchResult m_result;
-    bool             m_match_completed = false;
-    bool             m_match_running   = false;
-    std::shared_ptr<std::atomic<bool>> m_destroyed        { std::make_shared<std::atomic<bool>>(false) };
-    std::shared_ptr<std::atomic<bool>> m_cancel_requested { std::make_shared<std::atomic<bool>>(false) };
-    std::thread      m_worker_thread;
+    MatchingMethod                     m_matching_method = RECOMMENDED;
+    BatchMatchResult                   m_result;
+    bool                               m_match_completed = false;
+    bool                               m_match_running   = false; // UI-thread-only; do not access from worker
+    std::shared_ptr<std::atomic<bool>> m_destroyed{std::make_shared<std::atomic<bool>>(false)};
+    std::shared_ptr<std::atomic<bool>> m_cancel_requested{std::make_shared<std::atomic<bool>>(false)};
+    std::thread                        m_worker_thread;
 
     std::vector<ModelColorEntry> m_model_colors;
     std::vector<std::string>     m_physical_colors;
+    bool                         m_pending_64_color_warning = false; // deferred from load_model_colors until after build_ui
 
-    int   m_filament_selections[4] = {0, 1, 2, 3};
+    int m_filament_selections[4] = {0, 1, 2, 3};
 
-    int  m_tray_index = 1;
-    int  m_tray_count = 1;
-    ThumbnailView m_view = ThumbnailView::Iso;   // current preview viewpoint (drives render_thumbnail new overload)
+    int           m_tray_index = 1;
+    int           m_tray_count = 1;
+    ThumbnailView m_view       = ThumbnailView::Iso; // current preview viewpoint (drives render_thumbnail new overload)
 
     // Root layout
-    wxBoxSizer*   m_root         = nullptr;
+    wxBoxSizer* m_root = nullptr;
 
     // Top row
-    wxPanel*  m_mode_row_panel  = nullptr; // white-bg host for the mode/match-mode row
-    ComboBox* m_method_combo    = nullptr;
-    Button*   m_btn_start_match = nullptr;
-    Button*   m_btn_cancel_match = nullptr;
-    Button*   m_btn_rematch     = nullptr;
-    Button*   m_btn_confirm     = nullptr;
-    Button*   m_btn_stop_match  = nullptr; // "Stop Matching" — inline beside the progress bar, shown only while matching
+    wxPanel* m_mode_row_panel = nullptr; // white-bg host for the mode/match-mode row
+    ComboBox* m_method_combo = nullptr;  // Match Mode combo: Auto (recommended) / Manual
+    Button* m_btn_start_match  = nullptr;
+    Button* m_btn_cancel_match = nullptr;
+    Button* m_btn_rematch      = nullptr;
+    Button* m_btn_confirm      = nullptr;
+    Button* m_btn_stop_match   = nullptr; // "Stop Matching" — inline beside the progress bar, shown only while matching
 
     // Preview card (single card holds both previews + plate/view controls).
     // m_preview_orig_panel / m_preview_match_panel are RoundedPreviewPanel instances but
     // held as wxPanel* (the rounded thumbnail + badge are painted in-handler, no children).
-    StaticBox*      m_preview_card        = nullptr;
-    wxPanel*        m_preview_orig_panel  = nullptr;
-    wxPanel*        m_preview_match_panel = nullptr;
-    ComboBox*       m_view_combo  = nullptr;   // Isometric / Top
+    StaticBox* m_preview_card        = nullptr;
+    wxPanel*   m_preview_orig_panel  = nullptr;
+    wxPanel*   m_preview_match_panel = nullptr;
+    ComboBox*  m_view_combo          = nullptr; // Isometric / Top
 
     // Thumbnail cache: one wxBitmap per plate, bucketed by viewpoint.
     // Lazily rendered — a (viewpoint, plate) bitmap is produced on first access and kept.
@@ -141,9 +146,10 @@ private:
     // 0.7 = 70%. Kept as a named constant (not a literal) so the threshold is grep-able
     // and adjustable in one place.
     static constexpr double kManualDominantRatioPct = 0.7;
+    // Model colors whose ΔE to the closest physical is below this threshold
     std::array<std::vector<wxBitmap>, kNumThumbnailViews> m_thumb_cache_by_view;
     std::array<std::vector<wxBitmap>, kNumThumbnailViews> m_match_cache_by_view;
-    std::vector<ColorRGBA> m_match_colors;
+    std::vector<ColorRGBA>                                m_match_colors;
 
     // combo index -> ThumbnailView mapping. Decouples the View combobox's Append order
     // from the enum values so reordering/localizing the combo cannot silently misroute
@@ -175,11 +181,13 @@ private:
     // Accessors return the cache for the current viewpoint, with bounds protection
     // (adversarial review item 4). m_view is always assigned via kComboToView, so the
     // assert is a defensive check against future regressions.
-    std::vector<wxBitmap>& orig_cache() {
+    std::vector<wxBitmap>& orig_cache()
+    {
         assert(static_cast<size_t>(m_view) < m_thumb_cache_by_view.size());
         return m_thumb_cache_by_view[static_cast<size_t>(m_view)];
     }
-    std::vector<wxBitmap>& match_cache() {
+    std::vector<wxBitmap>& match_cache()
+    {
         assert(static_cast<size_t>(m_view) < m_match_cache_by_view.size());
         return m_match_cache_by_view[static_cast<size_t>(m_view)];
     }
@@ -190,8 +198,8 @@ private:
     ComboBox*       m_tray_combo    = nullptr;
 
     // Filament config cards (manual + recommended; only one visible per mode, both styled alike)
-    wxWindow*       m_manual_card            = nullptr;
-    wxWindow*       m_recommended_card       = nullptr;
+    wxWindow*       m_manual_card             = nullptr;
+    wxWindow*       m_recommended_card        = nullptr;
     wxStaticBitmap* m_recommended_swatches[4] = {nullptr};
     wxStaticText*   m_recommended_labels[4]   = {nullptr};
     ComboBox*       m_filament_combo[4]       = {nullptr};
@@ -202,10 +210,10 @@ private:
     ScalableButton* m_btn_add_filament    = nullptr;
 
     // Legend / mapping
-    StaticBox*      m_mapping_card      = nullptr;   // grows in height with content (no inner scroller)
-    wxPanel*        m_legend_panel      = nullptr;   // plain panel holding the legend grid
-    wxGridSizer*    m_legend_sizer      = nullptr;    // fixed-col grid (Mac-safe; wxWrapSizer miscomputes height on macOS)
-    ScalableButton* m_mapping_info_icon = nullptr;    // info tooltip next to "Color Mapping" title
+    StaticBox*      m_mapping_card      = nullptr; // grows in height with content (no inner scroller)
+    wxPanel*        m_legend_panel      = nullptr; // plain panel holding the legend grid
+    wxGridSizer*    m_legend_sizer      = nullptr; // fixed-col grid (Mac-safe; wxWrapSizer miscomputes height on macOS)
+    ScalableButton* m_mapping_info_icon = nullptr; // info tooltip next to "Color Mapping" title
 
     // Error / warning
     wxPanel* m_error_panel   = nullptr;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2367,7 +2367,7 @@ Sidebar::Sidebar(Plater *parent)
         std::unordered_map<unsigned int, uint64_t> dialog_vid_to_sid;
         const size_t dialog_num_physical = wxGetApp().preset_bundle->filament_presets.size();
         {
-            unsigned int vid = (unsigned int)dialog_num_physical + 1;
+            unsigned int vid = static_cast<unsigned int>(dialog_num_physical) + 1;
             for (const MixedFilament& mf : mgr.mixed_filaments()) {
                 if (!mf.enabled || mf.deleted) continue;
                 dialog_vid_to_sid[vid++] = mf.stable_id;
@@ -2409,7 +2409,7 @@ Sidebar::Sidebar(Plater *parent)
             // covers the existing painted virtual IDs (review item R3).
             const std::vector<MixedFilament> old_mixed_snapshot = pb->mixed_filaments.mixed_filaments();
 
-            pb->set_num_filaments((unsigned int)target_count, std::vector<std::string>{});
+            pb->set_num_filaments(static_cast<unsigned int>(target_count), std::vector<std::string>{});
 
             // Restore custom entries that were wiped by clear_custom_entries
             // in update_multi_material_filament_presets.  add_batch_custom_
@@ -2431,7 +2431,12 @@ Sidebar::Sidebar(Plater *parent)
                     old_mixed_snapshot, current_count, target_count);
             }
 
-            wxGetApp().plater()->on_filaments_change((int)target_count);
+            // Assign the Full Spectrum filament preset to slots 1-4 so the
+            // combobox displays the preset name instead of F1-F4 fallback.
+            for (size_t i = 0; i < std::min<size_t>(4, target_count); ++i)
+                pb->set_filament_preset(i, kFullSpectrumPresetName);
+
+            wxGetApp().plater()->on_filaments_change(static_cast<int>(target_count));
         } else {
             ConfigOptionStrings* co = wxGetApp().preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour");
             colors_vec = co ? co->values : std::vector<std::string>{};
@@ -2476,7 +2481,7 @@ Sidebar::Sidebar(Plater *parent)
                 // Locate that row in the CURRENT mixed list; record its vid.
                 MixedFilament* target     = nullptr;
                 unsigned int   target_vid = 0;
-                unsigned int   vid        = (unsigned int)cur_num_physical + 1;
+                unsigned int   vid        = static_cast<unsigned int>(cur_num_physical) + 1;
                 for (MixedFilament& mf : mgr.mixed_filaments()) {
                     if (!mf.enabled || mf.deleted) continue;
                     if (mf.stable_id == sid) { target = &mf; target_vid = vid; break; }
@@ -2518,12 +2523,12 @@ Sidebar::Sidebar(Plater *parent)
         // Translate mixed-slot source ids from the dialog epoch to the CURRENT
         // epoch.
         {
-            const unsigned int cur_num_physical = (unsigned int)colors_vec.size();
+            const unsigned int cur_num_physical = static_cast<unsigned int>(colors_vec.size());
             for (auto& mapping : model_result.mappings) {
                 std::vector<unsigned int> translated;
                 translated.reserve(mapping.source_extruder_ids.size());
                 for (unsigned int src : mapping.source_extruder_ids) {
-                    if (src <= (unsigned int)dialog_num_physical) {
+                    if (src <= static_cast<unsigned int>(dialog_num_physical)) {
                         translated.push_back(src); // physical slot: identity
                         continue;
                     }
@@ -8335,43 +8340,67 @@ void Sidebar::cleanup_unused_filaments_after_batch_match(const BatchMatchResult 
         // filament=false) bakes into the composite remap (tail-truncation).
         // If this ever flips to ascending, painting is silently remapped to
         // wrong colours. Source: compute_redundant_filaments @ MixedFilament.cpp.
-        for (size_t i = 1; i < red.redundant_physical.size(); ++i)
-            assert(red.redundant_physical[i] < red.redundant_physical[i - 1]);
-
-        // RAII: bump the single batch-deletion flag for the duration of the
-        // loop so on_filaments_delete (Sidebar + Plater) skip per-deletion panel
-        // rebuild and painting remap. Exception- and reentrancy-safe.
-        Plater *plater = wxGetApp().plater();
-        Plater::BatchPhysicalDeletionGuard guard(*plater);
-        for (unsigned int redundant_id : red.redundant_physical)
-            delete_filament(redundant_id - 1, -1,
-                            /*skip_dependency_check=*/true,
-                            /*skip_update=*/true);
-
-        // ONE composite painting remap: build old→new from the snapshot, apply
-        // to every volume.  Equivalent to K sequential single-deletion remaps
-        // (remap is a pure pointwise state_map lookup, composable).
-        pb->update_mixed_filament_id_remap(old_mixed_snapshot, old_num_physical, new_num_physical);
-        const std::vector<unsigned int> composite_remap = pb->consume_last_filament_id_remap();
-        if (!composite_remap.empty()) {
-            EnforcerBlockerStateMap state_map;
-            for (size_t i = 0; i < state_map.size(); ++i)
-                state_map[i] = EnforcerBlockerType(i);
-            const size_t total_filaments = new_num_physical + pb->mixed_filaments.enabled_count();
-            for (size_t i = 1; i < composite_remap.size() && i < state_map.size(); ++i) {
-                const unsigned int mapped = composite_remap[i];
-                if (mapped == 0 || mapped >= state_map.size() || mapped > total_filaments)
-                    state_map[i] = EnforcerBlockerType::NONE;
-                else
-                    state_map[i] = EnforcerBlockerType(mapped);
+        // The check is enforced at RUNTIME (not just assert) because the failure
+        // mode is silent wrong-colour mapping and assert() is compiled out under
+        // NDEBUG (Release builds). On violation we fall back to per-deletion
+        // updates (skip_update=false) so each deletion's own remap keeps colours
+        // correct, instead of the batched composite path that depends on the order.
+        bool descending_ok = true;
+        for (size_t i = 1; i < red.redundant_physical.size(); ++i) {
+            if (red.redundant_physical[i] >= red.redundant_physical[i - 1]) {
+                BOOST_LOG_TRIVIAL(error)
+                    << "redundant_physical descending invariant violated at index " << i
+                    << " (" << red.redundant_physical[i] << " >= " << red.redundant_physical[i - 1]
+                    << "); falling back to per-deletion update to avoid silent wrong-colour mapping";
+                descending_ok = false;
+                break;
             }
-            for (ModelObject* mo : wxGetApp().model().objects)
-                for (ModelVolume* mv : mo->volumes)
-                    if (mv->type() == ModelVolumeType::MODEL_PART)
-                        // Pass total_filaments (physical + mixed), NOT new_num_physical —
-                        // remap_enforcer_block_types clips any state > max_type to NONE,
-                        // and remapped mixed virtual ids (N+1..total) must survive.
-                        mv->remap_extruder_ids(total_filaments, state_map);
+        }
+        assert(descending_ok);
+
+        if (descending_ok) {
+            // RAII: bump the single batch-deletion flag for the duration of the
+            // loop so on_filaments_delete (Sidebar + Plater) skip per-deletion panel
+            // rebuild and painting remap. Exception- and reentrancy-safe.
+            Plater *plater = wxGetApp().plater();
+            Plater::BatchPhysicalDeletionGuard guard(*plater);
+            for (unsigned int redundant_id : red.redundant_physical)
+                delete_filament(redundant_id - 1, -1,
+                                /*skip_dependency_check=*/true,
+                                /*skip_update=*/true);
+
+            // ONE composite painting remap: build old→new from the snapshot, apply
+            // to every volume.  Equivalent to K sequential single-deletion remaps
+            // (remap is a pure pointwise state_map lookup, composable).
+            pb->update_mixed_filament_id_remap(old_mixed_snapshot, old_num_physical, new_num_physical);
+            const std::vector<unsigned int> composite_remap = pb->consume_last_filament_id_remap();
+            if (!composite_remap.empty()) {
+                EnforcerBlockerStateMap state_map;
+                for (size_t i = 0; i < state_map.size(); ++i)
+                    state_map[i] = EnforcerBlockerType(i);
+                const size_t total_filaments = new_num_physical + pb->mixed_filaments.enabled_count();
+                for (size_t i = 1; i < composite_remap.size() && i < state_map.size(); ++i) {
+                    const unsigned int mapped = composite_remap[i];
+                    if (mapped == 0 || mapped >= state_map.size() || mapped > total_filaments)
+                        state_map[i] = EnforcerBlockerType::NONE;
+                    else
+                        state_map[i] = EnforcerBlockerType(mapped);
+                }
+                for (ModelObject* mo : wxGetApp().model().objects)
+                    for (ModelVolume* mv : mo->volumes)
+                        if (mv->type() == ModelVolumeType::MODEL_PART)
+                            // Pass total_filaments (physical + mixed), NOT new_num_physical —
+                            // remap_enforcer_block_types clips any state > max_type to NONE,
+                            // and remapped mixed virtual ids (N+1..total) must survive.
+                            mv->remap_extruder_ids(total_filaments, state_map);
+            }
+        } else {
+            // Safe fallback: delete one by one with full per-deletion update so each
+            // deletion's own painting remap runs. Slower but colour-correct.
+            for (unsigned int redundant_id : red.redundant_physical)
+                delete_filament(redundant_id - 1, -1,
+                                /*skip_dependency_check=*/true,
+                                /*skip_update=*/false);
         }
     }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2404,7 +2404,33 @@ Sidebar::Sidebar(Plater *parent)
             // Write before set_num_filaments so auto_generate sees CMYG palette.
             if (fc) fc->values = colors_vec;
 
+            // Snapshot the old mixed list BEFORE set_num_filaments clears
+            // custom entries, so we can build a proper old→new remap that
+            // covers the existing painted virtual IDs (review item R3).
+            const std::vector<MixedFilament> old_mixed_snapshot = pb->mixed_filaments.mixed_filaments();
+
             pb->set_num_filaments((unsigned int)target_count, std::vector<std::string>{});
+
+            // Restore custom entries that were wiped by clear_custom_entries
+            // in update_multi_material_filament_presets.  add_batch_custom_
+            // filaments below will manage the batch-matched rows; we just
+            // need to keep the pre-existing custom rows alive so their
+            // stable_ids survive into the in-place edit block above and the
+            // translation step below.
+            {
+                const std::string saved = pb->project_config.opt_string("mixed_filament_definitions");
+                if (!saved.empty())
+                    pb->mixed_filaments.load_custom_entries(saved, colors_vec);
+            }
+
+            // Build a remap from old→new virtual IDs so on_filaments_change
+            // correctly remaps existing painted mixed-IDs before
+            // apply_batch_match_to_model runs.
+            if (old_mixed_snapshot != pb->mixed_filaments.mixed_filaments()) {
+                pb->update_mixed_filament_id_remap(
+                    old_mixed_snapshot, current_count, target_count);
+            }
+
             wxGetApp().plater()->on_filaments_change((int)target_count);
         } else {
             ConfigOptionStrings* co = wxGetApp().preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour");
@@ -2490,14 +2516,7 @@ Sidebar::Sidebar(Plater *parent)
         }
 
         // Translate mixed-slot source ids from the dialog epoch to the CURRENT
-        // epoch.  Growing the physical count (recommended mode, < 4 filaments)
-        // shifts every mixed virtual id, and on_filaments_change has already
-        // applied that shift to the painted facets (it consumes the remap built
-        // by set_num_filaments).  apply_batch_match_to_model keys its facet
-        // remap on source_extruder_ids, so a stale dialog-time mixed id would
-        // miss the moved facets and strand the painting on the old recipe row.
-        // Physical-slot ids are identity in this flow (nothing is deleted
-        // before apply); ids whose row no longer exists are dropped.
+        // epoch.
         {
             const unsigned int cur_num_physical = (unsigned int)colors_vec.size();
             for (auto& mapping : model_result.mappings) {
@@ -2546,9 +2565,7 @@ Sidebar::Sidebar(Plater *parent)
         mgr.add_batch_custom_filaments(batch_entries, colors_vec, &assigned_ids);
 
         // Replace dialog-computed target ids with the actual virtual ids assigned by
-        // add_batch_custom_filaments.  The dialog's estimate is stale by confirm time:
-        // recommended mode can grow num_physical (shifting every mixed virtual id), and
-        // the in-place block above reuses existing rows instead of allocating new ones.
+        // add_batch_custom_filaments.
         {
             size_t k = 0;
             size_t dropped = 0;
@@ -2560,9 +2577,6 @@ Sidebar::Sidebar(Plater *parent)
                 if (vid != 0u) {
                     mapping.target_filament_id = vid;
                 } else {
-                    // Dropped recipe (cap reached or invalid components): exclude it
-                    // from cleanup (target 0 is filtered out by extract_batch_kept_sets)
-                    // and leave its painted regions on their original filament.
                     mapping.target_filament_id = 0;
                     mapping.source_extruder_ids.clear();
                     ++dropped;
@@ -2586,6 +2600,11 @@ Sidebar::Sidebar(Plater *parent)
         update_mixed_filament_panel(false);
         update_ui_from_settings();
         update_dynamic_filament_list();
+        // Refresh the object list filament column so every row shows the
+        // post-remap extruder ID.  Without this the list still displays the
+        // old physical-slot IDs because the earlier on_filaments_change
+        // refresh ran BEFORE apply_batch_match_to_model.
+        obj_list()->update_objects_list_filament_column(colors_vec.size());
         // Force-refresh combo swatches in case filament count stayed the same
         // (Sidebar::on_filaments_change early-returns in that case).
         std::vector<PlaterPresetComboBox*>& fcombos = combos_filament();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2321,17 +2321,28 @@ Sidebar::Sidebar(Plater *parent)
     p->m_btn_batch_match->SetStyle(ButtonStyle::Confirm, ButtonType::Compact);
     p->m_btn_batch_match->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
         if (!wxGetApp().preset_bundle) return;
-        // No loaded model → batch match has nothing to map. Surface as an info dialog
-        // (not an error — these are "please do X first" hints, not failures) BEFORE
-        // opening the dialog.
+        // No loaded model → batch match has nothing to map. Surface as a confirmation
+        // dialog (not an error — these are "please do X first" hints, not failures)
+        // BEFORE opening the dialog, using the same RichMessageDialog style as the
+        // filament-sync prompts (caption "Batch Match", "Got it" button, screen-centred).
         if (p->plater->model().objects.empty()) {
-            show_info(this, _L("No model detected. Import a multi-color model to continue."));
+            RichMessageDialog dlg(this,
+                _L("No model detected. Import a multi-color model to continue."),
+                _L("Batch Match"), wxOK);
+            dlg.SetOKLabel(_L("Got it"));
+            dlg.CentreOnScreen();
+            dlg.ShowModal();
             return;
         }
         ConfigOptionStrings* co = wxGetApp().preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour");
         const std::vector<std::string> colors = co ? co->values : std::vector<std::string>{};
         if (colors.size() < 2) {
-            show_info(this, _L("Please add at least 2 filaments to use batch color matching."));
+            RichMessageDialog dlg(this,
+                _L("Please add at least 2 filaments to use batch color matching."),
+                _L("Batch Match"), wxOK);
+            dlg.SetOKLabel(_L("Got it"));
+            dlg.CentreOnScreen();
+            dlg.ShowModal();
             return;
         }
         MixedFilamentBatchDialog dlg(this);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2367,7 +2367,7 @@ Sidebar::Sidebar(Plater *parent)
         std::unordered_map<unsigned int, uint64_t> dialog_vid_to_sid;
         const size_t dialog_num_physical = wxGetApp().preset_bundle->filament_presets.size();
         {
-            unsigned int vid = (unsigned int)dialog_num_physical + 1;
+            unsigned int vid = static_cast<unsigned int>(dialog_num_physical) + 1;
             for (const MixedFilament& mf : mgr.mixed_filaments()) {
                 if (!mf.enabled || mf.deleted) continue;
                 dialog_vid_to_sid[vid++] = mf.stable_id;
@@ -2404,8 +2404,13 @@ Sidebar::Sidebar(Plater *parent)
             // Write before set_num_filaments so auto_generate sees CMYG palette.
             if (fc) fc->values = colors_vec;
 
-            pb->set_num_filaments((unsigned int)target_count, std::vector<std::string>{});
-            wxGetApp().plater()->on_filaments_change((int)target_count);
+            pb->set_num_filaments(static_cast<unsigned int>(target_count), std::vector<std::string>{});
+            // Assign the Full Spectrum filament preset to slots 1-4 so the
+            // combobox displays the preset name instead of F1-F4 fallback.
+            for (size_t i = 0; i < std::min<size_t>(4, target_count); ++i)
+                pb->set_filament_preset(i, kFullSpectrumPresetName);
+
+            wxGetApp().plater()->on_filaments_change(static_cast<int>(target_count));
         } else {
             ConfigOptionStrings* co = wxGetApp().preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour");
             colors_vec = co ? co->values : std::vector<std::string>{};
@@ -2450,7 +2455,7 @@ Sidebar::Sidebar(Plater *parent)
                 // Locate that row in the CURRENT mixed list; record its vid.
                 MixedFilament* target     = nullptr;
                 unsigned int   target_vid = 0;
-                unsigned int   vid        = (unsigned int)cur_num_physical + 1;
+                unsigned int   vid        = static_cast<unsigned int>(cur_num_physical) + 1;
                 for (MixedFilament& mf : mgr.mixed_filaments()) {
                     if (!mf.enabled || mf.deleted) continue;
                     if (mf.stable_id == sid) { target = &mf; target_vid = vid; break; }
@@ -2499,12 +2504,12 @@ Sidebar::Sidebar(Plater *parent)
         // Physical-slot ids are identity in this flow (nothing is deleted
         // before apply); ids whose row no longer exists are dropped.
         {
-            const unsigned int cur_num_physical = (unsigned int)colors_vec.size();
+            const unsigned int cur_num_physical = static_cast<unsigned int>(colors_vec.size());
             for (auto& mapping : model_result.mappings) {
                 std::vector<unsigned int> translated;
                 translated.reserve(mapping.source_extruder_ids.size());
                 for (unsigned int src : mapping.source_extruder_ids) {
-                    if (src <= (unsigned int)dialog_num_physical) {
+                    if (src <= static_cast<unsigned int>(dialog_num_physical)) {
                         translated.push_back(src); // physical slot: identity
                         continue;
                     }
@@ -8316,43 +8321,67 @@ void Sidebar::cleanup_unused_filaments_after_batch_match(const BatchMatchResult 
         // filament=false) bakes into the composite remap (tail-truncation).
         // If this ever flips to ascending, painting is silently remapped to
         // wrong colours. Source: compute_redundant_filaments @ MixedFilament.cpp.
-        for (size_t i = 1; i < red.redundant_physical.size(); ++i)
-            assert(red.redundant_physical[i] < red.redundant_physical[i - 1]);
-
-        // RAII: bump the single batch-deletion flag for the duration of the
-        // loop so on_filaments_delete (Sidebar + Plater) skip per-deletion panel
-        // rebuild and painting remap. Exception- and reentrancy-safe.
-        Plater *plater = wxGetApp().plater();
-        Plater::BatchPhysicalDeletionGuard guard(*plater);
-        for (unsigned int redundant_id : red.redundant_physical)
-            delete_filament(redundant_id - 1, -1,
-                            /*skip_dependency_check=*/true,
-                            /*skip_update=*/true);
-
-        // ONE composite painting remap: build old→new from the snapshot, apply
-        // to every volume.  Equivalent to K sequential single-deletion remaps
-        // (remap is a pure pointwise state_map lookup, composable).
-        pb->update_mixed_filament_id_remap(old_mixed_snapshot, old_num_physical, new_num_physical);
-        const std::vector<unsigned int> composite_remap = pb->consume_last_filament_id_remap();
-        if (!composite_remap.empty()) {
-            EnforcerBlockerStateMap state_map;
-            for (size_t i = 0; i < state_map.size(); ++i)
-                state_map[i] = EnforcerBlockerType(i);
-            const size_t total_filaments = new_num_physical + pb->mixed_filaments.enabled_count();
-            for (size_t i = 1; i < composite_remap.size() && i < state_map.size(); ++i) {
-                const unsigned int mapped = composite_remap[i];
-                if (mapped == 0 || mapped >= state_map.size() || mapped > total_filaments)
-                    state_map[i] = EnforcerBlockerType::NONE;
-                else
-                    state_map[i] = EnforcerBlockerType(mapped);
+        // The check is enforced at RUNTIME (not just assert) because the failure
+        // mode is silent wrong-colour mapping and assert() is compiled out under
+        // NDEBUG (Release builds). On violation we fall back to per-deletion
+        // updates (skip_update=false) so each deletion's own remap keeps colours
+        // correct, instead of the batched composite path that depends on the order.
+        bool descending_ok = true;
+        for (size_t i = 1; i < red.redundant_physical.size(); ++i) {
+            if (red.redundant_physical[i] >= red.redundant_physical[i - 1]) {
+                BOOST_LOG_TRIVIAL(error)
+                    << "redundant_physical descending invariant violated at index " << i
+                    << " (" << red.redundant_physical[i] << " >= " << red.redundant_physical[i - 1]
+                    << "); falling back to per-deletion update to avoid silent wrong-colour mapping";
+                descending_ok = false;
+                break;
             }
-            for (ModelObject* mo : wxGetApp().model().objects)
-                for (ModelVolume* mv : mo->volumes)
-                    if (mv->type() == ModelVolumeType::MODEL_PART)
-                        // Pass total_filaments (physical + mixed), NOT new_num_physical —
-                        // remap_enforcer_block_types clips any state > max_type to NONE,
-                        // and remapped mixed virtual ids (N+1..total) must survive.
-                        mv->remap_extruder_ids(total_filaments, state_map);
+        }
+        assert(descending_ok);
+
+        if (descending_ok) {
+            // RAII: bump the single batch-deletion flag for the duration of the
+            // loop so on_filaments_delete (Sidebar + Plater) skip per-deletion panel
+            // rebuild and painting remap. Exception- and reentrancy-safe.
+            Plater *plater = wxGetApp().plater();
+            Plater::BatchPhysicalDeletionGuard guard(*plater);
+            for (unsigned int redundant_id : red.redundant_physical)
+                delete_filament(redundant_id - 1, -1,
+                                /*skip_dependency_check=*/true,
+                                /*skip_update=*/true);
+
+            // ONE composite painting remap: build old→new from the snapshot, apply
+            // to every volume.  Equivalent to K sequential single-deletion remaps
+            // (remap is a pure pointwise state_map lookup, composable).
+            pb->update_mixed_filament_id_remap(old_mixed_snapshot, old_num_physical, new_num_physical);
+            const std::vector<unsigned int> composite_remap = pb->consume_last_filament_id_remap();
+            if (!composite_remap.empty()) {
+                EnforcerBlockerStateMap state_map;
+                for (size_t i = 0; i < state_map.size(); ++i)
+                    state_map[i] = EnforcerBlockerType(i);
+                const size_t total_filaments = new_num_physical + pb->mixed_filaments.enabled_count();
+                for (size_t i = 1; i < composite_remap.size() && i < state_map.size(); ++i) {
+                    const unsigned int mapped = composite_remap[i];
+                    if (mapped == 0 || mapped >= state_map.size() || mapped > total_filaments)
+                        state_map[i] = EnforcerBlockerType::NONE;
+                    else
+                        state_map[i] = EnforcerBlockerType(mapped);
+                }
+                for (ModelObject* mo : wxGetApp().model().objects)
+                    for (ModelVolume* mv : mo->volumes)
+                        if (mv->type() == ModelVolumeType::MODEL_PART)
+                            // Pass total_filaments (physical + mixed), NOT new_num_physical —
+                            // remap_enforcer_block_types clips any state > max_type to NONE,
+                            // and remapped mixed virtual ids (N+1..total) must survive.
+                            mv->remap_extruder_ids(total_filaments, state_map);
+            }
+        } else {
+            // Safe fallback: delete one by one with full per-deletion update so each
+            // deletion's own painting remap runs. Slower but colour-correct.
+            for (unsigned int redundant_id : red.redundant_physical)
+                delete_filament(redundant_id - 1, -1,
+                                /*skip_dependency_check=*/true,
+                                /*skip_update=*/false);
         }
     }
 

--- a/src/slic3r/GUI/ThumbnailView.hpp
+++ b/src/slic3r/GUI/ThumbnailView.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 // Lightweight header declaring the named-thumbnail-viewpoint enum.
 // Kept separate from GLCanvas3D.hpp so lightweight consumers (e.g.


### PR DESCRIPTION
# Description

Phase 2 hardening of the mixed-color batch-match flow. Builds on the phase-1
batch dialog with four areas of work: a per-component ratio cap, duplicate-
recipe deduplication, cancel-aware re-match, and UX polish.

## What's new

**Per-component ratio cap (`max_component_percent`)**
Threaded through the whole match chain (`build_best_color_match_recipe` →
`batch_match_model_colors` → `recommend_best_filament_combo`), limiting any
single filament's share of a mix:
- **RECOMMENDED mode: [0%, 70%]** — product spec: no single component > 70%.
- **MANUAL mode: [15%, 100%]** — near-pure allowed; over-70% surfaces as a
  post-match advisory via `check_manual_recipe_ratio()`, listing all
  over-threshold filament IDs.

**Duplicate-recipe deduplication (`merge_duplicate_recipe_mappings`)**
Mappings whose non-pure recipes are byte-identical (same components + ratio +
gradient) now share one virtual slot instead of each allocating a duplicate
mixed-filament row. The survivor unions `source_extruder_ids` and
`merged_model_indices`; runs after both ID-assignment phases so it keeps the
final `target_filament_id`. Pure recipes pass through untouched.

**Cancel-aware re-match**
`recommend_best_filament_combo` returns `{}` for both "no combo" and
"cancelled" — disambiguated via a post-call `cancel_token` re-check, routing
a cancelled result (error_code 2) directly with no error banner and skipping
the Pass-2 match. On a failed/cancelled re-match, the prior preview is
restored only when user-facing input is unchanged (mode + manual selections).

**"CMYW" → "Full Spectrum" rename**
New canonical constant `kFullSpectrumPresetName`; slots 1-4 auto-assigned the
preset after batch match so the combobox shows the preset name, not F1-F4.

## Bug & safety fixes

- **Dangling reference (UB)** in `extract_model_colors`: ternary bound a
  temporary to a reference (use-after-scope). Now a raw pointer with null-check
  at the virtual-lookup site; null warning logged once (was per-face).
- **Descending-invariant hardening** in `cleanup_unused_filaments_after_batch_match`:
  promoted from `assert()` (compiled out under `NDEBUG`) to a runtime check
  with a per-deletion fallback that keeps colours correct on violation.
- `mix_b_percent` clamped to `[0,100]`; 64-color warning deferred until after
  `build_ui()`; `preset_bundle` null-guarded at startup.
- Triple-loop `wb` upper bound now respects `max_component_percent`.
- C-style casts → `static_cast`; `m_match_running` documented UI-thread-only.

## UX polish

- Recommended-card hover tooltip: localized color name + hex + TD (resolved by
  color family, not palette position).
- Row border wraps swatch + name together; banners moved below the mode row.
- `canvas3D()` → `get_view3D_canvas3D()` on the thumbnail render path.
- Skip refresh on method re-select (wxMSW combobox quirk).

## Tests

- [ ] Build: `cmake --build build --target Snapmaker_Orca --config Release`
- [ ] Recommended-mode match: no single component > 70%
- [ ] Manual-mode match with near-pure selection: over-threshold advisory lists all offending IDs
- [ ] After confirm, combobox shows Full Spectrum preset names (not F1-F4)
- [ ] Two models whose recipes collide share one virtual slot (no duplicate row)
- [ ] Cancel a running match: no error banner, prior preview restored when input unchanged
- [ ] Regression: batch-match cleanup produces correct colours when redundant filaments removed
- [ ] Regression: no crash on early-startup paths where `preset_bundle` is null