### PR TITLE
i18n: update timelapse download popup strings to match design spec

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -3350,6 +3350,18 @@ msgstr "热床调平"
 msgid "Timelapse"
 msgstr "延时摄影"
 
+msgid "Download Lists"
+msgstr "下载列表"
+
+msgid "Download Lists (%d)"
+msgstr "下载列表 (%d)"
+
+msgid "Downloaded"
+msgstr "下载完成"
+
+msgid "Download Cancelled"
+msgstr "下载已取消"
+
 msgid "Download Failed"
 msgstr "下载失败"
 

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -5466,7 +5466,7 @@ void SSWCP_UserLogin_Instance::sw_DownLoadFile()
                 }
                 wxString status = ctx->is_wan
                     ? _L("Waiting for device upload...")
-                    : _L("Downloading...");
+                    : _L("Downloading");
                 ctx->popup->set_task_status(cur_idx,
                     wxString::FromUTF8(status.ToUTF8().data()));
             });

--- a/src/slic3r/GUI/Timelapse/TimelapseDownloadPopup.cpp
+++ b/src/slic3r/GUI/Timelapse/TimelapseDownloadPopup.cpp
@@ -206,7 +206,7 @@ void TimelapseTaskRow::set_state(State s)
             m_cancel_btn->SetCursor(wxCURSOR_HAND);
             break;
         case State::Completed:
-            m_status_text = _L("Completed");
+            m_status_text = _L("Downloaded");
             m_percent = 100;
             disable_cancel();
             break;
@@ -214,7 +214,7 @@ void TimelapseTaskRow::set_state(State s)
             disable_cancel();
             break;
         case State::Cancelled:
-            m_status_text = _L("Cancelled");
+            m_status_text = _L("Download Cancelled");
             disable_cancel();
             break;
     }
@@ -323,7 +323,7 @@ TimelapseDownloadPopup::TimelapseDownloadPopup(wxWindow* parent)
 
     wxBoxSizer* title_sizer = new wxBoxSizer(wxHORIZONTAL);
 
-    m_title_label = new Label(m_title_bar, _L("Download List"));
+    m_title_label = new Label(m_title_bar, _L("Download Lists"));
     m_title_label->SetFont(::Label::Head_13);
     m_title_label->SetForegroundColour(make_color(COL_TITLE_TEXT));
     title_sizer->Add(m_title_label, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(14));
@@ -381,7 +381,7 @@ void TimelapseDownloadPopup::add_tasks(const std::vector<TaskInfo>& tasks)
 {
     m_task_count = static_cast<int>(tasks.size());
     m_title_label->SetLabel(
-        wxString::Format(_L("Download List (%d)"), m_task_count));
+        wxString::Format(_L("Download Lists (%d)"), m_task_count));
 
     for (size_t i = 0; i < tasks.size(); ++i) {
         auto* row = new TimelapseTaskRow(m_task_panel,
@@ -544,7 +544,7 @@ void TimelapseDownloadPopup::dismiss_row(int index)
         }
     }
     m_title_label->SetLabel(
-        wxString::Format(_L("Download List (%d)"), visible_count));
+        wxString::Format(_L("Download Lists (%d)"), visible_count));
     if (visible_count == 0) {
         wxGetApp().CallAfter([this]() {
             if (!IsBeingDeleted()) {


### PR DESCRIPTION
# Description

- Download List → Download Lists
- Completed → Downloaded
- Cancelled → Download Cancelled
- Downloading... → Downloading
- Add Chinese translations for all new keys
