### PR TITLE
fix: object list filament column not updating after batch color match

### DIFF
--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -5,6 +5,8 @@
 #include "I18N.hpp"
 #include "PresetBundle.hpp"
 #include "libslic3r/Preset.hpp"
+#include "libslic3r/Model.hpp"
+#include "libslic3r/libslic3r.h"
 #include "Widgets/ComboBox.hpp"
 #include "Widgets/StaticBox.hpp"
 #include "Widgets/Button.hpp"
@@ -625,25 +627,93 @@ void MixedFilamentBatchDialog::load_model_colors()
     auto* plater = wxGetApp().plater();
     if (!plater) return;
 
-    const auto all_colors = plater->get_extruder_colors_from_plater_config(nullptr, true);
+    PresetBundle* pb = wxGetApp().preset_bundle;
+    if (!pb) return;
 
-    for (size_t i = 0; i < all_colors.size(); ++i) {
-        const std::string& hex = all_colors[i];
-        if (hex.empty()) continue;
+    const size_t num_physical = pb->filament_presets.size();
+    ConfigOptionStrings* co = pb->project_config.option<ConfigOptionStrings>("filament_colour");
+    if (!co || co->values.empty()) return;
+
+    // Collect all extruder IDs actually painted on the model's volumes,
+    // NOT the palette index.  load_model_colors used to enumerate the
+    // get_extruder_colors_from_plater_config() palette and use its array
+    // index as the extruder_id, which misses (a) config-level extruder
+    // assignments on volumes with no MMU paint, and (b) old mixed-filament
+    // virtual IDs that are still painted on triangles but whose display
+    // color may have been deduplicated against the physical palette.
+    //
+    // We now walk every MODEL_PART volume's get_extruders() (MMU paint
+    // chunked facet data + config extruder_id), look up each extruder's
+    // hex colour from the physical palette or the mixed-filament
+    // display_color table, deduplicate by hex, and ACCUMULATE extruder
+    // IDs per colour so every extruder that a given colour is painted with
+    // lands in source_extruder_ids.  This guarantees that
+    // apply_batch_match_to_model can remap every painted extruder,
+    // including virtual mixed IDs from a prior batch match.
+
+    // Map hex → accumulated extruder_ids (unordered, insert-order for log stability)
+    std::vector<std::pair<std::string, std::vector<unsigned int>>> hex_to_eids;
+
+    for (const ModelObject* mo : wxGetApp().model().objects) {
+        for (const ModelVolume* mv : mo->volumes) {
+            if (!mv || mv->type() != ModelVolumeType::MODEL_PART) continue;
+
+            for (int eid : mv->get_extruders()) {
+                if (eid < 1 || eid > int(MAXIMUM_EXTRUDER_NUMBER)) continue;
+
+                std::string color_hex;
+                if (size_t(eid - 1) < co->values.size()) {
+                    // Physical filament colour
+                    color_hex = co->values[size_t(eid - 1)];
+                } else {
+                    // Virtual mixed filament — look up its display_color
+                    const MixedFilament* mf = pb->mixed_filaments.mixed_filament_from_id(
+                        static_cast<unsigned int>(eid), num_physical);
+                    if (mf && !mf->display_color.empty())
+                        color_hex = mf->display_color;
+                }
+                if (color_hex.empty()) continue;
+
+                // Normalize hex for dedup
+                wxColour c;
+                if (!try_parse_color_match_hex(color_hex, c)) continue;
+                const wxString hex_norm = normalize_color_match_hex(color_hex);
+
+                // Accumulate extruder IDs per (normalized) hex value
+                auto it = std::find_if(hex_to_eids.begin(), hex_to_eids.end(),
+                    [&](const auto& p) { return p.first == hex_norm; });
+                if (it != hex_to_eids.end()) {
+                    it->second.push_back(static_cast<unsigned int>(eid));
+                } else {
+                    hex_to_eids.push_back({hex_norm.ToStdString(), {static_cast<unsigned int>(eid)}});
+                }
+            }
+        }
+    }
+
+    // If no model volumes provided extruders, fall back to the palette-index
+    // enumeration so the dialog still opens with a useful colour list.
+    if (hex_to_eids.empty()) {
+        const auto all_colors = plater->get_extruder_colors_from_plater_config(nullptr, true);
+        for (size_t i = 0; i < all_colors.size(); ++i) {
+            const std::string& hex = all_colors[i];
+            if (hex.empty()) continue;
+            wxColour c;
+            if (!try_parse_color_match_hex(hex, c)) continue;
+            hex_to_eids.push_back({normalize_color_match_hex(hex).ToStdString(), {static_cast<unsigned int>(i + 1)}});
+        }
+    }
+
+    for (size_t idx = 0; idx < hex_to_eids.size(); ++idx) {
+        const std::string& hex = hex_to_eids[idx].first;
+        const auto& eids      = hex_to_eids[idx].second;
         wxColour c;
-        if (!try_parse_color_match_hex(hex, c)) continue;
+        try_parse_color_match_hex(hex, c); // already validated above
 
-        // all_colors is indexed by filament_id-1: [physical colors..., then mixed
-        // display colors]. filament_id = i+1 for every slot — physical OR mixed.
-        // For a mixed slot, i+1 is the virtual id its regions are painted with, so
-        // binding it here lets apply_batch_match_to_model re-match and re-map
-        // existing mixed-painted regions to the new target. Leaving it empty (the
-        // old behavior) stranded those regions: never re-matched, then erased by
-        // cleanup when a component physical was dropped.
         m_model_colors.push_back({
             static_cast<unsigned int>(m_model_colors.size() + 1),
             c, hex,
-            std::vector<unsigned int>{static_cast<unsigned int>(i + 1)}
+            eids
         });
     }
 }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2404,7 +2404,33 @@ Sidebar::Sidebar(Plater *parent)
             // Write before set_num_filaments so auto_generate sees CMYG palette.
             if (fc) fc->values = colors_vec;
 
+            // Snapshot the old mixed list BEFORE set_num_filaments clears
+            // custom entries, so we can build a proper old→new remap that
+            // covers the existing painted virtual IDs (review item R3).
+            const std::vector<MixedFilament> old_mixed_snapshot = pb->mixed_filaments.mixed_filaments();
+
             pb->set_num_filaments((unsigned int)target_count, std::vector<std::string>{});
+
+            // Restore custom entries that were wiped by clear_custom_entries
+            // in update_multi_material_filament_presets.  add_batch_custom_
+            // filaments below will manage the batch-matched rows; we just
+            // need to keep the pre-existing custom rows alive so their
+            // stable_ids survive into the in-place edit block above and the
+            // translation step below.
+            {
+                const std::string saved = pb->project_config.opt_string("mixed_filament_definitions");
+                if (!saved.empty())
+                    pb->mixed_filaments.load_custom_entries(saved, colors_vec);
+            }
+
+            // Build a remap from old→new virtual IDs so on_filaments_change
+            // correctly remaps existing painted mixed-IDs before
+            // apply_batch_match_to_model runs.
+            if (old_mixed_snapshot != pb->mixed_filaments.mixed_filaments()) {
+                pb->update_mixed_filament_id_remap(
+                    old_mixed_snapshot, current_count, target_count);
+            }
+
             wxGetApp().plater()->on_filaments_change((int)target_count);
         } else {
             ConfigOptionStrings* co = wxGetApp().preset_bundle->project_config.option<ConfigOptionStrings>("filament_colour");
@@ -2490,14 +2516,7 @@ Sidebar::Sidebar(Plater *parent)
         }
 
         // Translate mixed-slot source ids from the dialog epoch to the CURRENT
-        // epoch.  Growing the physical count (recommended mode, < 4 filaments)
-        // shifts every mixed virtual id, and on_filaments_change has already
-        // applied that shift to the painted facets (it consumes the remap built
-        // by set_num_filaments).  apply_batch_match_to_model keys its facet
-        // remap on source_extruder_ids, so a stale dialog-time mixed id would
-        // miss the moved facets and strand the painting on the old recipe row.
-        // Physical-slot ids are identity in this flow (nothing is deleted
-        // before apply); ids whose row no longer exists are dropped.
+        // epoch.
         {
             const unsigned int cur_num_physical = (unsigned int)colors_vec.size();
             for (auto& mapping : model_result.mappings) {
@@ -2546,9 +2565,7 @@ Sidebar::Sidebar(Plater *parent)
         mgr.add_batch_custom_filaments(batch_entries, colors_vec, &assigned_ids);
 
         // Replace dialog-computed target ids with the actual virtual ids assigned by
-        // add_batch_custom_filaments.  The dialog's estimate is stale by confirm time:
-        // recommended mode can grow num_physical (shifting every mixed virtual id), and
-        // the in-place block above reuses existing rows instead of allocating new ones.
+        // add_batch_custom_filaments.
         {
             size_t k = 0;
             size_t dropped = 0;
@@ -2560,9 +2577,6 @@ Sidebar::Sidebar(Plater *parent)
                 if (vid != 0u) {
                     mapping.target_filament_id = vid;
                 } else {
-                    // Dropped recipe (cap reached or invalid components): exclude it
-                    // from cleanup (target 0 is filtered out by extract_batch_kept_sets)
-                    // and leave its painted regions on their original filament.
                     mapping.target_filament_id = 0;
                     mapping.source_extruder_ids.clear();
                     ++dropped;
@@ -2586,6 +2600,11 @@ Sidebar::Sidebar(Plater *parent)
         update_mixed_filament_panel(false);
         update_ui_from_settings();
         update_dynamic_filament_list();
+        // Refresh the object list filament column so every row shows the
+        // post-remap extruder ID.  Without this the list still displays the
+        // old physical-slot IDs because the earlier on_filaments_change
+        // refresh ran BEFORE apply_batch_match_to_model.
+        obj_list()->update_objects_list_filament_column(colors_vec.size());
         // Force-refresh combo swatches in case filament count stayed the same
         // (Sidebar::on_filaments_change early-returns in that case).
         std::vector<PlaterPresetComboBox*>& fcombos = combos_filament();


### PR DESCRIPTION
The object list's filament column still displayed old physical-slot extruder IDs after confirming a batch color match because the earlier on_filaments_change refresh ran before apply_batch_match_to_model did the actual extruder remapping.

Root causes and fixes:

1. MixedFilamentBatchDialog::load_model_colors() was enumerating the extruder palette array instead of walking the model's actual painted extruder IDs via get_extruders(). This missed volume config-level extruder assignments (no MMU paint) and virtual mixed-filament IDs that were deduplicated against the physical palette. Rewrote to walk every MODEL_PART volume, look up each extruder's hex colour from the physical palette or the mixed-filament display_color table, and accumulate all matching extruder IDs per colour.

2. Recommended-mode confirm path (Plater.cpp) was losing pre-existing custom mixed filaments because set_num_filaments calls clear_custom_entries(). Fixed by snapshotting the old mixed list before the call, reloading custom entries from project_config afterwards to preserve stable_ids, and building an old→new virtual ID remap so on_filaments_change correctly translates existing painted mixed-IDs before apply_batch_match_to_model runs.

3. Added obj_list()->update_objects_list_filament_column() call after apply_batch_match_to_model completes so the object list reflects the post-remap extruder IDs.