### PR TITLE
fix(mixed-filament): correct default/default-extruder handling in delete, batch match, and icon

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -865,12 +865,12 @@ void ObjectList::update_filament_values_for_items_when_delete_filament(const siz
         auto     object = (*m_objects)[i];
         wxString extruder;
         if (!object->config.has("extruder")) {
-            // Keep this object "缺省" (default): do NOT materialize a
+            // Keep this object set to "default": do NOT materialize a
             // non-zero extruder here.  Materializing (e.g. 1) would pin the
-            // object — and every inheriting ("缺省") child volume — to a
+            // object — and every inheriting ("default") child volume — to a
             // specific filament after a filament is deleted, silently
             // changing the real print material.  Leaving the config unset
-            // keeps the object default; a "缺省" child volume shows the
+            // keeps the object default; a "default" child volume shows the
             // default icon (see UpdateExtruderAndColorIcon), not the
             // parent's color.
             extruder = "0";

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -865,8 +865,15 @@ void ObjectList::update_filament_values_for_items_when_delete_filament(const siz
         auto     object = (*m_objects)[i];
         wxString extruder;
         if (!object->config.has("extruder")) {
-            extruder = std::to_string(1);
-            object->config.set_key_value("extruder", new ConfigOptionInt(1));
+            // Keep this object "缺省" (default): do NOT materialize a
+            // non-zero extruder here.  Materializing (e.g. 1) would pin the
+            // object — and every inheriting ("缺省") child volume — to a
+            // specific filament after a filament is deleted, silently
+            // changing the real print material.  Leaving the config unset
+            // keeps the object default; a "缺省" child volume shows the
+            // default icon (see UpdateExtruderAndColorIcon), not the
+            // parent's color.
+            extruder = "0";
         } else if (size_t(object->config.extruder()) == filament_id + 1) {
             extruder = std::to_string(replace_filament_id);
             object->config.set_key_value("extruder", new ConfigOptionInt(replace_filament_id));
@@ -914,6 +921,7 @@ void ObjectList::update_filament_values_for_items_when_delete_filament(const siz
                 continue;
             } else if (size_t(object->volumes[id]->config.extruder()) == filament_id + 1) {
                 object->volumes[id]->config.set_key_value("extruder", new ConfigOptionInt(replace_filament_id));
+                extruder = std::to_string(replace_filament_id);
             } else {
                 int new_extruder = object->volumes[id]->config.extruder() > filament_id ? object->volumes[id]->config.extruder() - 1 :
                                                                                           object->volumes[id]->config.extruder();

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1905,7 +1905,7 @@ void apply_batch_match_to_model(const BatchMatchResult& result, Print& print)
             //   - volume carries its OWN explicit extruder  -> remap volume
             //   - volume inherits (no own "extruder")       -> remap OBJECT,
             //     but only if the object has a real (non-default) extruder.
-            //   A truly "缺省" object/volume (no/zero extruder) stays default.
+            //   A genuinely default object/volume (no/zero extruder) is not remapped.
             const ConfigOption* vol_ext_opt = mv->config.option("extruder");
             if (vol_ext_opt && vol_ext_opt->getInt() > 0) {
                 auto it = extruder_remap.find(vol_ext_opt->getInt());

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1897,27 +1897,18 @@ void apply_batch_match_to_model(const BatchMatchResult& result, Print& print)
                 mv->remap_extruder_ids(total_filaments, state_map);
 
             // Level 2: config-level extruder (always needed — even for
-            // painted volumes, get_extruders() includes extruder_id()).
-            // extract_model_colors collects the *inherited* object extruder
-            // as a remap source (vol->get_extruders() -> extruder_id()
-            // falls back to the object config), so the remap has to be
-            // applied at the same level that carries the value:
-            //   - volume carries its OWN explicit extruder  -> remap volume
-            //   - volume inherits (no own "extruder")       -> remap OBJECT,
-            //     but only if the object has a real (non-default) extruder.
-            //   A genuinely default object/volume (no/zero extruder) is not remapped.
-            const ConfigOption* vol_ext_opt = mv->config.option("extruder");
-            if (vol_ext_opt && vol_ext_opt->getInt() > 0) {
-                auto it = extruder_remap.find(vol_ext_opt->getInt());
-                if (it != extruder_remap.end())
-                    mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(it->second)));
-            } else {
-                const ConfigOption* obj_ext_opt = mo->config.option("extruder");
-                if (!obj_ext_opt || obj_ext_opt->getInt() <= 0) continue;
-                auto it = extruder_remap.find(obj_ext_opt->getInt());
-                if (it != extruder_remap.end())
-                    mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(it->second)));
-            }
+            // painted volumes, get_extruders() includes extruder_id())
+            int old_eid = mv->extruder_id();
+            if (old_eid <= 0) continue;
+            auto it = extruder_remap.find(old_eid);
+            if (it == extruder_remap.end()) continue;
+
+            const unsigned int new_eid = it->second;
+            const ConfigOption* vol_opt = mv->config.option("extruder");
+            if (vol_opt && vol_opt->getInt() > 0)
+                mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(new_eid)));
+            else
+                mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(new_eid)));
         }
     }
 

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1897,18 +1897,27 @@ void apply_batch_match_to_model(const BatchMatchResult& result, Print& print)
                 mv->remap_extruder_ids(total_filaments, state_map);
 
             // Level 2: config-level extruder (always needed — even for
-            // painted volumes, get_extruders() includes extruder_id())
-            int old_eid = mv->extruder_id();
-            if (old_eid <= 0) continue;
-            auto it = extruder_remap.find(old_eid);
-            if (it == extruder_remap.end()) continue;
-
-            const unsigned int new_eid = it->second;
-            const ConfigOption* vol_opt = mv->config.option("extruder");
-            if (vol_opt && vol_opt->getInt() > 0)
-                mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(new_eid)));
-            else
-                mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(new_eid)));
+            // painted volumes, get_extruders() includes extruder_id()).
+            // extract_model_colors collects the *inherited* object extruder
+            // as a remap source (vol->get_extruders() -> extruder_id()
+            // falls back to the object config), so the remap has to be
+            // applied at the same level that carries the value:
+            //   - volume carries its OWN explicit extruder  -> remap volume
+            //   - volume inherits (no own "extruder")       -> remap OBJECT,
+            //     but only if the object has a real (non-default) extruder.
+            //   A truly "缺省" object/volume (no/zero extruder) stays default.
+            const ConfigOption* vol_ext_opt = mv->config.option("extruder");
+            if (vol_ext_opt && vol_ext_opt->getInt() > 0) {
+                auto it = extruder_remap.find(vol_ext_opt->getInt());
+                if (it != extruder_remap.end())
+                    mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(it->second)));
+            } else {
+                const ConfigOption* obj_ext_opt = mo->config.option("extruder");
+                if (!obj_ext_opt || obj_ext_opt->getInt() <= 0) continue;
+                auto it = extruder_remap.find(obj_ext_opt->getInt());
+                if (it != extruder_remap.end())
+                    mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(it->second)));
+            }
         }
     }
 

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -390,7 +390,7 @@ void ObjectDataViewModelNode::UpdateExtruderAndColorIcon(wxString extruder /*= "
     if (extruder_idx == 0) {
         if (m_type & itObject);
         else if (m_type & itVolume && m_volume_type == ModelVolumeType::MODEL_PART) {
-            // A part explicitly set to "缺省" (extruder 0) shows the default
+            // A part explicitly set to "default" (extruder 0) shows the default
             // icon — do NOT inherit the parent object's color.  Volumes that
             // truly inherit (no own extruder config) already had the object's
             // value baked into m_extruder by update_filament_values_for_items,

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -390,7 +390,13 @@ void ObjectDataViewModelNode::UpdateExtruderAndColorIcon(wxString extruder /*= "
     if (extruder_idx == 0) {
         if (m_type & itObject);
         else if (m_type & itVolume && m_volume_type == ModelVolumeType::MODEL_PART) {
-            extruder_idx = atoi(m_parent->GetExtruder().c_str());
+            // A part explicitly set to "缺省" (extruder 0) shows the default
+            // icon — do NOT inherit the parent object's color.  Volumes that
+            // truly inherit (no own extruder config) already had the object's
+            // value baked into m_extruder by update_filament_values_for_items,
+            // so they don't reach this branch.
+            m_extruder_bmp = *get_default_extruder_color_icon();
+            return;
         }
         // BBS
         else if (m_type & itVolume && m_volume_type == ModelVolumeType::PARAMETER_MODIFIER) {


### PR DESCRIPTION
fix(mixed-filament): correct default/default-extruder handling in delete, batch match, and icon

Three fixes to how a "default" (extruder 0) MODEL_PART is handled across the
filament lifecycle:

- apply_batch_match_to_model: remap the config-level extruder at the level
  that actually carries the value. A volume with its own explicit extruder
  is remapped on the volume config; a volume that inherits (no own config)
  is remapped on the OBJECT config, but only when the object has a real
  (non-default) extruder. Previously every inheriting volume was skipped,
  so objects whose filament is set at the object level were never remapped
  and stayed pinned to a stale/invalid filament id (wrong print material).
  Truly 缺省 objects/volumes still stay default.

- update_filament_values_for_items_when_delete_filament: when a filament is
  deleted, an object with no own extruder config now stays "default (display
  "0") instead of being materialized to extruder 1, which would silently
  change the object's — and its inheriting volumes' — real print material.
  Also fix the volume sub-loop's deleted-filament branch to update the
  display value to the replacement filament, so the remapped volume shows
  the correct color instead of a stale/default icon.

- UpdateExtruderAndColorIcon: a MODEL_PART explicitly set to default now shows
  the default color icon instead of inheriting the parent object's color.