### PR TITLE
fix: prevent NULL FILE* crash when loading a missing G-code file

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -15349,3 +15349,6 @@ msgstr "其他颜色"
 
 msgid "Multiple Color"
 msgstr "多色"
+
+msgid "does not exist."
+msgstr "不存在。"

--- a/src/libslic3r/GCodeReader.cpp
+++ b/src/libslic3r/GCodeReader.cpp
@@ -126,6 +126,15 @@ template<typename ParseLineCallback, typename LineEndCallback>
 bool GCodeReader::parse_file_raw_internal(const std::string &filename, ParseLineCallback parse_line_callback, LineEndCallback line_end_callback)
 {
     FilePtr in{ boost::nowide::fopen(filename.c_str(), "rb") };
+    if (in.f == nullptr) {
+        // fopen failed: file missing, inaccessible, or path invalid.
+        // Returning false here prevents ::fread(buffer.data(), 1, ..., NULL)
+        // below, which would otherwise trigger a CRT invalid-parameter crash
+        // on Windows (and similarly undefined behavior elsewhere).
+        BOOST_LOG_TRIVIAL(error) << "GCodeReader::parse_file_raw_internal: "
+                                 << "failed to open file '" << filename << "'";
+        return false;
+    }
 
     // Read the input stream 64kB at a time, extract lines and process them.
     std::vector<char> buffer(65536 * 10, 0);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17618,6 +17618,21 @@ void Plater::load_gcode(const wxString& filename)
         )
         return;
 
+    // Reject a missing / inaccessible file up front. Without this check the
+    // code below would walk through process_file -> parse_file_raw_internal,
+    // which used to crash on a NULL FILE* (now it just returns false), and
+    // would otherwise surface the misleading "does not contain valid G-code"
+    // message even when the real problem is that the file doesn't exist at all.
+    if (!wxFileExists(filename))
+    {
+        BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ": file does not exist: " << filename;
+        MessageDialog(this,
+            _L("The selected file") + ":\n" + filename + "\n" + _L("does not exist."),
+            wxString(GCODEVIEWER_APP_NAME) + " - " + _L("Error occurs while loading G-code file"),
+            wxCLOSE | wxICON_WARNING | wxCENTRE).ShowModal();
+        return;
+    }
+
     m_last_loaded_gcode = filename;
 
     // BSS: create a new project when load_gcode, force close previous one


### PR DESCRIPTION
## Summary

Two related defensive fixes for the G-code load path, split out of PR #589 (filament temp mixing) per change-scope-control review finding (M3):

- **`GCodeReader::parse_file_raw_internal`** returns `false` when `fopen` fails, preventing `::fread(buffer.data(), 1, ..., NULL)` from triggering a CRT invalid-parameter crash on Windows (and UB elsewhere).
- **`Plater::load_gcode`** rejects a missing / inaccessible file up front with a precise "does not exist" message, instead of letting the load path proceed and surface the misleading "does not contain valid G-code" error.

## Why split out

These were originally bundled into PR #589 commit `4d7ffd5` alongside the mixing-notification work. They have an **independent regression surface** (loading missing / invalid G-code files) and should ship in a separate PR so any regression can be bisected cleanly. The split was done as:

- `fix_top_cover` (PR #589): adds `abe6eb9` revert, removing these two changes from the PR #589 diff.
- `fix_gcodereader_null_deref` (this PR): contains only these two changes on top of `main`.

## Test plan

- [ ] Load a project, then attempt to load a G-code file whose path has been deleted between file-picker and load → expect the new "The selected file: ... does not exist." dialog (no CRT crash).
- [ ] Load a valid G-code file → unchanged behavior, no regression.
- [ ] CLI path: slice a project whose referenced G-code path is invalid → `parse_file_raw_internal` returns `false` cleanly (no CRT crash on Windows).
- [ ] zh_CN locale: the new "does not exist." string renders correctly; other locales fall back to English until `update-translation.yml` syncs.

## Downstream

This PR can merge independently of #589. After both merge, the final state of `main` is identical to what PR #589 would have produced if the GCodeReader/load_gcode changes had not been bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
