### PR TITLE
fix: ironing fan speed not restored after ironing ends

### DIFF
--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -877,7 +877,7 @@ std::string CoolingBuffer::apply_layer_cooldown(
                 fan_speed_change_requests[CoolingLine::TYPE_IRONING_FAN_START] = true;
                 need_set_fan = true;
             }
-        } else if (line->type & CoolingLine::TYPE_IRONING_FAN_END && fan_speed_change_requests[CoolingLine::TYPE_IRONING_FAN_START]) {
+        } else if (line->type & CoolingLine::TYPE_IRONING_FAN_END) {
             if (ironing_fan_control) {
                 fan_speed_change_requests[CoolingLine::TYPE_IRONING_FAN_START] = false;
             }
@@ -996,8 +996,10 @@ std::string CoolingBuffer::apply_layer_cooldown(
                 new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_current_fan_speed);
                 fan_speed_change_requests[CoolingLine::TYPE_FORCE_RESUME_FAN] = false;
             }
-            else
+            else {
+                m_current_fan_speed = m_fan_speed;
                 new_gcode += GCodeWriter::set_fan(m_config.gcode_flavor, m_fan_speed);
+            }
             need_set_fan = false;
         }
         pos = line_end;


### PR DESCRIPTION
# Description

This PR fixes an issue where the part-cooling fan speed was not restored after an ironing path finished.

The ironing fan speed is a temporary override that should only apply while printing ironing paths. After leaving ironing, the fan should return to the speed calculated by the existing cooling logic.

Before this fix:

```text
Normal path: 100%
→ Ironing path: 50%
→ Next non-ironing path: 50%
```

Expected behavior:

```text
Normal path: 100%
→ Ironing path: 50%
→ Next non-ironing path: 100%
```

## Root Cause

`CoolingBuffer::apply_layer_cooldown()` creates a new `fan_speed_change_requests` map for each CoolingBuffer processing batch.

The original `TYPE_IRONING_FAN_END` handler required the current batch to contain both `_IRONING_FAN_START` and `_IRONING_FAN_END`.

When ironing was the final extrusion role before a flush boundary, the markers could be split across two batches:

```text
Batch N:
_IRONING_FAN_START
Ironing paths
Flush

Batch N+1:
_IRONING_FAN_END
Non-ironing paths
```

The map was recreated for batch N+1, so the `TYPE_IRONING_FAN_START` flag was reset to `false`.

As a result, the END handler was skipped, no restoring `M106` command was generated, and subsequent non-ironing paths continued using the ironing fan speed.

## Changes

### 1. Process `TYPE_IRONING_FAN_END` across batch boundaries

The same-batch START condition was removed from the END handler.

```cpp
// Before
} else if (
    line->type & CoolingLine::TYPE_IRONING_FAN_END &&
    fan_speed_change_requests[
        CoolingLine::TYPE_IRONING_FAN_START
    ]
) {

// After
} else if (
    line->type & CoolingLine::TYPE_IRONING_FAN_END
) {
```

A valid `_IRONING_FAN_END` marker can now restore the fan speed even when its matching START marker was processed in the previous batch.

### 2. Synchronize the cached current fan speed

The restore branch now updates `m_current_fan_speed` before emitting the restoring fan command:

```cpp
m_current_fan_speed = m_fan_speed;
new_gcode += GCodeWriter::set_fan(
    m_config.gcode_flavor,
    m_fan_speed
);
```

This keeps the internal cached fan state consistent with the fan speed written to G-code.

The restored value is not hard-coded to `100%`. It uses `m_fan_speed`, which is calculated by the existing cooling logic.

## Compatibility

This change does not modify:

- Ironing toolpaths.
- Extrusion amounts.
- Toolpath ordering.
- Normal cooling calculations.
- Bridge or overhang fan settings.
- Auxiliary or exhaust fan behavior.

There are no breaking changes or new external dependencies introduced by this PR.

# Screenshots/Recordings/Graphs

## Before

After an ironing path finished, subsequent non-ironing paths could continue using the ironing fan speed.

```text
Normal: 100%
→ Ironing: 50%
→ Non-ironing: 50%
```

<img width="2511" height="1356" alt="image" src="https://github.com/user-attachments/assets/e8199b5a-f136-4c05-85a8-852d81741111" />

## After

The fan speed is restored when leaving ironing, including when START and END are separated by a CoolingBuffer flush boundary.

```text
Normal: 100%
→ Ironing: 50%
→ Non-ironing: 100%
```

<img width="2533" height="1373" alt="image" src="https://github.com/user-attachments/assets/ba7511c1-0a68-49a0-b614-dbb76baa9e6f" />

# Tests

## Build

- [x] Built the `libslic3r` Release target successfully.
- [x] Generated `libslic3r.lib`.
- [x] Build completed with 0 errors and 0 warnings.


## Manual Tests

- [x] Verified `100% normal → 50% ironing → 100% normal`.
- [x] Verified fan restoration when START and END are separated by a layer/CoolingBuffer batch boundary.
- [x] Verified `70% normal → 50% ironing → 70% normal`.
- [x] Verified that the restored speed is not hard-coded to `100%`.
- [x] Verified fan restoration when START and END are processed in the same batch.
- [x] Verified repeated transitions across multiple ironing regions.
- [x] Disabled ironing and verified that the existing normal cooling behavior remains unchanged.