### PR TITLE
chore: downgrade WebSocket debug log levels from info/warning to debug

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3079,7 +3079,7 @@ bool GUI_App::on_init_inner()
     // When off, explicitly stop the debug server so port 8766 is not left listening.
     const bool websocket_debug_pref = app_config->get_bool("websocket_debug");
     if (websocket_debug_pref) {
-        BOOST_LOG_TRIVIAL(info) << "Web Debug Mode enabled in preferences, starting WebSocket debug server (port 8766)";
+        BOOST_LOG_TRIVIAL(debug) << "Web Debug Mode enabled in preferences, starting WebSocket debug server (port 8766)";
         Slic3r::GUI::SSWCP::enable_debug_mode(true);
     } else {
         Slic3r::GUI::SSWCP::enable_debug_mode(false);

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -6782,15 +6782,15 @@ void SSWCP::enable_debug_mode(bool enable, unsigned short port)
 
         if (m_debug_server->start()) {
             m_debug_mode_enabled = true;
-            BOOST_LOG_TRIVIAL(info) << " WebSocket debug mode enabled successfully";
-            BOOST_LOG_TRIVIAL(info) << " Flutter Web can connect to: ws://localhost:" << port;
+            BOOST_LOG_TRIVIAL(debug) << " WebSocket debug mode enabled successfully";
+            BOOST_LOG_TRIVIAL(debug) << " Flutter Web can connect to: ws://localhost:" << port;
         } else {
             BOOST_LOG_TRIVIAL(error) << "Failed to start WebSocket debug server";
             m_debug_server.reset();
             m_debug_mode_enabled = false;
         }
     } else if (!enable && m_debug_server) {
-        BOOST_LOG_TRIVIAL(info) << "Disabling WebSocket debug mode";
+        BOOST_LOG_TRIVIAL(debug) << "Disabling WebSocket debug mode";
         m_debug_server->stop();
         m_debug_server.reset();
         m_debug_mode_enabled = false;
@@ -6815,7 +6815,7 @@ void SSWCP::send_message_to_flutter(const std::string& message)
     if (m_debug_server && m_debug_mode_enabled) {
         m_debug_server->send_message(message);
     } else {
-        BOOST_LOG_TRIVIAL(warning) << "Cannot send message: WebSocket debug mode not enabled";
+        BOOST_LOG_TRIVIAL(debug) << "Cannot send message: WebSocket debug mode not enabled";
     }
 }
 


### PR DESCRIPTION
## Summary
Downgrade WebSocket debug server log levels to reduce log noise in production.

## Changes
- `GUI_App.cpp`: `info` → `debug` — "Web Debug Mode enabled in preferences" message
- `SSWCP.cpp`:
  - `info` → `debug` — "WebSocket debug mode enabled successfully"
  - `info` → `debug` — "Flutter Web can connect to" address hint
  - `info` → `debug` — "Disabling WebSocket debug mode"
  - `warning` → `debug` — "Cannot send message: WebSocket debug mode not enabled"

## Rationale
These are debug-mode lifecycle messages that are expected during normal operation. Logging them at `info`/`warning` level clutters production logs; `debug` level keeps them available when needed without the noise.