### PR TITLE
fix: preserve smoothed variable layer height profile with raft

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1653,7 +1653,7 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
     // Custom layering is not allowed for tree supports as of now.
     for (size_t print_object_idx = 0; print_object_idx < m_objects.size(); ++ print_object_idx)
         if (const PrintObject &print_object = *m_objects[print_object_idx];
-            print_object.has_support_material() && is_tree(print_object.config().support_type.value) && (print_object.config().support_style.value == smsTreeOrganic || 
+            print_object.has_support() && is_tree(print_object.config().support_type.value) && (print_object.config().support_style.value == smsTreeOrganic || 
                 // Orca: use organic as default
                 print_object.config().support_style.value == smsDefault) &&
             print_object.model_object()->has_custom_layering()) {

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -3927,7 +3927,14 @@ bool PrintObject::update_layer_height_profile(const ModelObject          &model_
             std::abs(layer_height_profile[layer_height_profile.size() - 2] - slicing_parameters.object_print_z_uncompensated_max + slicing_parameters.object_print_z_min) > 1e-3))
         layer_height_profile.clear();
 
-    if (layer_height_profile.empty() || layer_height_profile[1] != slicing_parameters.first_object_layer_height || has_dithering_ranges) {
+    // Validate the first profile height only when the first object layer height is fixed
+    // (no raft, or raft with bridging). When raft is present without bridging, the first
+    // object layer height is variable and profile[1] may legitimately differ.
+    const bool first_layer_height_mismatch =
+        slicing_parameters.first_object_layer_height_fixed()
+        && !layer_height_profile.empty()
+        && layer_height_profile[1] != slicing_parameters.first_object_layer_height;
+    if (layer_height_profile.empty() || first_layer_height_mismatch || has_dithering_ranges) {
         //layer_height_profile = layer_height_profile_adaptive(slicing_parameters, model_object.layer_config_ranges, model_object.volumes);
         layer_height_profile = layer_height_profile_from_ranges(slicing_parameters, *ranges_to_use);
         // The layer height profile is already compressed.


### PR DESCRIPTION
# Description

This PR fixes two variable layer height issues that occur in raft-only configurations.

## Issue 1: Smoothed variable layer height profile resets with raft enabled

### Problem

When raft layers are enabled, the following steps cause the variable layer height profile to reset:

1. Open the Variable Layer Height tool.
2. Click **Adaptive** to generate a profile.
3. Click **Smooth**.

The smoothed profile is displayed correctly at first, but approximately 500 ms later it is reset to the default straight profile.

### Root Cause

`PrintObject::update_layer_height_profile()` compared the first height stored in the profile with the calculated first object layer height:

```cpp
layer_height_profile[1] != slicing_parameters.first_object_layer_height
```

When a raft is present, the slicing logic may adjust the calculated first object layer height.

For example:

```text
layer_height_profile[1]                       = 0.25 mm
slicing_parameters.first_object_layer_height = 0.20 mm
```

This difference is valid because the first object layer height is not fixed when a raft is present.

However, the previous validation treated the difference as invalid profile data and rebuilt the profile with `layer_height_profile_from_ranges()`. This caused the smoothed profile to be replaced by the default straight profile during the delayed background-process refresh.

### Fix

The first profile height mismatch is now checked only when the first object layer height is fixed:

```cpp
const bool first_layer_height_mismatch =
    slicing_parameters.first_object_layer_height_fixed() &&
    !layer_height_profile.empty() &&
    layer_height_profile[1] != slicing_parameters.first_object_layer_height;
```

When the first object layer height is not fixed because of a raft, the comparison is skipped and the valid variable layer height profile is preserved.

## Issue 2: Incorrect Organic support incompatibility error with raft only

### Problem

The following configuration incorrectly prevents the Variable Layer Height tool from opening:

1. Select **Organic tree** as the support type.
2. Keep support disabled.
3. Enable raft layers only.
4. Open the Variable Layer Height tool.

The application incorrectly reports:

```text
Variable layer height is not supported with Organic supports
```

### Root Cause

The Organic support compatibility check in `Print.cpp` used:

```cpp
print_object.has_support_material()
```

`has_support_material()` returns true when either support or raft is enabled:

```cpp
has_support() || has_raft()
```

As a result, a raft-only configuration was incorrectly treated as if Organic support were enabled.

### Fix

The compatibility check now uses:

```cpp
print_object.has_support()
```

instead of:

```cpp
print_object.has_support_material()
```

The Organic support restriction is now applied only when support is actually enabled, not when the object only has raft layers.

## Changes

Modified files:

- `src/libslic3r/PrintObject.cpp`
  - Validate the first profile height only when the first object layer height is fixed.
  - Preserve valid variable layer height profiles when raft layers are enabled.

- `src/libslic3r/Print.cpp`
  - Replace `has_support_material()` with `has_support()` in the Organic support compatibility check.
  - Prevent raft-only configurations from being treated as enabled support.

## Compatibility

- No new dependencies.
- No configuration format changes.
- No breaking changes.
- No changes to the smoothing algorithm.
- Existing first-layer validation remains active when the first object layer height is fixed.
- Existing Organic support restrictions remain active when support is actually enabled.

# Screenshots/Recordings/Graphs

## Issue 1: Variable layer height profile reset

### Before

With raft layers enabled, the smoothed variable layer height profile is briefly displayed and then reset to a straight line after the delayed background-process refresh.


https://github.com/user-attachments/assets/5d1d3ec8-26e5-41d2-b177-aa76300efd38



### After

With raft layers enabled, the smoothed variable layer height profile remains unchanged after the background-process refresh.


https://github.com/user-attachments/assets/de9e572b-7d77-4c89-9d62-d7406a23c26e



## Issue 2: Incorrect Organic support error

### Before

With Organic tree selected, support disabled, and raft enabled, opening the Variable Layer Height tool incorrectly displays an incompatibility error.
<img width="2547" height="1430" alt="image" src="https://github.com/user-attachments/assets/d3d9ac6f-ff72-4afd-b2b0-35f4af76b24a" />


### After

With Organic tree selected, support disabled, and raft enabled, the Variable Layer Height tool opens normally.

<img width="3065" height="1814" alt="image" src="https://github.com/user-attachments/assets/52f3bc2a-60ec-4e66-8a6b-bd30e0c88271" />


## Tests

- [x] Enable raft layers, apply Adaptive and then Smooth, and verify that the profile does not reset.
- [x] Disable raft layers and verify that Adaptive and Smooth continue to work normally.
- [x] Select Organic tree, disable support, enable raft layers, and verify that the Variable Layer Height tool opens normally.
- [x] Enable Organic tree support and verify that the existing variable layer height incompatibility restriction is still applied.
- [x] Verify that normal first-layer profile validation remains active when the first object layer height is fixed.