### PR TITLE
Fix 3MF project-load crash from unavailable plate picker

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -1322,6 +1322,9 @@ void PartPlate::render_right_arrow(const ColorRGBA render_color, bool use_lighti
 
 static void register_model_for_picking(GLCanvas3D &canvas, PickingModel &model, int id)
 {
+    if (model.mesh_raycaster == nullptr)
+        return;
+
     canvas.add_raycaster_for_picking(SceneRaycaster::EType::Bed, id, *model.mesh_raycaster, Transform3d::Identity());
 }
 


### PR DESCRIPTION
## Summary\n\nFixes a crash while loading certain 3MF projects.\n\nDuring project reload, a plate picker can be registered before its mesh raycaster has been built. Later mouse picking dereferences that unavailable picker. This adds the same early-return guard used by current upstream OrcaSlicer so unavailable picker meshes are skipped until initialized.\n\n## Validation\n\n- Built Snapmaker_Orca locally in Release with /m:1.\n- Opened drago.3mf and ed+dragon+head+3d+model.3mf with the rebuilt runtime; both remained alive and responsive after load.\n- Change is limited to src/slic3r/GUI/PartPlate.cpp.\n\nNo AMP or surface-color-assist changes are included.