### PR TITLE
feat(mixed-filament): nozzle-preset-driven Recommended guard, badge dark-mode fix, ratio-warning cleanup

### DIFF
--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1462,9 +1462,17 @@ std::vector<ModelColorEntry> extract_model_colors(const Print& print)
                     continue;
                 }
 
-                // Deduplicate by hex value — accumulate extruder IDs for this color
+                // Deduplicate by NORMALIZED hex value — same RGB written differently
+                // (e.g. "#ff0000" vs "#FF0000", "FF0000" vs "#FF0000", or alpha variants
+                // "#RRGGBBAA" vs "#RRGGBB") must collapse to one entry. Comparing raw
+                // strings would double-count such colors and waste virtual slots. Mirrors
+                // the normalized dedup in build_color_match_presets (line ~213). The
+                // stored hex_value keeps its original form for display.
+                const std::string color_key = normalize_color_match_hex(color_hex).ToStdString();
                 auto it = std::find_if(colors.begin(), colors.end(),
-                    [&](const ModelColorEntry& e) { return e.hex_value == color_hex; });
+                    [&](const ModelColorEntry& e) {
+                        return normalize_color_match_hex(e.hex_value).ToStdString() == color_key;
+                    });
                 if (it != colors.end()) {
                     it->extruder_ids.push_back(static_cast<unsigned int>(eid));
                     continue;

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -613,27 +613,31 @@ MixedColorMatchRecipeResult build_best_color_match_recipe(const std::vector<std:
     return best;
 }
 
-// Full Spectrum preset name, with nozzle diameter resolved from the current
-// printer's nozzle_diameter (mirrors PresetComboBoxes.cpp's @U1 <nozzle> nozzle
-// convention). Falls back to the canonical 0.4 SKU when no matching preset
-// exists for the current nozzle. Follows the same preset_bundle-access pattern
-// as build_mixed_filament_display_context below (null-check + warning log +
-// std::max clamp) -- see the header doc for the UI-thread convention.
-std::string full_spectrum_preset_name()
+// Shared constants + helpers for Full Spectrum preset-name resolution. Kept in
+// an anonymous namespace so the table is not visible outside this TU (these are
+// pure implementation details of the two functions below).
+namespace {
+constexpr const char*  kFullSpectrumBase  = "Snapmaker PLA Full Spectrum @U1 ";
+constexpr double       kFallbackNozzle    = 0.4;   // the only SKU shipped historically
+constexpr double       kMinNozzle         = 0.05;  // matches build_mixed_filament_display_context
+
+// Format a nozzle diameter the same way the preset JSON names do ("0.4", "0.2"):
+// two decimals, trailing zeros and a dangling dot stripped.
+std::string format_nozzle_label(double mm)
 {
-    static const std::string kBase           = "Snapmaker PLA Full Spectrum @U1 ";
-    static constexpr double  kFallbackNozzle = 0.4;
-    static constexpr double  kMinNozzle      = 0.05; // matches build_mixed_filament_display_context
+    std::string s = float_to_string_decimal_point(mm, 2);
+    while (!s.empty() && s.back() == '0') s.pop_back();
+    if (!s.empty() && s.back() == '.') s.pop_back();
+    return s;
+}
 
-    auto format_nozzle = [](double mm) -> std::string {
-        std::string s = float_to_string_decimal_point(mm, 2);
-        while (!s.empty() && s.back() == '0') s.pop_back();
-        if (!s.empty() && s.back() == '.') s.pop_back();
-        return s;
-    };
-
+// Read the current printer's nozzle_diameter from preset_bundle with the same
+// null-check + kMinNozzle clamp as build_mixed_filament_display_context. Falls
+// back to kFallbackNozzle when preset_bundle / the option is unavailable.
+double current_nozzle_diameter()
+{
     double nozzle = kFallbackNozzle;
-    auto* pb = wxGetApp().preset_bundle;
+    auto*  pb     = wxGetApp().preset_bundle;
     if (pb != nullptr) {
         if (const auto* opt = pb->printers.get_edited_preset().config.option<ConfigOptionFloats>("nozzle_diameter");
             opt != nullptr && !opt->values.empty()) {
@@ -642,19 +646,50 @@ std::string full_spectrum_preset_name()
         }
     } else {
         BOOST_LOG_TRIVIAL(warning)
-            << "full_spectrum_preset_name: preset_bundle null; falling back to "
-            << kBase << format_nozzle(kFallbackNozzle) << " nozzle";
+            << "full_spectrum nozzle resolution: preset_bundle null; falling back to "
+            << kFullSpectrumBase << format_nozzle_label(kFallbackNozzle) << " nozzle";
     }
+    return nozzle;
+}
+} // namespace
+
+// Full Spectrum preset name, with nozzle diameter resolved from the current
+// printer's nozzle_diameter (mirrors PresetComboBoxes.cpp's @U1 <nozzle> nozzle
+// convention). Falls back to the canonical 0.4 SKU when no matching preset
+// exists for the current nozzle. Follows the same preset_bundle-access pattern
+// as build_mixed_filament_display_context below (null-check + warning log +
+// std::max clamp) -- see the header doc for the UI-thread convention.
+//
+// NOTE: because this function falls back to the 0.4 name on a miss, its return
+// value alone cannot tell you whether the *current* nozzle actually has a preset
+// -- use full_spectrum_preset_exists_for_current_nozzle() for that.
+std::string full_spectrum_preset_name()
+{
+    const double  nozzle    = current_nozzle_diameter();
+    auto*         pb        = wxGetApp().preset_bundle;
+    const std::string candidate = std::string(kFullSpectrumBase) + format_nozzle_label(nozzle) + " nozzle";
 
     // Candidate for the current nozzle; verify the preset actually exists.
-    const std::string candidate = kBase + format_nozzle(nozzle) + " nozzle";
     if (pb != nullptr && pb->filaments.find_preset(candidate) != nullptr)
         return candidate;
 
     // Fallback: the canonical 0.4 SKU (shipped today). If even that is missing
     // (profile not loaded), return the literal name so upstream fallback chains
     // (load_full_spectrum_colors -> canonical CMYW palette) take over.
-    return kBase + format_nozzle(kFallbackNozzle) + " nozzle";
+    return std::string(kFullSpectrumBase) + format_nozzle_label(kFallbackNozzle) + " nozzle";
+}
+
+// True iff a Full Spectrum preset exists for the printer's *current* nozzle
+// diameter (no fallback). Used by the batch-match guard to decide whether
+// Recommended mode is available, instead of hard-coding 0.4 mm: shipping a new
+// nozzle variant (e.g. 0.2/0.6/0.8) just requires adding its preset JSON under
+// resources/profiles/Snapmaker/filament/, and this returns true automatically.
+bool full_spectrum_preset_exists_for_current_nozzle()
+{
+    const double     nozzle    = current_nozzle_diameter();
+    auto*            pb        = wxGetApp().preset_bundle;
+    const std::string candidate = std::string(kFullSpectrumBase) + format_nozzle_label(nozzle) + " nozzle";
+    return pb != nullptr && pb->filaments.find_preset(candidate) != nullptr;
 }
 
 MixedFilamentDisplayContext build_mixed_filament_display_context(const std::vector<std::string>& physical_colors)

--- a/src/slic3r/GUI/MixedColorMatchHelpers.hpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.hpp
@@ -36,6 +36,12 @@ namespace Slic3r { namespace GUI {
 // off preset_bundle (see load_full_spectrum_colors's safety note).
 std::string full_spectrum_preset_name();
 
+// True iff a Full Spectrum preset exists for the printer's *current* nozzle
+// diameter (no 0.4 fallback, unlike full_spectrum_preset_name). UI-thread only
+// (reads preset_bundle, same convention as above). Used by the batch-match guard
+// to gate Recommended mode on preset availability rather than a hard-coded 0.4.
+bool full_spectrum_preset_exists_for_current_nozzle();
+
 // ---- CIELAB color space types ----
 
 struct CIELab {

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -1954,10 +1954,17 @@ void MixedFilamentBatchDialog::on_manual_selection_changed()
 {
     // Preserve the previous match result; only Start/Re-match clears it.
     set_match_buttons_state(false);
-    // A combo change invalidates any prior match result, so retire the warning banner
-    // (e.g. a leftover recipe-ratio advisory from the previous match). There is no
-    // pre-match ratio guard: any ratio warning now comes from check_manual_recipe_ratio
-    // after a match completes.
+    // Two warning-banner cases, branched on whether a match is still on screen:
+    //  - m_match_completed: the previous match's preview is still displayed, so keep its
+    //    recipe-ratio advisory current. check_manual_recipe_ratio() internally Hides the
+    //    banner first, then re-evaluates against m_result.mappings (the still-shown result)
+    //    and may re-show it. There is no pre-match ratio guard; ratio warnings come only
+    //    from this post-match check.
+    //  - else: no match result is shown, so clear any stale banner (e.g. the 64-color
+    //    limit advisory from display_warning at build_ui, which fires while
+    //    m_match_completed is false). This Hide replaces the unconditional Hide that used
+    //    to live in the now-removed check_manual_filament_ratio(); dropping this branch
+    //    would leave stale banners stuck on screen.
     if (m_match_completed)
         check_manual_recipe_ratio();
     else if (m_warning_panel)

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -64,6 +64,13 @@ static constexpr int kMaxComponentPercent = 70;  // recommended mode cap; also t
 // add_batch_custom_filaments and predicted post-match by handle_batch_match_result.
 static constexpr size_t kMaxColors = 64;
 
+// ΔE color-difference grade thresholds (PRD 6.2.5). The match-quality tooltip bands a
+// mapping's delta_e into Good / Fair / Poor. Product-owned values — adjust here when the
+// spec changes (recently 3/5 → 4/8). Open intervals: <kDeltaEGoodMax Good,
+// [kDeltaEGoodMax, kDeltaEFairMax) Fair, ≥kDeltaEFairMax Poor.
+static constexpr double kDeltaEGoodMax = 4.0;  // <4.0 → Good
+static constexpr double kDeltaEFairMax = 8.0;  // <8.0 → Fair, else Poor
+
 // Recommended-mode (Full Spectrum) per-color transmittance-density (TD) values. These are NOT
 // in the filament data model (filaments_colours.json carries no TD field), so they are pinned
 // here as product constants — provided by product spec (snapshot in code per request).
@@ -219,7 +226,8 @@ private:
         const int pad_y = FromDIP(4);
         const int inset = FromDIP(8);
         wxRect badge(inset, inset, text_sz.x + pad_x * 2, text_sz.y + pad_y * 2);
-        dc.SetBrush(wxBrush(StateColor::darkModeColorFor(wxColour(147, 147, 147))));
+        // Inline resolve — not the shared dark map, to avoid the #000000 reverse-lookup collision.
+        dc.SetBrush(wxBrush(wxGetApp().dark_mode() ? *wxBLACK : wxColour(147, 147, 147)));
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.DrawRectangle(badge);
         dc.SetTextForeground(*wxWHITE);
@@ -1550,9 +1558,8 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
     {
         auto* prow = new wxBoxSizer(wxHORIZONTAL);
         m_preview_orig_panel = new RoundedPreviewPanel(m_preview_card, 180, 8, _L("Original"));
-        // Top-align so the smaller (180h) original lines up with the 227h match panel at the
-        // top; the 47px difference shows as empty space below the original.
-        prow->Add(m_preview_orig_panel, 0, wxALIGN_TOP | wxRIGHT, FromDIP(12));
+        // Top-align: the smaller (180h) original lines up with the 227h match panel; 20 DIP gap per Figma.
+        prow->Add(m_preview_orig_panel, 0, wxALIGN_TOP | wxRIGHT, FromDIP(20));
 
         m_preview_match_panel = new RoundedPreviewPanel(m_preview_card, 227, 8, _L("Matched"));
         prow->Add(m_preview_match_panel, 0, wxALIGN_TOP);
@@ -1653,7 +1660,7 @@ void MixedFilamentBatchDialog::build_mapping_card(wxBoxSizer& parent)
     m_mapping_card->SetMaxSize(wxSize(FromDIP(CARD_WIDTH_DIP), -1));
     auto* cs = new wxBoxSizer(wxVERTICAL);
 
-    // Title row: label + info icon
+    // Title row: label
     {
         auto* tr = new wxBoxSizer(wxHORIZONTAL);
         auto* lbl = new wxStaticText(m_mapping_card, wxID_ANY, _L("Color Mapping"));
@@ -1661,9 +1668,6 @@ void MixedFilamentBatchDialog::build_mapping_card(wxBoxSizer& parent)
         lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         tr->Add(lbl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
-        m_mapping_info_icon = new ScalableButton(m_mapping_card, wxID_ANY, "info");
-        m_mapping_info_icon->SetToolTip(_L("Hover a row to see its color difference."));
-        tr->Add(m_mapping_info_icon, 0, wxALIGN_CENTER_VERTICAL);
         cs->Add(tr, 0, wxTOP | wxLEFT | wxRIGHT, FromDIP(16));
     }
     // 10px gap between the title row and the legend grid (no divider — see commit history).
@@ -1950,60 +1954,21 @@ void MixedFilamentBatchDialog::on_manual_selection_changed()
 {
     // Preserve the previous match result; only Start/Re-match clears it.
     set_match_buttons_state(false);
-    // Manual mode only: re-evaluate both the dominance warning (before match) and
-    // the recipe ratio warning (after match) whenever a combo flips or a filament
-    // row is added/removed.  Either check may hide a prior warning, so both must
-    // run — their mutual Hide is safe inside each function.
-    check_manual_filament_ratio();
+    // A combo change invalidates any prior match result, so retire the warning banner
+    // (e.g. a leftover recipe-ratio advisory from the previous match). There is no
+    // pre-match ratio guard: any ratio warning now comes from check_manual_recipe_ratio
+    // after a match completes.
     if (m_match_completed)
         check_manual_recipe_ratio();
-}
-
-void MixedFilamentBatchDialog::check_manual_filament_ratio()
-{
-    // Tally how many rows currently point at each physical filament slot. If the most-picked
-    // slot accounts for more than kManualDominantRatioPct of the visible rows, the mix is
-    // lopsided — surface the advisory warning (Confirm stays enabled; this is not a hard
-    // error). Hidden rows (beyond m_manual_filament_count) are skipped so the ratio reflects
-    // only the filaments actually in play.
-    //
-    // Mirrors MixedFilamentDialog::get_ratio_warning_msg: same threshold semantics, same
-    // "Filament %d ratio is too high" message shape, just computed from combo selections
-    // (no gradient/tri-slider here — manual mode has no continuous weights, only which
-    // physical slot each row picks).
-    if (m_warning_panel) m_warning_panel->Hide();
-
-    std::unordered_map<int, int> picks; // combo-selection -> row count
-    int total = 0;
-    for (int i = 0; i < m_manual_filament_count && i < 4; ++i) {
-        if (!m_filament_combo[i]) continue;
-        const int sel = m_filament_combo[i]->GetSelection();
-        if (sel < 0) continue;
-        ++picks[sel];
-        ++total;
-    }
-    if (total < 2) return; // need at least 2 rows for "ratio" to be meaningful
-
-    int max_count = 0;
-    int max_sel   = -1;
-    for (const auto& kv : picks) {
-        if (kv.second > max_count) {
-            max_count = kv.second;
-            max_sel   = kv.first;
-        }
-    }
-    const double ratio = double(max_count) / double(total);
-    if (max_sel < 0 || ratio <= kManualDominantRatioPct) return;
-
-    display_warning(wxString::Format(_L("Filament %d ratio is too high. Mix may be affected."), max_sel + 1));
+    else if (m_warning_panel)
+        m_warning_panel->Hide();
 }
 
 void MixedFilamentBatchDialog::check_manual_recipe_ratio()
 {
-    // Post-match complement to check_manual_filament_ratio: that one warns BEFORE a match
-    // (based on how many rows picked the same physical slot). This one warns AFTER a match,
-    // scanning every non-pure recipe for any single component above kMaxComponentPercent and
-    // listing ALL offending rows in one banner (gap doc case 13).
+    // Manual-mode post-match ratio guard: after a match completes, scan every non-pure
+    // recipe for any single component above kMaxComponentPercent and list ALL such
+    // over-threshold colors in the warning banner (gap doc case 13).
     //
     // The IDs reported here are the TARGET filament ids (target_filament_id) — i.e. the
     // numbers shown on the right-hand badge of each Color Mapping row — NOT the recipe
@@ -2186,27 +2151,21 @@ void MixedFilamentBatchDialog::start_batch_match()
         set_error(_L("No model detected. Import a multi-color model to continue."));
         return;
     }
-    // Recommended (auto) mode relies on the Full Spectrum filament preset, which today
-    // only ships for the 0.4 nozzle. Other nozzles have no validated palette, so block the
-    // match up front and direct the user to Manual mode or a nozzle change. Manual mode
-    // is unaffected (user picks filaments from the current list, palette-agnostic).
-    if (m_matching_method == RECOMMENDED) {
-        double nozzle = 0.4; // fallback if preset_bundle/option unavailable
-        if (auto* pb = wxGetApp().preset_bundle) {
-            if (const auto* opt = pb->printers.get_edited_preset().config.option<ConfigOptionFloats>("nozzle_diameter");
-                opt != nullptr && !opt->values.empty()) {
-                nozzle = opt->values.front();
-            }
-        }
-        if (std::abs(nozzle - 0.4) > 1e-6) {
-            RichMessageDialog dlg(this,
-                _L("Automatic color mixing match is not supported with the current nozzle diameter. Use Manual mode or switch to a 0.4 mm nozzle."),
-                _L("Color Mixing Match"), wxOK);
-            dlg.SetOKLabel(_L("Got it"));
-            dlg.CentreOnScreen();
-            dlg.ShowModal();
-            return;
-        }
+    // Recommended (auto) mode relies on the Full Spectrum filament preset, whose
+    // palette is validated per-nozzle. Gate on whether a Full Spectrum preset
+    // actually exists for the *current* nozzle diameter (instead of a hard-coded
+    // 0.4) -- shipping a new nozzle variant just needs its preset JSON, and this
+    // opens up automatically. When no preset exists, block up front and direct
+    // the user to Manual mode or a nozzle change. Manual mode itself is
+    // unaffected (user picks filaments from the current list, palette-agnostic).
+    if (m_matching_method == RECOMMENDED && !full_spectrum_preset_exists_for_current_nozzle()) {
+        RichMessageDialog dlg(this,
+            _L("Automatic color mixing match is not supported with the current nozzle diameter. Use Manual mode or switch to a 0.4 mm nozzle."),
+            _L("Color Mixing Match"), wxOK);
+        dlg.SetOKLabel(_L("Got it"));
+        dlg.CentreOnScreen();
+        dlg.ShowModal();
+        return;
     }
     m_match_running = true;
     m_error_panel->Hide();
@@ -2716,12 +2675,13 @@ void MixedFilamentBatchDialog::update_mapping_legend()
             // parent), and the swatches/arrow are independent child windows — so we must set
             // the same tip on every child too, otherwise hovering a swatch shows nothing and
             // only the gaps between children trigger the row's tip.
-            // Grade bands per PRD 6.2.5 — open intervals: <3 Good, 3≤ΔE<5 Fair, >5 Poor.
-            // Use strict < so ΔE exactly 3.0 → Fair, exactly 5.0 → Poor (boundary correctness).
-            const wxString grade = (mapping.delta_e < 3.0) ? _L("Good")
-                                  : (mapping.delta_e < 5.0) ? _L("Fair")
+            // Grade bands per PRD 6.2.5 — open intervals: <kDeltaEGoodMax Good,
+            // kDeltaEGoodMax≤ΔE<kDeltaEFairMax Fair, ≥kDeltaEFairMax Poor. Strict < so a value
+            // exactly on the boundary lands in the worse band (4.0→Fair, 8.0→Poor).
+            const wxString grade = (mapping.delta_e < kDeltaEGoodMax) ? _L("Good")
+                                  : (mapping.delta_e < kDeltaEFairMax) ? _L("Fair")
                                   : _L("Poor");
-            // Per copy spec: "色差：{等级}（ΔE={X}）" / "Color Difference: {Level} (ΔE={X})".
+            // Per copy spec, tooltip format: "Color Difference: {Level} (ΔE={X})".
             // The ΔE glyph needs a font with Greek coverage; wx's default UI font on all
             // supported platforms (Win10+, macOS, mainstream Linux) has it.
             const wxString tip = wxString::Format(_L("Color Difference: %s (\u0394E=%.1f)"), grade, mapping.delta_e);

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -1954,21 +1954,18 @@ void MixedFilamentBatchDialog::on_manual_selection_changed()
 {
     // Preserve the previous match result; only Start/Re-match clears it.
     set_match_buttons_state(false);
-    // Two warning-banner cases, branched on whether a match is still on screen:
-    //  - m_match_completed: the previous match's preview is still displayed, so keep its
-    //    recipe-ratio advisory current. check_manual_recipe_ratio() internally Hides the
-    //    banner first, then re-evaluates against m_result.mappings (the still-shown result)
-    //    and may re-show it. There is no pre-match ratio guard; ratio warnings come only
-    //    from this post-match check.
-    //  - else: no match result is shown, so clear any stale banner (e.g. the 64-color
-    //    limit advisory from display_warning at build_ui, which fires while
-    //    m_match_completed is false). This Hide replaces the unconditional Hide that used
-    //    to live in the now-removed check_manual_filament_ratio(); dropping this branch
-    //    would leave stale banners stuck on screen.
+    // Re-evaluate the post-match ratio advisory only when a previous match is still on
+    // screen. check_manual_recipe_ratio() internally Hides the banner first, then
+    // re-evaluates against m_result.mappings (the still-shown result) and may re-show it.
+    // There is no pre-match ratio guard; ratio warnings come only from this post-match check.
+    //
+    // Note: when no match is shown (m_match_completed == false), a pre-existing banner —
+    // e.g. the 64-color limit advisory from display_warning at build_ui — is intentionally
+    // NOT cleared here. It persists until the next Start/Re-match (which Hides all banners).
+    // This is acceptable: the advisory is still contextually relevant while the user is
+    // picking filaments for the over-limit model.
     if (m_match_completed)
         check_manual_recipe_ratio();
-    else if (m_warning_panel)
-        m_warning_panel->Hide();
 }
 
 void MixedFilamentBatchDialog::check_manual_recipe_ratio()

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
@@ -81,9 +81,6 @@ private:
     // Red error banner, but unlike set_error it leaves Confirm enabled — for serious
     // advisories the user may still choose to proceed past (e.g. slot overflow).
     void display_error_advisory(const wxString& msg);
-    // Manual-mode pre-match ratio guard: if a single physical filament is picked by more than
-    // kManualDominantRatioPct of the rows, warn that the mix is lopsided.
-    void check_manual_filament_ratio();
     // Manual-mode post-match ratio guard: after a match completes, scan every non-pure
     // recipe for any component > kMaxComponentPercent and list ALL such over-threshold
     // colors in the warning banner (gap doc case 13).
@@ -188,11 +185,6 @@ private:
     // Bucket count is derived from the enum, not a magic 8, so adding a viewpoint fails
     // the static_assert below instead of silently going out of bounds.
     static constexpr size_t kNumThumbnailViews = static_cast<size_t>(ThumbnailView::Rear) + 1;
-    // Manual-mode dominance threshold: when one physical filament accounts for more than
-    // this fraction of the selected rows, the mix is lopsided and we warn the user.
-    // 0.7 = 70%. Kept as a named constant (not a literal) so the threshold is grep-able
-    // and adjustable in one place.
-    static constexpr double kManualDominantRatioPct = 0.7;
     // Model colors whose ΔE to the closest physical is below this threshold
     std::array<std::vector<wxBitmap>, kNumThumbnailViews> m_thumb_cache_by_view;
     std::array<std::vector<wxBitmap>, kNumThumbnailViews> m_match_cache_by_view;
@@ -260,7 +252,6 @@ private:
     StaticBox*      m_mapping_card      = nullptr; // grows in height with content (no inner scroller)
     wxPanel*        m_legend_panel      = nullptr; // plain panel holding the legend grid
     wxGridSizer*    m_legend_sizer      = nullptr; // fixed-col grid (Mac-safe; wxWrapSizer miscomputes height on macOS)
-    ScalableButton* m_mapping_info_icon = nullptr; // info tooltip next to "Color Mapping" title
 
     // Error / warning
     wxPanel* m_error_panel   = nullptr;

--- a/src/slic3r/GUI/Widgets/StateColor.cpp
+++ b/src/slic3r/GUI/Widgets/StateColor.cpp
@@ -60,7 +60,8 @@ static std::map<wxColour, wxColour> gDarkColors{
     {"#FF842D", "#FF9F43"}, // rgb(255, 132, 45)   Warning text
     {"#B4B4B4", "#73737D"}, // rgb(180, 180, 180)  Preview/strip border
     {"#E7E7E7", "#54545B"}, // rgb(231, 231, 231)  MixedFilament preview panel background
-    {"#939393", "#000000"}, // rgb(147, 147, 147)  MixedFilament preview badge (dark = pure black)
+    // NOTE: removed {"#939393","#000000"} — its dark value #000000 collided with
+    // {"#000000","#FFFFFE"} in revert()'s reverse map and broke lightModeColorFor(#000000).
     {"#D1D5DC", "#52525B"}, // rgb(209, 213, 220)  Cancel button border
     {"#FF0000", "#FF5252"}, // rgb(255, 0, 0)      Hex input error border
     {"#019687", "#00675B"}, // rgb(1, 150, 135)    Confirm button bg (near #009688)


### PR DESCRIPTION
## Summary

Three independent improvements to the Color Mixing Match (Mixed Filament Batch) dialog, built on top of `feat_mix_filament_Phase2`.

### 1. Gate Recommended mode on Full Spectrum preset existence (instead of hard-coded 0.4 mm)
- **Before:** Recommended (auto) mode was blocked unless the nozzle was exactly 0.4 mm — a hard-coded check.
- **After:** The guard now asks `full_spectrum_preset_exists_for_current_nozzle()`: Recommended is available iff a Full Spectrum preset exists for the *current* nozzle diameter.
- Shipping a new nozzle variant (0.2 / 0.6 / 0.8) now only requires dropping its preset JSON under `resources/profiles/Snapmaker/filament/` — no code change, no re-gate.
- `MixedColorMatchHelpers` refactored: `full_spectrum_preset_name()` split into `current_nozzle_diameter()` + `format_nozzle_label()` (anonymous-namespace helpers) + the new `full_spectrum_preset_exists_for_current_nozzle()`.

### 2. Fix StateColor reverse-lookup collision (badge dark-mode)
- **Bug:** `gDarkColors` had `{"#939393","#000000"}`. Its dark value `#000000` collided with the existing `{"#000000","#FFFFFE"}` entry: `revert()` builds the light-mode map via `emplace()`, and the `#939393` line won the `#000000` key, so `lightModeColorFor(#000000)` wrongly returned `#939393`. This turned every default-black-foreground control (e.g. Slice/Print SideButtons) grey at startup.
- **Fix:** removed the colliding entry; the MixedFilament badge now resolves its colour inline via `wxGetApp().dark_mode()` instead of the shared dark map.

### 3. Mixed-filament dialog cleanup
- Extract ΔE grade thresholds (`kDeltaEGoodMax` / `kDeltaEFairMax`) to named constants.
- Remove the pre-match dominance warning (`check_manual_filament_ratio` + `kManualDominantRatioPct`). Manual mode keeps only the **post-match** ratio guard (`check_manual_recipe_ratio`): any ratio warning surfaces after a match completes, not before. A combo change now just retires the banner (or re-runs the post-match check if a match already finished).
- Remove the info-tip button next to the "Color Mapping" title.

## Files
- `src/slic3r/GUI/MixedColorMatchHelpers.{cpp,hpp}` — nozzle resolution refactor + `full_spectrum_preset_exists_for_current_nozzle()`
- `src/slic3r/GUI/MixedFilamentBatchDialog.{cpp,hpp}` — preset-driven guard, tip-button removal, threshold constants
- `src/slic3r/GUI/Widgets/StateColor.cpp` — remove colliding map entry


## Test plan
- [ ] Build on Windows / macOS / Linux
- [ ] 0.4 mm nozzle: Recommended mode available, match runs end-to-end
- [ ] Non-Full-Spectrum nozzle (e.g. 0.6/0.8 without preset): Recommended blocked with the dialog; Manual mode unaffected
- [ ] Dark mode: startup text colours correct (no grey SideButtons); badge renders black bg + white text legibly
- [ ] Manual mode: combo flip / add / remove filament re-evaluates ratio warnings

## Notes
- This branch was rebased/merged onto upstream `feat_mix_filament_Phase2` (PR #649, #650). The upstream ratio-warning persistence (`check_manual_filament_ratio`) was kept over this branch's earlier removal — upstream's version is more complete.