### PR TITLE
Show unmatched machine filaments as Generic by material type

### DIFF
--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -151,6 +151,60 @@ wxBitmap* GetFilamentColorPickerBitmap(const DynamicPrintConfig& config,
                                                     std::max(1, size.GetWidth()), std::max(1, size.GetHeight()));
 }
 
+// Resolve a machine filament name to a compatible local preset.
+// Tries exact name variants for U1/nozzle first, then falls back to
+// "Generic <filament_type>" so unmatched brands (e.g. Voolt3D PLA)
+// still appear under Machine Filament with the printer-reported color.
+std::deque<Preset>::const_iterator find_compatible_machine_filament_preset(
+    const std::deque<Preset>& filaments,
+    const std::string& filament_name,
+    const std::string& filament_type,
+    const std::string& machine_nozzles)
+{
+    auto match_by_name = [&filaments, &machine_nozzles](const std::string& name)
+        -> std::deque<Preset>::const_iterator {
+        if (name.empty())
+            return filaments.end();
+
+        const std::string candidates[] = {
+            name + " @U1 " + machine_nozzles + " nozzle",
+            name + " @U1 " + machine_nozzles,
+            name + " @U1",
+            name,
+        };
+
+        for (const std::string& candidate : candidates) {
+            auto item_iter = std::find_if(filaments.begin(), filaments.end(),
+                [&candidate](const Preset& f) {
+                    return f.is_compatible && f.name == candidate;
+                });
+            if (item_iter != filaments.end())
+                return item_iter;
+        }
+        return filaments.end();
+    };
+
+    if (!filament_name.empty()) {
+        auto item_iter = match_by_name(filament_name);
+        if (item_iter != filaments.end())
+            return item_iter;
+    }
+
+    if (!filament_type.empty() && filament_type != "NONE") {
+        const std::string generic_name = "Generic " + filament_type;
+        auto item_iter = match_by_name(generic_name);
+        if (item_iter != filaments.end()) {
+            const std::string preset_type =
+                item_iter->config.opt_string("filament_type", static_cast<unsigned int>(0));
+            // Exact type check avoids Generic PLA matching Generic PLA-CF etc.
+            if (boost::algorithm::iequals(preset_type, filament_type))
+                return item_iter;
+        }
+    }
+
+    return filaments.end();
+}
+
 } // namespace
 
 // ---------------------------------
@@ -1411,32 +1465,15 @@ void PlaterPresetComboBox::update()
         
         for (int i = 0; i < machine_nozzles_list.size(); i++) {
             std::string filament_name   = machine_nozzles_list[i].filament_info;
+            std::string filament_type   = machine_nozzles_list[i].filament_type;
             std::string machine_nozzles = machine_nozzles_list[i].nozzle_info;
 
             // Filter by nozzle for display only; machine_filaments / m_connect_machine_info_list stay from sync (SSWCP).
             if (currentNozzleInfo != machine_nozzles)
                 continue;
 
-            auto item_iter = std::find_if(filaments.begin(), filaments.end(),
-            [&filament_name, &machine_nozzles, &currentNozzleInfo](auto& f) {
-                if (f.name == filament_name + " @U1 " + machine_nozzles + " nozzle")
-                    if (f.is_compatible)
-                        return true;
-                
-                if (f.name == filament_name + " @U1 " + machine_nozzles)
-                    if (f.is_compatible)
-                        return true;
-
-                if (f.name == filament_name + " @U1")
-                    if (f.is_compatible)
-                        return true;
-
-                if (f.name == filament_name)
-                    if (f.is_compatible)
-                        return true;
-
-                return false;
-            });
+            auto item_iter = find_compatible_machine_filament_preset(
+                filaments, filament_name, filament_type, machine_nozzles);
 
             if (item_iter != filaments.end()) {
                 const_cast<Preset&>(*item_iter).is_visible = true;
@@ -1983,31 +2020,14 @@ void TabPresetComboBox::update()
 
         for (int i = 0; i < machine_nozzles_list.size(); i++) {
             std::string filament_name   = machine_nozzles_list[i].filament_info;
+            std::string filament_type   = machine_nozzles_list[i].filament_type;
             std::string machine_nozzles = machine_nozzles_list[i].nozzle_info;
 
             if (currentNozzleInfo != machine_nozzles)
                 continue;
 
-            auto item_iter = std::find_if(filaments.begin(), filaments.end(),[&filament_name, &machine_nozzles, &currentNozzleInfo](auto& f) {               
-
-                if (f.name == filament_name + " @U1 " + machine_nozzles + " nozzle")
-                    if (f.is_compatible)
-                        return true;
-                
-                if (f.name == filament_name + " @U1 " + machine_nozzles)
-                    if (f.is_compatible)
-                        return true;
-                
-                if (f.name == filament_name + " @U1")
-                    if (f.is_compatible)
-                        return true;
-
-                if (f.name == filament_name)
-                    if (f.is_compatible)
-                        return true;
-
-                return false;                
-                });
+            auto item_iter = find_compatible_machine_filament_preset(
+                filaments, filament_name, filament_type, machine_nozzles);
 
             if (item_iter != filaments.end()) {
                 const_cast<Preset&>(*item_iter).is_visible = true;


### PR DESCRIPTION
# Description

When a filament loaded on the printer has no exact matching local profile (for example a third-party brand like **Voolt3D PLA**), it was previously omitted from the **Machine Filament** list entirely. That made it hard to pick the correct slot and, more importantly, to keep the printer-reported color.

This PR adds a fallback resolution path for Machine Filament entries:

1. Try an exact compatible match for the machine filament name (including `@U1` / nozzle variants), same as before.
2. If that fails, fall back to a compatible **`Generic <filament_type>`** preset (e.g. PLA → `Generic PLA`).
3. Keep using the color / multi-color data reported by the printer for the icon.
4. If neither an exact nor a generic compatible preset exists, still omit the entry (no incompatible presets shown).

The matching logic is shared through a small helper used by both `PlaterPresetComboBox` and `TabPresetComboBox`, so sidebar and Filament tab stay consistent. Exact material-type checks avoid false matches such as PLA vs PLA-CF.

## Motivation

Color accuracy matters a lot when mapping design filaments to machine slots. Hiding unmatched brands made that workflow worse for any filament without a dedicated Snapmaker profile.

# Screenshots/Recordings/Graphs

_Before:_ third-party filaments without a perfect profile match did not appear under Machine Filament.
<img width="774" height="222" alt="image" src="https://github.com/user-attachments/assets/78a8f20e-933b-4857-8906-6621524e2e4c" />
<img width="340" height="150" alt="image" src="https://github.com/user-attachments/assets/c91b913e-73ab-4786-80ba-d8027a0f03c3" />

_After:_ they appear as the matching Generic material profile (e.g. Generic PLA) while preserving the printer color swatch.
<img width="142" height="201" alt="image" src="https://github.com/user-attachments/assets/4f0f2ea1-73e8-4da1-bd0f-605ef2c9f3c1" />
<img width="778" height="232" alt="image" src="https://github.com/user-attachments/assets/f5f6d5e8-86d5-4e48-852b-d824d686b7a6" />
<img width="278" height="170" alt="image" src="https://github.com/user-attachments/assets/005e2dfb-ee39-4756-914d-6b7f397f8190" />

## Tests

- [x] Built Release slicer successfully on Windows (VS 2022)
- [x] Connect a printer with a third-party PLA (no dedicated profile) and confirm it appears under **Machine Filament** as **Generic PLA** with the correct color
- [x] Confirm filaments that already have an exact compatible profile still resolve to that profile (no unintended generic fallback)
- [x] Confirm other material types fall back to their own generic preset (e.g. PETG → Generic PETG)
- [x] Confirm nozzle-diameter filtering still hides slots for a different nozzle size
- [x] Confirm that if no Generic preset is compatible, the entry remains hidden (no incompatible preset shown)
