### PR TITLE
fix: download cancel crash + error reasons + early-notify replay

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -3365,6 +3365,18 @@ msgstr "下载已取消"
 msgid "Download Failed"
 msgstr "下载失败"
 
+msgid "Insufficient disk space."
+msgstr "磁盘空间不足"
+
+msgid "File was removed. Download canceled."
+msgstr "文件已被移除，下载中断"
+
+msgid "Network timeout"
+msgstr "网络连接超时"
+
+msgid "Request timed out. Please check the device connection."
+msgstr "加载超时，请检查设备连接。"
+
 msgid "Flow Dynamic Calibration"
 msgstr "动态流量校准"
 

--- a/src/slic3r/GUI/DownloadManager.cpp
+++ b/src/slic3r/GUI/DownloadManager.cpp
@@ -271,6 +271,11 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
                         return;
                     }
 
+                    if (task->callbacks.on_should_write && !task->callbacks.on_should_write()) {
+                        cleanup_task(task->task_id);
+                        return;
+                    }
+
                     try {
                         boost::nowide::ofstream file(task->dest_path, std::ios::binary);
                         if (!file.is_open()) {

--- a/src/slic3r/GUI/DownloadManager.hpp
+++ b/src/slic3r/GUI/DownloadManager.hpp
@@ -30,6 +30,8 @@ struct DownloadCallbacks {
     std::function<void(size_t task_id, int percent, size_t downloaded, size_t total)> on_progress;
     std::function<void(size_t task_id, const std::string& file_path)> on_complete;
     std::function<void(size_t task_id, const std::string& error)> on_error;
+    // Called right before writing the downloaded body to disk.
+    std::function<bool()> on_should_write;
     
     DownloadCallbacks() = default;
     DownloadCallbacks(

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -4830,6 +4830,7 @@ struct WanPendingEntry { std::shared_ptr<TimelapseQueueContext> ctx; int idx; };
 
 static std::unordered_map<std::string, WanPendingEntry> g_wan_pending;
 static std::mutex g_wan_pending_mtx;
+static std::unordered_map<std::string, std::string> g_pending_upload_notifications;
 
 // Shared download popup (one at a time) + active batch list + date_index dedup.
 // Multiple sw_DownLoadFile calls append to the same popup; a file whose
@@ -4934,8 +4935,8 @@ void cancel_all_active_timelapse()
             push_file_state(ctx, i, "failed");
             release_date_index(ctx->files[i].date_index);
             if (ctx->popup && !ctx->popup->IsBeingDeleted()) {
-                // Empty reason → mark_task_error falls back to "Download Failed".
-                ctx->popup->mark_task_error(ctx->row_offset + i, "");
+                ctx->popup->mark_task_error(ctx->row_offset + i,
+                    std::string(_L("File was removed. Download canceled.").ToUTF8().data()));
             }
         }
     }
@@ -5165,6 +5166,7 @@ void SSWCP_UserLogin_Instance::sw_NotifyUploadTimelaspe()
                 std::lock_guard<std::mutex> lk(g_wan_pending_mtx);
                 auto it = g_wan_pending.find(date_index);
                 if (it == g_wan_pending.end()) {
+                    g_pending_upload_notifications[date_index] = url;
                     continue;
                 }
                 entry = it->second;
@@ -5400,9 +5402,27 @@ void SSWCP_UserLogin_Instance::sw_DownLoadFile()
         // WAN: register each file by date_index so sw_NotifyUploadTimelaspe can
         // find it when flutter forwards the device upload url.
         if (ctx->is_wan) {
-            std::lock_guard<std::mutex> lk(g_wan_pending_mtx);
-            for (int i = 0; i < total_count; ++i) {
-                g_wan_pending[unique_files[i].date_index] = { ctx, i };
+            // Register each date_index and replay any upload notification that arrived before this registration
+            std::vector<std::pair<int, std::string>> replay;
+            {
+                std::lock_guard<std::mutex> lk(g_wan_pending_mtx);
+                for (int i = 0; i < total_count; ++i) {
+                    g_wan_pending[unique_files[i].date_index] = { ctx, i };
+                    auto nit = g_pending_upload_notifications.find(unique_files[i].date_index);
+                    if (nit != g_pending_upload_notifications.end()) {
+                        replay.emplace_back(i, nit->second);
+                        g_pending_upload_notifications.erase(nit);
+                    }
+                }
+            }
+            for (auto& r : replay) {
+                int idx = r.first;
+                std::string url = r.second;
+                wxGetApp().CallAfter([ctx, idx, url]() {
+                    if (!ctx || ctx->cancelled) return;
+                    if (ctx->skipped_indices.count(idx)) return;
+                    ctx->kickoff_download(idx, url);
+                });
             }
         }
 
@@ -5562,7 +5582,14 @@ void SSWCP_UserLogin_Instance::sw_DownLoadFile()
 
                 if (ctx->popup && !ctx->popup->IsBeingDeleted())
                 {
-                    ctx->popup->mark_task_error(global_row, error);
+                    // Map Http timeout to a friendly reason.
+                    bool is_timeout = error.find("timeout") != std::string::npos
+                                   || error.find("Timeout") != std::string::npos
+                                   || error.find("timed out") != std::string::npos;
+                    std::string reason = is_timeout
+                        ? std::string(_L("Network timeout").ToUTF8().data())
+                        : error;
+                    ctx->popup->mark_task_error(global_row, reason);
                 }
 
                 push_file_state(ctx, idx, "failed");
@@ -5591,6 +5618,10 @@ void SSWCP_UserLogin_Instance::sw_DownLoadFile()
                     ctx->current_index = idx + 1;
                     if (ctx->start_next) { ctx->start_next(); }
                 }
+            };
+
+            callbacks.on_should_write = [ctx, idx]() {
+                return !ctx->skipped_indices.count(idx);
             };
 
             ctx->current_task_id = DownloadManager::getInstance().start_internal_download(
@@ -5680,7 +5711,14 @@ void SSWCP_UserLogin_Instance::sw_DownLoadFile()
                 }
                 unsubscribe_wan_upload(c);
                 c->cancelled = true;
+                c->popup = nullptr;
             }
+
+            if (g_timelapse_popup && !g_timelapse_popup->IsBeingDeleted()) {
+                g_timelapse_popup->Destroy();
+            }
+            g_timelapse_popup = nullptr;
+            // Push cancelled state on next idle (doesn't touch the popup).
             wxGetApp().CallAfter([ctxs]() {
                 for (auto& c : ctxs) {
                     for (int i = 0; i < c->total_count; ++i) {
@@ -5690,12 +5728,6 @@ void SSWCP_UserLogin_Instance::sw_DownLoadFile()
                         wcp->finish_job();
                     }
                 }
-                // Destroy the shared popup and clear the singleton pointer so
-                // the next sw_DownLoadFile creates a fresh one.
-                if (g_timelapse_popup && !g_timelapse_popup->IsBeingDeleted()) {
-                    g_timelapse_popup->Destroy();
-                }
-                g_timelapse_popup = nullptr;
             });
         });
 


### PR DESCRIPTION
# Description

- on_should_write: skip writing the file if the user cancelled (skipped_indices) even when Http already finished the body
- Early sw_NotifyUploadTimelaspe (before g_wan_pending registration) is now cached and replayed once sw_DownLoadFile registers — fixes intermittent "stuck on waiting for device upload"
- close callback nulls ctx->popup before destroying the popup, preventing use-after-free if cancel_active / on_error touches ctx->popup afterwards
- Error reason messages: "Network timeout" (Http timeout), "File was removed. Download canceled." (file deleted mid-download), plus .po translations
- g_pending_upload_notifications simplified to map<string,string>

