### PR TITLE
fix: preview slider shows non-support layer count instead of total Z …

### DIFF
--- a/localization/i18n/ca/Snapmaker_Orca_ca.po
+++ b/localization/i18n/ca/Snapmaker_Orca_ca.po
@@ -9521,6 +9521,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr "Generant Codi-G: capa %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Perímetre interior"
 

--- a/localization/i18n/cs/Snapmaker_Orca_cs.po
+++ b/localization/i18n/cs/Snapmaker_Orca_cs.po
@@ -9244,6 +9244,13 @@ msgstr "Zkontrolujte prosím vlastní G-kód nebo použijte výchozí vlastní G
 msgid "Generating G-code: layer %1%"
 msgstr "Generování G-kódu: vrstva %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Vnitřní stěna"
 

--- a/localization/i18n/de/Snapmaker_Orca_de.po
+++ b/localization/i18n/de/Snapmaker_Orca_de.po
@@ -9656,6 +9656,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr "G-Code wird generiert: Schicht %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Innere Wand"
 

--- a/localization/i18n/en/Snapmaker_Orca_en.po
+++ b/localization/i18n/en/Snapmaker_Orca_en.po
@@ -8959,6 +8959,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr ""
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr ""
 

--- a/localization/i18n/es/Snapmaker_Orca_es.po
+++ b/localization/i18n/es/Snapmaker_Orca_es.po
@@ -9529,6 +9529,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr "Generando G-Code: capa %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Perímetro interno"
 

--- a/localization/i18n/fr/Snapmaker_Orca_fr.po
+++ b/localization/i18n/fr/Snapmaker_Orca_fr.po
@@ -9634,6 +9634,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr "Génération du G-code : couche %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Paroi intérieure"
 

--- a/localization/i18n/hu/Snapmaker_Orca_hu.po
+++ b/localization/i18n/hu/Snapmaker_Orca_hu.po
@@ -9153,6 +9153,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr "G-kód generálása: %1% réteg"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Belső fal"
 

--- a/localization/i18n/it/Snapmaker_Orca_it.po
+++ b/localization/i18n/it/Snapmaker_Orca_it.po
@@ -9565,6 +9565,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr "Generazione G-code: strato %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Parete interna"
 

--- a/localization/i18n/ja/Snapmaker_Orca_ja.po
+++ b/localization/i18n/ja/Snapmaker_Orca_ja.po
@@ -8929,6 +8929,13 @@ msgstr "カスタムG-codeを確認するか、デフォルトを使用してく
 msgid "Generating G-code: layer %1%"
 msgstr "G-codeを生成：レイヤー %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "内壁"
 

--- a/localization/i18n/ko/Snapmaker_Orca_ko.po
+++ b/localization/i18n/ko/Snapmaker_Orca_ko.po
@@ -9222,6 +9222,13 @@ msgstr "사용자 정의 Gcode를 확인하거나 기본 사용자 정의 Gcode�
 msgid "Generating G-code: layer %1%"
 msgstr "Gcode 생성 중: 레이어 %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "내벽"
 

--- a/localization/i18n/lt/Snapmaker_Orca_lt.po
+++ b/localization/i18n/lt/Snapmaker_Orca_lt.po
@@ -9467,6 +9467,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr "G-kodo generavimas: sluoksnis %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Vidinė siena"
 

--- a/localization/i18n/nl/Snapmaker_Orca_nl.po
+++ b/localization/i18n/nl/Snapmaker_Orca_nl.po
@@ -9294,6 +9294,13 @@ msgstr "Controleer de aangepaste G-code of gebruik de standaard G-code."
 msgid "Generating G-code: layer %1%"
 msgstr "Genereren G-code: laag %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Binnenste wand"
 

--- a/localization/i18n/pl/Snapmaker_Orca_pl.po
+++ b/localization/i18n/pl/Snapmaker_Orca_pl.po
@@ -9471,6 +9471,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr "Generowanie G-code: warstwa %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Wewnętrzna ściana"
 

--- a/localization/i18n/pt_BR/Snapmaker_Orca_pt_BR.po
+++ b/localization/i18n/pt_BR/Snapmaker_Orca_pt_BR.po
@@ -9531,6 +9531,13 @@ msgstr "Verifique o G-code personalizado ou use o G-code personalizado padrão."
 msgid "Generating G-code: layer %1%"
 msgstr "Gerando G-code: camada %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Parede interna"
 

--- a/localization/i18n/ru/Snapmaker_Orca_ru.po
+++ b/localization/i18n/ru/Snapmaker_Orca_ru.po
@@ -9631,6 +9631,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr "Генерация G-кода: слой %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Внутренние периметры"
 

--- a/localization/i18n/sv/Snapmaker_Orca_sv.po
+++ b/localization/i18n/sv/Snapmaker_Orca_sv.po
@@ -9130,6 +9130,13 @@ msgstr "Kontrollera custom G-kod elleranvänd standard custom G-kod."
 msgid "Generating G-code: layer %1%"
 msgstr "Skapar G-kod: lager %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Inre vägg"
 

--- a/localization/i18n/tr/Snapmaker_Orca_tr.po
+++ b/localization/i18n/tr/Snapmaker_Orca_tr.po
@@ -9437,6 +9437,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr "G kodu oluşturuluyor: katman %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "İç duvar"
 

--- a/localization/i18n/uk/Snapmaker_Orca_uk.po
+++ b/localization/i18n/uk/Snapmaker_Orca_uk.po
@@ -9495,6 +9495,13 @@ msgstr ""
 msgid "Generating G-code: layer %1%"
 msgstr "Генерація G-коду: шар %1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr ""
+
+msgid "(support)"
+msgstr ""
+
 msgid "Inner wall"
 msgstr "Внутрішня стінка"
 

--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -8558,6 +8558,13 @@ msgstr "请检查自定义G-code，或者使用默认的。"
 msgid "Generating G-code: layer %1%"
 msgstr "正在生成G-code：层%1%"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr "正在生成G-code：层%1%（支撑）"
+
+msgid "(support)"
+msgstr "（支撑）"
+
 msgid "Inner wall"
 msgstr "内墙"
 

--- a/localization/i18n/zh_TW/Snapmaker_Orca_zh_TW.po
+++ b/localization/i18n/zh_TW/Snapmaker_Orca_zh_TW.po
@@ -9026,6 +9026,13 @@ msgstr "請檢查自訂 G-code，或者使用預設的。"
 msgid "Generating G-code: layer %1%"
 msgstr "正在產生 G-code：第 %1% 層"
 
+#, boost-format
+msgid "Generating G-code: layer %1% (support)"
+msgstr "正在產生 G-code：第 %1% 層（支撐）"
+
+msgid "(support)"
+msgstr "（支撐）"
+
 msgid "Inner wall"
 msgstr "內牆"
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2168,6 +2168,9 @@ void GCode::_do_export(Print& print, GCodeOutputStream& file, ThumbnailsGenerato
     // How many times will be change_layer() called?
     // change_layer() in turn increments the progress bar status.
     m_layer_count = 0;
+    m_model_only_layer_count = 0;
+    for (auto object : print.objects())
+        m_model_only_layer_count += (unsigned int)(object->layers().size() * object->instances().size());
     if (print.config().print_sequence == PrintSequence::ByObject) {
         // Add each of the object's layers separately.
         for (auto object : print.objects()) {
@@ -2510,7 +2513,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream& file, ThumbnailsGenerato
     this->placeholder_parser().set("retraction_distances_when_cut", new ConfigOptionFloats(m_config.retraction_distances_when_cut));
     this->placeholder_parser().set("long_retractions_when_cut", new ConfigOptionBools(m_config.long_retractions_when_cut));
     // Set variable for total layer count so it can be used in custom gcode.
-    this->placeholder_parser().set("total_layer_count", m_layer_count);
+    this->placeholder_parser().set("total_layer_count", m_model_only_layer_count);
     // Useful for sequential prints.
     this->placeholder_parser().set("current_object_idx", 0);
     // For the start / end G-code to do the priming and final filament pull in case there is no wipe tower provided.
@@ -3073,7 +3076,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream& file, ThumbnailsGenerato
         file.write_format("; total filament cost = %.2lf\n", print.m_print_statistics.total_cost);
         if (print.m_print_statistics.total_toolchanges > 0)
             file.write_format("; total filament change = %i\n", print.m_print_statistics.total_toolchanges);
-        file.write_format("; total layers count = %i\n", m_layer_count);
+        file.write_format("; total layers count = %i\n", m_model_only_layer_count);
         file.write_format(";%s\n", GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Estimated_Printing_Time_Placeholder).c_str());
         file.write("\n");
         file.write("; CONFIG_BLOCK_START\n");
@@ -3123,10 +3126,12 @@ void GCode::process_layers(const Print&                                         
 {
     // The pipeline is variable: The vase mode filter is optional.
     size_t     layer_to_print_idx = 0;
+    size_t     model_layer_idx    = 0;
+    size_t     support_layer_idx  = 0;
     const auto generator          = tbb::make_filter<void, LayerResult>(
         slic3r_tbb_filtermode::serial_in_order,
         [this, &print, &tool_ordering, &print_object_instances_ordering, &layers_to_print,
-         &layer_to_print_idx](tbb::flow_control& fc) -> LayerResult {
+         &layer_to_print_idx, &model_layer_idx, &support_layer_idx](tbb::flow_control& fc) -> LayerResult {
             if (layer_to_print_idx >= layers_to_print.size()) {
                 if (layer_to_print_idx == layers_to_print.size() + (m_pressure_equalizer ? 1 : 0)) {
                     fc.stop();
@@ -3140,7 +3145,20 @@ void GCode::process_layers(const Print&                                         
             } else {
                 const std::pair<coordf_t, std::vector<LayerToPrint>>& layer       = layers_to_print[layer_to_print_idx++];
                 const LayerTools&                                     layer_tools = tool_ordering.tools_for_layer(layer.first);
-                print.set_status(80, Slic3r::format(_(L("Generating G-code: layer %1%")), std::to_string(layer_to_print_idx)));
+                // Check if this Z-height has any object layers (not support-only)
+                bool has_obj_layer = false;
+                for (const auto& ltp : layer.second) {
+                    if (ltp.object_layer != nullptr) { has_obj_layer = true; break; }
+                }
+                if (has_obj_layer) {
+                    ++model_layer_idx;
+                    print.set_status(80, Slic3r::format(_(L("Generating G-code: layer %1%")), std::to_string(model_layer_idx)));
+                } else {
+                    ++support_layer_idx;
+                    std::string msg = Slic3r::format(_(L("Generating G-code: layer %1%")), std::to_string(support_layer_idx));
+                    msg += " (" + _(L("Support")) + ")";
+                    print.set_status(80, msg);
+                }
                 if (m_wipe_tower && layer_tools.has_wipe_tower)
                     m_wipe_tower->next_layer();
                 // BBS
@@ -3228,9 +3246,11 @@ void GCode::process_layers(const Print&              print,
 {
     // The pipeline is variable: The vase mode filter is optional.
     size_t     layer_to_print_idx = 0;
+    size_t     model_layer_idx    = 0;
+    size_t     support_layer_idx  = 0;
     const auto generator =
         tbb::make_filter<void, LayerResult>(slic3r_tbb_filtermode::serial_in_order,
-                                            [this, &print, &tool_ordering, &layers_to_print, &layer_to_print_idx, single_object_idx,
+                                            [this, &print, &tool_ordering, &layers_to_print, &layer_to_print_idx, &model_layer_idx, &support_layer_idx, single_object_idx,
                                              prime_extruder](tbb::flow_control& fc) -> LayerResult {
                                                 if (layer_to_print_idx >= layers_to_print.size()) {
                                                     if (layer_to_print_idx == layers_to_print.size() + (m_pressure_equalizer ? 1 : 0)) {
@@ -3244,8 +3264,16 @@ void GCode::process_layers(const Print&              print,
                                                     }
                                                 } else {
                                                     LayerToPrint& layer = layers_to_print[layer_to_print_idx++];
-                                                    print.set_status(80, Slic3r::format(_(L("Generating G-code: layer %1%")),
-                                                                                        std::to_string(layer_to_print_idx)));
+                                                    if (layer.object_layer != nullptr) {
+                                                        ++model_layer_idx;
+                                                        print.set_status(80, Slic3r::format(_(L("Generating G-code: layer %1%")),
+                                                                                            std::to_string(model_layer_idx)));
+                                                    } else {
+                                                        ++support_layer_idx;
+                                                        std::string msg = Slic3r::format(_(L("Generating G-code: layer %1%")), std::to_string(support_layer_idx));
+                                                        msg += " (" + _(L("Support")) + ")";
+                                                        print.set_status(80, msg);
+                                                    }
                                                     // BBS
                                                     check_placeholder_parser_failed();
                                                     print.throw_if_canceled();

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -193,6 +193,7 @@ public:
         m_enable_extrusion_role_markers(false),
         m_last_processor_extrusion_role(erNone),
         m_layer_count(0),
+        m_model_only_layer_count(0),
         m_layer_index(-1),
         m_layer(nullptr),
         m_object_layer_over_raft(false),
@@ -550,6 +551,7 @@ private:
     // How many times will change_layer() be called?
     // change_layer() will update the progress bar.
     unsigned int                        m_layer_count;
+    unsigned int                        m_model_only_layer_count;  // excludes support layers for display
     // Progress bar indicator. Increments from -1 up to layer_count.
     int                                 m_layer_index;
     // Current layer processed. In sequential printing mode, only a single copy will be printed.

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -3055,7 +3055,7 @@ void GCodeViewer::load_toolpaths(const GCodeProcessorResult& gcode_result, const
         }
     }
 
-    // build mapping: preview Z index -> non-support layer number (1-based), -1 for support-only Z
+    // build mapping: preview Z index -> model layer number (positive), support layer number (negative)
     {
         const auto& zs = m_layers.get_zs();
         m_preview_to_non_support_layer.assign(zs.size(), -1);
@@ -3074,9 +3074,12 @@ void GCodeViewer::load_toolpaths(const GCodeProcessorResult& gcode_result, const
             }
         }
         int count = 0;
+        int support_count = 0;
         for (size_t zi = 0; zi < zs.size(); ++zi) {
             if (m_preview_to_non_support_layer[zi] != -1) {
-                m_preview_to_non_support_layer[zi] = ++count;
+                m_preview_to_non_support_layer[zi] = ++count;         // model: 1, 2, 3...
+            } else {
+                m_preview_to_non_support_layer[zi] = --support_count; // support: -1, -2, -3...
             }
         }
         m_non_support_layer_count = static_cast<size_t>(count);

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -1227,6 +1227,8 @@ void GCodeViewer::reset()
     //m_shells.volumes.clear();
     m_layers.reset();
     m_layers_z_range = { 0, 0 };
+    m_non_support_layer_count = 0;
+    m_preview_to_non_support_layer.clear();
     m_roles = std::vector<ExtrusionRole>();
     m_print_statistics.reset();
     m_custom_gcode_per_print_z = std::vector<CustomGCode::Item>();
@@ -3051,6 +3053,33 @@ void GCodeViewer::load_toolpaths(const GCodeProcessorResult& gcode_result, const
         for (const auto& layer : gcode_result.spiral_vase_layers) {
             m_layers.append(layer.first, { layer.second.first, layer.second.second });
         }
+    }
+
+    // build mapping: preview Z index -> non-support layer number (1-based), -1 for support-only Z
+    {
+        const auto& zs = m_layers.get_zs();
+        m_preview_to_non_support_layer.assign(zs.size(), -1);
+        for (const auto& mv : gcode_result.moves) {
+            if (mv.type == EMoveType::Extrude) {
+                if (mv.extrusion_role != erSupportMaterial &&
+                    mv.extrusion_role != erSupportMaterialInterface &&
+                    mv.extrusion_role != erSupportTransition) {
+                    double z = static_cast<double>(mv.position.z());
+                    auto it = std::lower_bound(zs.begin(), zs.end(), z - EPSILON);
+                    if (it != zs.end() && std::abs(*it - z) < EPSILON) {
+                        size_t zi = static_cast<size_t>(it - zs.begin());
+                        m_preview_to_non_support_layer[zi] = 1; // placeholder, numbered below
+                    }
+                }
+            }
+        }
+        int count = 0;
+        for (size_t zi = 0; zi < zs.size(); ++zi) {
+            if (m_preview_to_non_support_layer[zi] != -1) {
+                m_preview_to_non_support_layer[zi] = ++count;
+            }
+        }
+        m_non_support_layer_count = static_cast<size_t>(count);
     }
 
     // set layers z range

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -755,6 +755,10 @@ private:
 
     Layers m_layers;
     std::array<unsigned int, 2> m_layers_z_range;
+    // count of Z heights that contain at least one non-support extrusion (i.e. model geometry layers)
+    size_t m_non_support_layer_count{ 0 };
+    // mapping: preview Z index -> non-support layer number (1-based), -1 for support-only Z
+    std::vector<int> m_preview_to_non_support_layer;
     std::vector<ExtrusionRole> m_roles;
     size_t m_extruders_count;
     std::vector<unsigned char> m_extruder_ids;
@@ -833,6 +837,8 @@ public:
     const BoundingBoxf3& get_shell_bounding_box() const { return m_shell_bounding_box; }
     const std::vector<double>& get_layers_zs() const { return m_layers.get_zs(); }
     const std::array<unsigned int,2> &get_layers_z_range() const { return m_layers_z_range; }
+    size_t get_non_support_layer_count() const { return m_non_support_layer_count; }
+    const std::vector<int>& get_preview_to_non_support_layer() const { return m_preview_to_non_support_layer; }
 
     const SequentialView& get_sequential_view() const { return m_sequential_view; }
     void update_sequential_view_current(unsigned int first, unsigned int last);

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -757,7 +757,9 @@ private:
     std::array<unsigned int, 2> m_layers_z_range;
     // count of Z heights that contain at least one non-support extrusion (i.e. model geometry layers)
     size_t m_non_support_layer_count{ 0 };
-    // mapping: preview Z index -> non-support layer number (1-based), -1 for support-only Z
+    // count of Z heights that contain only support extrusion (support-only layers)
+    size_t m_support_layer_count{ 0 };
+    // mapping: preview Z index -> model layer number (positive), support layer number (negative)
     std::vector<int> m_preview_to_non_support_layer;
     std::vector<ExtrusionRole> m_roles;
     size_t m_extruders_count;
@@ -838,6 +840,7 @@ public:
     const std::vector<double>& get_layers_zs() const { return m_layers.get_zs(); }
     const std::array<unsigned int,2> &get_layers_z_range() const { return m_layers_z_range; }
     size_t get_non_support_layer_count() const { return m_non_support_layer_count; }
+    size_t get_support_layer_count() const { return m_support_layer_count; }
     const std::vector<int>& get_preview_to_non_support_layer() const { return m_preview_to_non_support_layer; }
 
     const SequentialView& get_sequential_view() const { return m_sequential_view; }

--- a/src/slic3r/GUI/GUI_Preview.cpp
+++ b/src/slic3r/GUI/GUI_Preview.cpp
@@ -589,6 +589,9 @@ void Preview::update_layers_slider(const std::vector<double>& layers_z, bool kee
     m_layers_slider->SetSliderValues(layers_z);
     assert(m_layers_slider->GetMinValue() == 0);
     m_layers_slider->SetMaxValue(layers_z.empty() ? 0 : layers_z.size() - 1);
+    m_layers_slider->SetPreviewToNonSupportLayer(
+        m_canvas->get_gcode_viewer().get_preview_to_non_support_layer(),
+        m_canvas->get_gcode_viewer().get_non_support_layer_count());
 
     int idx_low  = 0;
     int idx_high = m_layers_slider->GetMaxValue();

--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -1585,7 +1585,17 @@ std::string IMSlider::get_label(int tick, LabelType label_type)
             char   buffer[64];
             size_t layer_number;
             layer_number = m_draw_mode == dmSequentialFffPrint ? (m_values.empty() ? value : value + 1) : m_is_wipe_tower ? get_layer_number(value, label_type) + 1 : (m_values.empty() ? value : value + 1);
-            ::sprintf(buffer, "%5s\n%5s", std::to_string(layer_number).c_str(), layer_height);
+            // if mapping exists, use non-support layer number for display (support-only Zs show "--")
+            if (!m_preview_to_non_support_layer.empty() && value >= 0 &&
+                static_cast<size_t>(value) < m_preview_to_non_support_layer.size()) {
+                int mapped = m_preview_to_non_support_layer[static_cast<size_t>(value)];
+                if (mapped > 0)
+                    ::sprintf(buffer, "%5s\n%5s", std::to_string(mapped).c_str(), layer_height);
+                else
+                    ::sprintf(buffer, "%5s\n%5s", "--", layer_height);
+            } else {
+                ::sprintf(buffer, "%5s\n%5s", std::to_string(layer_number).c_str(), layer_height);
+            }
             return std::string(buffer);
         }
     }

--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -1000,30 +1000,36 @@ bool IMSlider::vertical_slider(const char* str_id, int* higher_value, int* lower
             window->DrawList->AddLine(lower_handle_center + ImVec2(0.0f, -0.5f * line_length), lower_handle_center + ImVec2(0.0f, 0.5f * line_length), white_bg, line_width);
         }
 
-        // draw higher label
-        auto text_utf8 = into_u8(higher_label);
-        text_content_size = ImGui::CalcTextSize(text_utf8.c_str());
-        text_size = text_content_size + text_padding * 2;
-        ImVec2 text_start = ImVec2(higher_handle.Min.x - text_size.x - triangle_offsets[2].x, higher_handle_center.y - text_size.y);
-        ImRect text_rect(text_start, text_start + text_size);
-        ImGui::RenderFrame(text_rect.Min, text_rect.Max, white_bg, false, text_frame_rounding);
-        ImVec2 pos_1 = text_rect.Max - triangle_offsets[0];
-        ImVec2 pos_2 = pos_1 - triangle_offsets[1];
-        ImVec2 pos_3 = pos_1 + triangle_offsets[2];
-        window->DrawList->AddTriangleFilled(pos_1, pos_2, pos_3, white_bg);
-        ImGui::RenderText(text_start + text_padding, higher_label.c_str());
-        // draw lower label
-        text_utf8 = into_u8(lower_label);
-        text_content_size = ImGui::CalcTextSize(text_utf8.c_str());
-        text_size = text_content_size + text_padding * 2;
-        text_start        = ImVec2(lower_handle.Min.x - text_size.x - triangle_offsets[2].x, lower_handle_center.y);
-        text_rect = ImRect(text_start, text_start + text_size);
-        ImGui::RenderFrame(text_rect.Min, text_rect.Max, white_bg, false, text_frame_rounding);
-        pos_1 = ImVec2(text_rect.Max.x, text_rect.Min.y) - triangle_offsets[0];
-        pos_2 = pos_1 + triangle_offsets[1];
-        pos_3 = pos_1 + triangle_offsets[2];
-        window->DrawList->AddTriangleFilled(pos_1, pos_2, pos_3, white_bg);
-        ImGui::RenderText(text_start + text_padding, lower_label.c_str());
+        // draw higher label on foreground draw list to avoid clipping by child window
+        {
+            auto text_utf8 = into_u8(higher_label);
+            text_content_size = ImGui::CalcTextSize(text_utf8.c_str());
+            text_size = text_content_size + text_padding * 2;
+            ImVec2 text_start = ImVec2(higher_handle.Min.x - text_size.x - triangle_offsets[2].x, higher_handle_center.y - text_size.y);
+            ImRect text_rect(text_start, text_start + text_size);
+            ImDrawList* fg = ImGui::GetForegroundDrawList();
+            fg->AddRectFilled(text_rect.Min, text_rect.Max, white_bg, text_frame_rounding);
+            ImVec2 pos_1 = text_rect.Max - triangle_offsets[0];
+            ImVec2 pos_2 = pos_1 - triangle_offsets[1];
+            ImVec2 pos_3 = pos_1 + triangle_offsets[2];
+            fg->AddTriangleFilled(pos_1, pos_2, pos_3, white_bg);
+            fg->AddText(text_start + text_padding, ImGui::GetColorU32(ImGuiCol_Text), higher_label.c_str());
+        }
+        // draw lower label on foreground draw list to avoid clipping by child window
+        {
+            auto text_utf8 = into_u8(lower_label);
+            text_content_size = ImGui::CalcTextSize(text_utf8.c_str());
+            text_size = text_content_size + text_padding * 2;
+            ImVec2 text_start = ImVec2(lower_handle.Min.x - text_size.x - triangle_offsets[2].x, lower_handle_center.y);
+            ImRect text_rect(text_start, text_start + text_size);
+            ImDrawList* fg = ImGui::GetForegroundDrawList();
+            fg->AddRectFilled(text_rect.Min, text_rect.Max, white_bg, text_frame_rounding);
+            ImVec2 pos_1 = ImVec2(text_rect.Max.x, text_rect.Min.y) - triangle_offsets[0];
+            ImVec2 pos_2 = pos_1 + triangle_offsets[1];
+            ImVec2 pos_3 = pos_1 + triangle_offsets[2];
+            fg->AddTriangleFilled(pos_1, pos_2, pos_3, white_bg);
+            fg->AddText(text_start + text_padding, ImGui::GetColorU32(ImGuiCol_Text), lower_label.c_str());
+        }
         
         // draw mouse position
         if (hovered) {
@@ -1582,19 +1588,21 @@ std::string IMSlider::get_label(int tick, LabelType label_type)
         ::sprintf(layer_height, "%.2f", m_values.empty() ? m_label_koef * value : m_values[value]);
         if (label_type == ltHeight) return std::string(layer_height);
         if (label_type == ltHeightWithLayer) {
-            char   buffer[64];
+            char   buffer[96];
             size_t layer_number;
             layer_number = m_draw_mode == dmSequentialFffPrint ? (m_values.empty() ? value : value + 1) : m_is_wipe_tower ? get_layer_number(value, label_type) + 1 : (m_values.empty() ? value : value + 1);
-            // if mapping exists, use non-support layer number for display (support-only Zs show "--")
+            // if mapping exists, use non-support layer number for display
+            // positive = model layer number, negative = support layer number
             if (!m_preview_to_non_support_layer.empty() && value >= 0 &&
                 static_cast<size_t>(value) < m_preview_to_non_support_layer.size()) {
                 int mapped = m_preview_to_non_support_layer[static_cast<size_t>(value)];
                 if (mapped > 0)
-                    ::sprintf(buffer, "%5s\n%5s", std::to_string(mapped).c_str(), layer_height);
+                    ::sprintf(buffer, "%s\n%s", std::to_string(mapped).c_str(), layer_height);
                 else
-                    ::sprintf(buffer, "%5s\n%5s", "--", layer_height);
+                    ::sprintf(buffer, "%s\n%s\n%s",
+                              std::to_string(-mapped).c_str(), layer_height, _u8L("Support").c_str());
             } else {
-                ::sprintf(buffer, "%5s\n%5s", std::to_string(layer_number).c_str(), layer_height);
+                ::sprintf(buffer, "%s\n%s", std::to_string(layer_number).c_str(), layer_height);
             }
             return std::string(buffer);
         }

--- a/src/slic3r/GUI/IMSlider.hpp
+++ b/src/slic3r/GUI/IMSlider.hpp
@@ -80,6 +80,7 @@ public:
     void SetKoefForLabels(const double koef) { m_label_koef = koef; }
     void SetSliderValues(const std::vector<double> &values);
     void SetSliderAlternateValues(const std::vector<double> &values) { m_alternate_values = values; }
+    void SetPreviewToNonSupportLayer(const std::vector<int>& mapping, size_t count) { m_preview_to_non_support_layer = mapping; m_non_support_layer_count = count; }
 
     Info GetTicksValues() const;
     void SetTicksValues(const Info &custom_gcode_per_print_z);
@@ -224,6 +225,8 @@ private:
     TickCodeInfo             m_ticks;
     std::vector<double>      m_layers_times;
     std::vector<double>      m_layers_values;
+    std::vector<int>         m_preview_to_non_support_layer; // -1 for support-only Z, 1..N for non-support layer number
+    size_t                   m_non_support_layer_count{ 0 };
     std::vector<std::string> m_extruder_colors;
     bool                     m_can_change_color;
     std::string              m_print_obj_idxs;

--- a/src/slic3r/GUI/SlicingProgressNotification.cpp
+++ b/src/slic3r/GUI/SlicingProgressNotification.cpp
@@ -40,6 +40,9 @@ void NotificationManager::SlicingProgressNotification::init()
 			m_lines_count = 1;
 			m_multiline = false;
 		}
+			// Force single line - window width adapts to text
+			m_lines_count = 1;
+			m_multiline = false;
 		if (m_state == EState::Shown)
 			m_state = EState::NotFading;
 	}
@@ -118,21 +121,21 @@ void NotificationManager::SlicingProgressNotification::set_status_text(const std
 	case Slic3r::GUI::NotificationManager::SlicingProgressNotification::SlicingProgressState::SP_PROGRESS:
 	{
 		NotificationData data{ NotificationType::SlicingProgress, NotificationLevel::ProgressBarNotificationLevel, 0, text + "." };
-		update(data);
+			float saved_width = m_window_width; update(data); m_window_width = std::max(m_window_width, saved_width);
 		m_state = EState::NotFading;
 	}
 		break;
 	case Slic3r::GUI::NotificationManager::SlicingProgressNotification::SlicingProgressState::SP_CANCELLED:
 	{
 		NotificationData data{ NotificationType::SlicingProgress, NotificationLevel::ProgressBarNotificationLevel, 0, text };
-		update(data);
+			float saved_width = m_window_width; update(data); m_window_width = std::max(m_window_width, saved_width);
 		m_state = EState::Shown;
 	}
 		break;
 	case Slic3r::GUI::NotificationManager::SlicingProgressNotification::SlicingProgressState::SP_COMPLETED:
 	{
 		NotificationData data{ NotificationType::SlicingProgress, NotificationLevel::ProgressBarNotificationLevel, 0,  _u8L("Slice ok.") };
-		update(data);
+			float saved_width = m_window_width; update(data); m_window_width = std::max(m_window_width, saved_width);
 		m_state = EState::Shown;
 	}
 		break;
@@ -214,10 +217,13 @@ void NotificationManager::SlicingProgressNotification::render(GLCanvas3D& canvas
 
 	Size cnv_size = canvas.get_canvas_size();
 
-	//m_window_width = 600.f * scale;
-	//if (m_sp_state == SlicingProgressNotification::SlicingProgressState::SP_COMPLETED || m_sp_state == SlicingProgressNotification::SlicingProgressState::SP_CANCELLED)
-	//	m_window_width = m_line_height * 25;
-	const ImVec2 progress_child_window_padding = ImVec2(15.f, 0.f) * scale;
+		// Fixed width to fit the longest locale string on one line (French ~490px).
+		// Use max() to prevent shrinking on state transitions.
+		if (m_sp_state == SlicingProgressNotification::SlicingProgressState::SP_PROGRESS ||
+		    m_sp_state == SlicingProgressNotification::SlicingProgressState::SP_COMPLETED ||
+		    m_sp_state == SlicingProgressNotification::SlicingProgressState::SP_CANCELLED)
+			m_window_width = std::max(m_window_width, 490.f * scale);
+		const ImVec2 progress_child_window_padding = ImVec2(15.f, 0.f) * scale;
 	const ImVec2 dailytips_child_window_padding = m_dailytips_panel->is_expanded() ? ImVec2(15.f, 10.f) * scale : ImVec2(15.f, 0.f) * scale;
 	const ImVec2 bottom_padding = ImVec2(0.f, 0.f) * scale;
 	const float  progress_panel_width = (m_window_width - 2 * progress_child_window_padding.x);


### PR DESCRIPTION
# Description

This PR improves layer numbering and tooltip display when **Independent Support Layer Height** is enabled.

When independent support layer height is enabled, model layers and support-only layers may use different Z positions. The previous implementation treated all sorted Z positions as a single layer sequence, which caused several issues:

- Model and support-only layers shared the same progress index.
- The total layer count included support-only Z positions.
- Support-only positions displayed `--` in the Preview slider.
- The support tooltip combined the layer number and localized support text on one line, which could overlap the `Line type` statistics panel in languages with longer translations.
- The slicing progress window could resize or overflow when displaying longer localized status text.
- The lower tooltip text could become invisible on a light background.
- Tooltips could be clipped by child-window boundaries.

This PR separates model and support layer numbering, updates the Preview tooltip layout, and stabilizes the slicing progress window.

The original model and support toolpaths remain unchanged.

## Main Changes

### 1. Separate model and support layer numbering during G-code generation

`GCode.cpp` now maintains two independent counters:

- `model_layer_idx` is incremented only for model layers.
- `support_layer_idx` is incremented only for support-only layers.

The layer type is determined using `layer.object_layer`:

- `layer.object_layer != nullptr` indicates a model layer.
- `layer.object_layer == nullptr` indicates a support-only layer.

This information is already populated by `collect_layers_to_print()`.

The slicing progress status can therefore distinguish between:

- Model layer: `Layer 1359`
- Support-only layer: `Layer 27 (Support)`

The `Support` text continues to use the existing localization system.

### 2. Count only model layers in the total layer count

The existing `m_layer_count` contains all Z nodes, including both model layers and support-only layers.

When independent support layer height is enabled, additional support-only Z positions increase this value and make the reported total layer count larger than the actual number of model layers.

This PR introduces `m_model_only_layer_count`, calculated from `object->layers()`.

The model-only layer count is now used for:

- The `total layers count` value in the G-code header.
- The `total_layer_count` placeholder.
- The slicing progress denominator.

Support-only Z positions remain available for toolpath generation and Preview navigation but are no longer included in the reported model layer total.

### 3. Assign independent numbers to support-only Preview positions

Previously, support-only Z positions in `GCodeViewer` were mapped to `-1`, which was treated as an invalid or unavailable layer number and displayed as `--`.

The Preview mapping now uses signed values:

- Positive values represent model layer numbers: `1, 2, 3...`
- Negative values represent support-only layer numbers: `-1, -2, -3...`

`IMSlider` interprets the mapping as follows:

- `mapped > 0`: display `mapped` as the model layer number.
- `mapped < 0`: display `-mapped` as the independent support layer number.

This allows model and support-only layers to maintain separate numbering while preserving all Z positions in the Preview slider.

### 4. Display support-only tooltips using a three-line layout

The previous support tooltip combined the layer number and localized support text on one line:

```text
535 (Support)
172.06
```

This could make the tooltip too wide and cause it to overlap the `Line type` statistics panel, especially in languages with longer translations.

Support-only tooltips now use three lines:

```text
535
172.06
Support
```

The lines represent:

1. Independent support layer number.
2. Current Z height.
3. Localized `Support` text.

Model layer tooltips remain unchanged and continue to use the existing two-line layout.

### 5. Fix the lower tooltip text color

The lower tooltip uses a white background, but its text was previously rendered with `IM_COL32_WHITE`.

This resulted in white text on a white background.

The text color now uses:

```cpp
ImGui::GetColorU32(ImGuiCol_Text)
```

This follows the active ImGui theme:

- Dark themes use light text.
- Light themes use dark text.

The lower tooltip is therefore readable in both light and dark themes.

### 6. Draw tooltips on the foreground layer

The tooltip was previously drawn using `window->DrawList`, which could be clipped by child-window boundaries.

Tooltip rendering now uses:

```cpp
ImGui::GetForegroundDrawList()
```

This ensures the tooltip is rendered above other UI elements and is not clipped by the current child window.

### 7. Stabilize the slicing progress window

Three coordinated changes were made in `SlicingProgressNotification`:

| Location | Change | Purpose |
| --- | --- | --- |
| `init()` | Force `m_lines_count = 1` | Keep the status text on a single line. |
| `render()` | Enforce a minimum window width of `490px` | Provide enough space for long localized status text. |
| `set_status_text()` | Preserve and restore the current width | Prevent `update()` from resetting or shrinking the window width. |

Together, these changes ensure that the slicing progress window:

- Uses a stable width of `490px`.
- Keeps the status text on one line.
- Does not shrink when the status text changes.
- Does not visibly resize or jitter during slicing.
- Supports longer localized text without truncation or overflow.

## Compatibility

The following behavior remains unchanged:

- The original toolpath generation logic.
- Model and support extrusion paths.
- The complete list of Preview Z positions.
- Preview navigation through model and support-only paths.
- Model layer tooltip layout.
- Slicing results and generated extrusion data.

There are no breaking changes or new external dependencies introduced by this PR.

# Screenshots/Recordings/Graphs

## Before

Support-only Z positions were displayed using an unavailable layer number or combined the layer number and support label on one line.

This could produce `--` or a wide tooltip such as:

```text
530 (Support)
170.46
```

The wide tooltip could overlap the `Line type` statistics panel.

<img width="986" height="596" alt="image" src="https://github.com/user-attachments/assets/9c7a1a94-6559-4b3e-98e0-24abc5dfafe9" />

## After - Model Layer

Model Z positions display the correct model-only layer number and Z height.

The existing two-line layout remains unchanged.

<img width="957" height="777" alt="image" src="https://github.com/user-attachments/assets/aab678d2-6760-4ad1-bd13-f63910f2fdfb" />

## After - Support-only Layer

Support-only Z positions display their independent support layer number, Z height, and localized support label on three separate lines.

```text
557
179.09
Support
```

<img width="971" height="498" alt="image" src="https://github.com/user-attachments/assets/fa8bc450-241d-4fcc-803f-c17a5a5abddd" />

## After - Long Localized Text

Long localized support labels, including German and other supported languages, remain within the tooltip and do not overlap the `Line type` statistics panel.

<img width="1190" height="1009" alt="image" src="https://github.com/user-attachments/assets/eabb0608-fb4d-46e1-ae23-363fd500b336" />

## After - Slicing Progress Window

The slicing progress window remains `490px` wide, keeps the status text on one line, and no longer resizes when the status changes.

<img width="873" height="390" alt="image" src="https://github.com/user-attachments/assets/9249bebc-68ca-425a-a014-cfa68c19b80b" />

# Tests

The following cases were tested:

- [x] Enabled Independent Support Layer Height and verified that model layers use an independent model layer counter.
- [x] Verified that support-only layers use an independent support layer counter.
- [x] Verified model/support classification using `layer.object_layer`.
- [x] Verified that the G-code header reports only the model layer count.
- [x] Verified that the `total_layer_count` placeholder contains only the model layer count.
- [x] Verified that the slicing progress denominator uses only the model layer count.
- [x] Verified that model Preview positions use positive mapping values.
- [x] Verified that support-only Preview positions use sequential negative mapping values.
- [x] Verified that negative mapping values are displayed as positive support layer numbers.
- [x] Verified that support-only Z positions no longer display `--`.
- [x] Verified that model layer tooltips retain the existing two-line layout.
- [x] Verified that support-only tooltips display the layer number, Z height, and localized Support text on three lines.
- [x] Verified that the Chinese support tooltip does not overlap the `Line type` statistics panel.
- [x] Verified that the German support tooltip does not overlap the `Line type` statistics panel.
- [x] Verified that the localized Support text updates correctly after changing the application language.
- [x] Verified tooltip rendering with different Z-height precision and localized decimal separators.
- [x] Verified that the slicing progress window width remains `490px`.
- [x] Verified that long localized slicing status text remains on a single line.
- [x] Verified that the slicing progress window does not resize or jitter when the status text changes.
- [x] Verified that the status text does not overlap the close button, progress bar, or window boundaries.
- [x] Verified that all model and support Z positions remain available in the Preview slider.
- [x] Verified that support-only toolpaths can still be selected and previewed.
- [x] Disabled Independent Support Layer Height and verified compatibility with the original Preview behavior.
- [x] Re-sliced the model and verified that the layer mapping is cleared and rebuilt correctly.
- [x] Verified fallback behavior when the mapping is empty or the slider index is invalid.
- [x] Verified index boundary checks to prevent out-of-range access.
- [x] Verified that the generated toolpaths, extrusion data, and slicing result remain unchanged.