### PR TITLE
Fix filament mixed

### DIFF
--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -1950,8 +1950,13 @@ void MixedFilamentBatchDialog::on_manual_selection_changed()
 {
     // Preserve the previous match result; only Start/Re-match clears it.
     set_match_buttons_state(false);
-    // Manual mode only: re-evaluate the dominance warning whenever a combo flips.
+    // Manual mode only: re-evaluate both the dominance warning (before match) and
+    // the recipe ratio warning (after match) whenever a combo flips or a filament
+    // row is added/removed.  Either check may hide a prior warning, so both must
+    // run — their mutual Hide is safe inside each function.
     check_manual_filament_ratio();
+    if (m_match_completed)
+        check_manual_recipe_ratio();
 }
 
 void MixedFilamentBatchDialog::check_manual_filament_ratio()

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2421,8 +2421,26 @@ Sidebar::Sidebar(Plater *parent)
             // Build full palette: CMYG in slots 1-4, original in 5+.
             colors_vec = fc ? fc->values : std::vector<std::string>{};
             colors_vec.resize(target_count);
-            for (size_t i = 0; i < 4 && i < cm.size(); ++i)
+
+            // Recommended-mode colors are plain single-color filaments.
+            // Clear any left-over dual-color / gradient metadata on the
+            // first 4 slots so the UI renders the new palette instead of
+            // the old multi-color swatches.  (filament_multi_colors is
+            // indexed the same as filament_colour; a non-empty entry
+            // takes precedence over the single-color value.)
+            auto* multi_colors = pb->project_config.option<ConfigOptionStrings>("filament_multi_colors");
+            auto* color_modes  = pb->project_config.option<ConfigOptionInts>("filament_colour_mode");
+            if (multi_colors)
+                multi_colors->values.resize(target_count);
+            if (color_modes)
+                color_modes->values.resize(target_count);
+            for (size_t i = 0; i < 4 && i < cm.size(); ++i) {
                 colors_vec[i] = cm[i];
+                if (multi_colors)
+                    multi_colors->values[i].clear();
+                if (color_modes)
+                    color_modes->values[i] = 0;
+            }
 
             // Write before set_num_filaments so auto_generate sees CMYG palette.
             if (fc) fc->values = colors_vec;


### PR DESCRIPTION
## Summary

Two follow-up bug fixes for the mixed-filament batch-match dialog,
landed on top of the Phase 2 feature (#617/#628/#637):

1. In **Recommended mode**, leftover dual-color / gradient swatches
   were still rendering on the newly assigned CMYG single-color slots.
2. In **Manual mode**, the recipe-ratio warning banner disappeared and
   was not restored after combo flip / add-remove filament row /
   mode toggle.

## Changes

### Recommended mode — clear leftover multi-color metadata on CMYG slots
**`src/slic3r/GUI/Plater.cpp`** (+19 / -1)

When batch-matching in Recommended mode, the first 4 physical slots
now have `filament_multi_colors` and `filament_colour_mode` cleared
*before* the CMYG palette is assigned. Previously, stale dual-color /
gradient swatches from a previous recipe rendered in place of the new
single-color filaments.

The ordering is deliberate: **resize+clear → write `filament_colour`
→ `set_num_filaments`**, so that `EnsureFilamentColorFieldsAligned`
refreshes the `multi_colors` entries from the newly assigned
single-color values.

### Manual mode — persist recipe-ratio warning across UI actions
**`src/slic3r/GUI/MixedFilamentBatchDialog.cpp`** (+6 / -1)

When a post-match recipe exceeds the 0%–70% recommended range in
Manual mode, the advisory warning banner was hidden — and never
restored — on any of these actions:
- changing a filament combo selection
- adding / removing a filament row
- switching to Recommended mode and back

**Root cause:** `on_manual_selection_changed()` and
`on_method_changed()` both called `Hide()` on `m_warning_panel` but
only re-ran `check_manual_filament_ratio()` (the pre-match dominance
check). The post-match recipe-ratio check (`check_manual_recipe_ratio`)
was only called once after a successful match and never again.

**Fix:** call `check_manual_recipe_ratio()`
- from `on_manual_selection_changed()` when `m_match_completed` is true;
- from `on_method_changed()` when switching **to** Manual mode.

Both checks are safe to call together — each internally `Hide()`s the
panel first, so the last one to fire wins. Now the warning survives
any UI action that does not re-run the match; only **Start / Re-match**
clears `m_match_completed` and resets the banners.

## Files changed
| File | + | - |
|---|---|---|
| `src/slic3r/GUI/Plater.cpp` | 19 | 1 |
| `src/slic3r/GUI/MixedFilamentBatchDialog.cpp` | 6 | 1 |
| **Total** | **25** | **2** |

## Verification
- Recommended mode: load a model, run a batch match, then re-run with
  a different recipe → CMYG slots must show single colors, no leftover
  gradient/dual swatches.
- Manual mode: produce a recipe whose ratio is outside 0–70 %, then
  flip combos / add-remove rows / toggle Recommended↔Manual → the
  ratio warning must stay visible.