### PR TITLE
fix: add ws fallback to push_timelapse_state

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -5547,10 +5547,11 @@ void SSWCP_UserLogin_Instance::push_timelapse_state(const std::string& sn,
         std::string script = "window.postMessage(JSON.stringify(" + json_str + "), '*');";
 
         wxWebView* webview = sub->webview;
-        wxGetApp().CallAfter([webview, script]() {
+        wxGetApp().CallAfter([webview, script, json_str]() {
             if (webview && webview->GetRefData()) {
                 WebView::RunScript(webview, script);
             }
+            SSWCP::send_message_to_flutter(json_str);
         });
     }
 }


### PR DESCRIPTION
push_timelapse_state now calls send_message_to_flutter in CallAfter, so timelapse download_complete pushes reach Flutter even in ws debug environment where sub->webview is null. Same pattern as send_to_js.