### PR TITLE
# fix(support): port Bambu cantilever floating-contour detection to fix large ring overhangs being dropped

### DIFF
--- a/src/libslic3r/ExPolygon.cpp
+++ b/src/libslic3r/ExPolygon.cpp
@@ -548,4 +548,39 @@ void keep_largest_contour_only(ExPolygons &polygons)
 	}
 }
 
+// Split an expolygon with holes into up to 4 sub-expolygons along the centroid of the largest hole.
+// Ported from Bambu 976b5062c.
+ExPolygons ExPolygon::split_expoly_with_holes(coord_t gap_width, const ExPolygons& collision) const
+{
+    ExPolygons sub_overhangs;
+    Polygon    max_hole;
+    coordf_t   max_area = 0;
+    bool       is_collided = false;
+    for (const auto &hole : this->holes) {
+        if (!is_collided && Slic3r::overlaps({ExPolygon(hole)}, collision)) {
+            max_area = abs(hole.area());
+            max_hole = hole;
+            is_collided = true;
+        } else if (is_collided && Slic3r::overlaps({ExPolygon(hole)}, collision) && abs(hole.area()) > max_area) {
+            max_area = abs(hole.area());
+            max_hole = hole;
+        } else if (!is_collided && !Slic3r::overlaps({ExPolygon(hole)}, collision) && abs(hole.area()) > max_area) {
+            max_area = abs(hole.area());
+            max_hole = hole;
+        }
+    }
+    Point cent;
+    if (max_hole.size() > 0) {
+        auto overhang_bbx = get_extents(*this);
+        cent = max_hole.centroid();
+        append(sub_overhangs, intersection_ex(ExPolygon(BoundingBox(overhang_bbx.min, Point(cent.x() - gap_width, cent.y() - gap_width)).polygon()), *this));
+        append(sub_overhangs, intersection_ex(ExPolygon(BoundingBox(Point(cent.x() + gap_width, cent.y() + gap_width), overhang_bbx.max).polygon()), *this));
+        append(sub_overhangs,
+               intersection_ex(ExPolygon(BoundingBox(Point(overhang_bbx.min(0), cent.y() + gap_width), Point(cent.x() - gap_width, overhang_bbx.max(1))).polygon()), *this));
+        append(sub_overhangs,
+               intersection_ex(ExPolygon(BoundingBox(Point(cent.x() + gap_width, overhang_bbx.min(1)), Point(overhang_bbx.max(0), cent.y() - gap_width)).polygon()), *this));
+    }
+    return sub_overhangs;
+}
+
 } // namespace Slic3r

--- a/src/libslic3r/ExPolygon.hpp
+++ b/src/libslic3r/ExPolygon.hpp
@@ -80,6 +80,10 @@ public:
     size_t   		num_contours() const { return this->holes.size() + 1; }
     Polygon& 		contour_or_hole(size_t idx) 		{ return (idx == 0) ? this->contour : this->holes[idx - 1]; }
     const Polygon& 	contour_or_hole(size_t idx) const 	{ return (idx == 0) ? this->contour : this->holes[idx - 1]; }
+
+    // Split an expolygon with holes into up to 4 sub-expolygons,
+    // cutting along the centroid of the largest hole. Ported from Bambu 976b5062c.
+    ExPolygons split_expoly_with_holes(coord_t gap_width, const ExPolygons& collision) const;
 };
 
 inline bool operator==(const ExPolygon &lhs, const ExPolygon &rhs) { return lhs.contour == rhs.contour && lhs.holes == rhs.holes; }

--- a/src/libslic3r/Layer.hpp
+++ b/src/libslic3r/Layer.hpp
@@ -157,6 +157,7 @@ public:
 
     // BBS
     ExPolygons              loverhangs;
+    std::vector<std::pair<ExPolygon, int>> loverhangs_with_type;
     BoundingBox             loverhangs_bbox;
     size_t                  region_count() const { return m_regions.size(); }
     const LayerRegion*      get_region(int idx) const { return m_regions[idx]; }

--- a/src/libslic3r/Point.hpp
+++ b/src/libslic3r/Point.hpp
@@ -221,6 +221,14 @@ public:
             return this->x() < rhs.x() || this->y() < rhs.y();
         return false;
     }
+    bool any_comp(const coord_t val, const std::string &op)
+    {
+        if (op == ">")
+            return this->x() > val || this->y() > val;
+        else if (op == "<")
+            return this->x() < val || this->y() < val;
+        return false;
+    }
 
     void   rotate(double angle) { this->rotate(std::cos(angle), std::sin(angle)); }
     void   rotate(double cos_a, double sin_a) {

--- a/src/libslic3r/Support/SupportCommon.hpp
+++ b/src/libslic3r/Support/SupportCommon.hpp
@@ -4,6 +4,8 @@
 #include "../Layer.hpp"
 #include "../Polygon.hpp"
 #include "../Print.hpp"
+#include "../ClipperUtils.hpp"
+#include "../ExPolygon.hpp"
 #include "SupportLayer.hpp"
 #include "SupportParameters.hpp"
 
@@ -150,6 +152,59 @@ template<typename T, typename FN_LOWER_EQUAL>
 int idx_lower_or_equal(const std::vector<T*> &vec, int idx, FN_LOWER_EQUAL fn_lower_equal)
 {
     return idx_lower_or_equal(vec.begin(), vec.end(), idx, fn_lower_equal);
+}
+
+/*!
+ * \brief Safely offset ExPolygons in steps, checking collision each step.
+ *
+ * Ported from Bambu Studio to fix tree-support transition-layer fragmentation.
+ * Uses union_ex instead of safe_union to avoid an extra ExPolygons dependency.
+ */
+template<typename CollisionPolyType>
+[[nodiscard]] ExPolygons safe_offset_inc(
+    const ExPolygons &me, coord_t distance, const CollisionPolyType &collision, coord_t safe_step_size, coord_t last_step_offset_without_check, size_t min_amount_offset)
+{
+    bool     do_final_difference = last_step_offset_without_check == 0;
+    ExPolygons ret               = union_ex(me); // ensure sane input
+
+    Polygons collision_trimmed_buffer;
+    auto     collision_trimmed = [&collision_trimmed_buffer, &collision, &ret, distance]() -> const Polygons &{
+        if (collision_trimmed_buffer.empty() && !collision.empty())
+            collision_trimmed_buffer = ClipperUtils::clip_clipper_polygons_with_subject_bbox(collision, get_extents(ret).inflated(std::max<coord_t>(0, distance) + SCALED_EPSILON));
+        return collision_trimmed_buffer;
+    };
+
+    if (distance == 0) return do_final_difference ? diff_ex(ret, collision_trimmed()) : union_ex(ret);
+    if (safe_step_size < 0 || last_step_offset_without_check < 0) {
+        return do_final_difference ? diff_ex(ret, collision_trimmed()) : union_ex(ret);
+    }
+
+    coord_t step_size = safe_step_size;
+    int     steps     = distance > last_step_offset_without_check ? (distance - last_step_offset_without_check) / step_size : 0;
+    if (distance - steps * step_size > last_step_offset_without_check) {
+        if ((steps + 1) * step_size <= distance)
+            ++steps;
+        else
+            do_final_difference = true;
+    }
+    if (steps + (distance < last_step_offset_without_check || (distance % step_size) != 0) < int(min_amount_offset) && min_amount_offset > 1) {
+        step_size = distance / min_amount_offset;
+        if (step_size >= safe_step_size) {
+            step_size = safe_step_size;
+            steps     = min_amount_offset;
+        } else
+            steps = distance / step_size;
+    }
+    for (int i = 0; i < steps; ++i) {
+        ret = diff_ex(offset_ex(ret, step_size, ClipperLib::jtRound, scaled<float>(0.01)), collision_trimmed());
+        if (i % 10 == 7) ret = expolygons_simplify(ret, scaled<double>(0.015));
+    }
+    float last_offset = distance - steps * step_size;
+    if (last_offset > SCALED_EPSILON) ret = offset_ex(ret, distance - steps * step_size, ClipperLib::jtRound, scaled<float>(0.01));
+    ret = expolygons_simplify(ret, scaled<double>(0.015));
+
+    if (do_final_difference) ret = diff_ex(ret, collision_trimmed());
+    return union_ex(ret);
 }
 
 } // namespace Slic3r

--- a/src/libslic3r/Support/SupportParameters.hpp
+++ b/src/libslic3r/Support/SupportParameters.hpp
@@ -291,7 +291,10 @@ struct SupportParameters {
     	{ return this->raft_angle_interface + ((interface_id & 1) ? float(- M_PI / 4.) : float(+ M_PI / 4.)); }
 		
     bool independent_layer_height = false;
-    const double thresh_big_overhang = Slic3r::sqr(scale_(10));
+    // Changed from sqr(scale_(10)) [area, 100mm^2] to scale_(10) [length, 10mm].
+    // check_polygon_node applies SQ() internally to restore area comparison.
+    // Ported from Bambu 976b5062c.
+    const double thresh_big_overhang = scale_(10);
 
 	bool          ironing;
     Flow          ironing_flow; // Flow at the interface ironing.

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -905,7 +905,7 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
                 if (layer->lower_layer == nullptr) {
                     for (auto& slice : layer->lslices_extrudable) {
                         auto bbox_size = get_extents(slice).size();
-                        if (!((bbox_size.x() > length_thresh_well_supported && bbox_size.y() > length_thresh_well_supported))
+                        if (!(bbox_size.x() > length_thresh_well_supported || bbox_size.y() > length_thresh_well_supported)
                             && g_config_support_sharp_tails) {
                             layer->sharp_tails.push_back(slice);
                             layer->sharp_tails_height.push_back(layer->height);
@@ -939,8 +939,21 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
                         bool  is_sharp_tail = false;
                         // 1. nothing below
                         // this is a sharp tail region if it's floating and non-ignorable
-                        if (!overlaps(offset_ex(expoly, 0.1 * extrusion_width_scaled), lower_polys)) {
+                        // The (area && bbox) gate excludes "large looped structures" but also catches
+                        // thin-but-wide rings (small area, large bbox), which would otherwise be dropped
+                        // by check_small_overhang and end up unsupported. Rescue them here: if eroding by
+                        // radius_thresh_small_overhang (the same radius small-overhang detection uses)
+                        // makes the polygon vanish, treat it as a sharp tail regardless of bbox.
+                        if (!overlaps(offset_ex(expoly, 0.1 * extrusion_width_scaled), lower_polys) &&
+                            area(expoly) < SQ(m_support_params.thresh_big_overhang) &&
+                            (get_extents(expoly).area() < SQ(m_support_params.thresh_big_overhang) ||
+                             offset_ex(expoly, -radius_thresh_small_overhang).empty())) {
                             is_sharp_tail = !offset_ex(expoly, -0.1 * extrusion_width_scaled).empty();
+                        }
+
+                        if (is_sharp_tail && lower_layer->lower_layer) {
+                            if (overlaps(offset_ex(expoly, 0.1 * extrusion_width_scaled), lower_layer->lower_layer->lslices_extrudable))
+                                is_sharp_tail = false;
                         }
 
                         if (is_sharp_tail) {
@@ -957,22 +970,49 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
 
 
                 // check cantilever
+                auto lower_layer_support_thresh = offset_ex(lower_polys, extrusion_width_scaled, SUPPORT_SURFACES_OFFSET_PARAMETERS);
                 // lower_layer_offset may be very small, so we need to do max and then add 0.1
-                lower_layer_offseted = offset_ex(lower_layer_offseted, scale_(std::max(extrusion_width - lower_layer_offset, 0.) + 0.1));
+                lower_layer_offseted            = offset_ex(lower_layer_offseted, scale_(std::max(extrusion_width - lower_layer_offset, 0.) + 0.1));
                 for (ExPolygon& poly : overhangs_all_layers[layer_nr]) {
-                    auto cluster_boundary_ex = intersection_ex(poly, lower_layer_offseted);
-                    Polygons cluster_boundary = to_polygons(cluster_boundary_ex);
-                    if (cluster_boundary.empty()) continue;
-                    double dist_max = 0;
-                    for (auto& pt : poly.contour.points) {
-                        double dist_pt = std::numeric_limits<double>::max();
-                        for (auto& ply : cluster_boundary) {
-                            double d = ply.distance_to(pt);
-                            dist_pt = std::min(dist_pt, d);
+                    // check if there is some contour that is totally floating
+                    bool   is_cantilever = false;
+                    double dist_max      = 0;
+                    for (size_t i = 0; i < poly.num_contours(); i++) {
+                        Polygon contour      = poly.contour_or_hole(i);
+                        bool    is_floating  = true;
+                        double  tmp_dist_max = 0;
+                        for (const auto& pt : contour.points) {
+                            if (is_inside_ex(lower_layer_support_thresh, pt)) {
+                                is_floating = false;
+                                break;
+                            } else {
+                                tmp_dist_max = std::max(tmp_dist_max, (projection_onto(lower_layer_support_thresh, pt) - pt).cast<double>().norm());
+                            }
                         }
-                        dist_max = std::max(dist_max, dist_pt);
+                        if (is_floating) {
+                            is_cantilever = true;
+                            dist_max      = tmp_dist_max;
+                            break;
+                        }
                     }
-                    if (dist_max > scale_(3)) {  // is cantilever if the farmost point is larger than 3mm away from base
+                    if (!is_cantilever) {
+                        dist_max = 0;
+                        auto     cluster_boundary_ex = intersection_ex(poly, lower_layer_offseted);
+                        Polygons cluster_boundary    = to_polygons(cluster_boundary_ex);
+                        if (cluster_boundary.empty()) continue;
+
+                        for (auto& pt : poly.contour.points) {
+                            double dist_pt = std::numeric_limits<double>::max();
+                            for (auto& ply : cluster_boundary) {
+                                double d = ply.distance_to(pt);
+                                dist_pt  = std::min(dist_pt, d);
+                            }
+                            dist_max = std::max(dist_max, dist_pt);
+                        }
+                        is_cantilever = dist_max > scale_(3);
+                    }
+                    // is cantilever if the farmost point is larger than 3mm away from base or some contour is totally floating
+                    if (is_cantilever) {
                         max_cantilever_dist = std::max(max_cantilever_dist, dist_max);
                         layer->cantilevers.emplace_back(poly);
                         BOOST_LOG_TRIVIAL(debug) << "found a cantilever cluster. layer_nr=" << layer_nr << dist_max;

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -55,6 +55,9 @@ inline double vsize2_with_unscale(const Point pt)
     return dot_with_unscale(pt, pt);
 }
 
+// Second moment of area for stability checks. Implemented in Brim.cpp.
+extern bool compSecondMoment(const ExPolygons &expolys, double &smExpolysX, double &smExpolysY);
+
 inline Point turn90_ccw(const Point pt)
 {
     Point ret;
@@ -638,6 +641,26 @@ TreeSupport::TreeSupport(PrintObject& object, const SlicingParameters &slicing_p
 
 
 #define SUPPORT_SURFACES_OFFSET_PARAMETERS ClipperLib::jtSquare, 0.
+
+// Ported from Bambu 976b5062c.
+// Adds an overhang to both loverhangs and loverhangs_with_type, tagging it with a type.
+void add_overhang(Layer *layer, const ExPolygon &overhang, int type)
+{
+    layer->loverhangs_with_type.emplace_back(overhang, type);
+    layer->loverhangs.emplace_back(overhang);
+}
+
+// Checks whether an overhang region is structurally stable enough to become an ePolygon node.
+// Uses second moment of area: moment / height > 3.0 means stable.
+bool is_stable(float height, const ExPolygon &overhang, float strength_z)
+{
+    float  stability = 1. * height;
+    double Ixx = 0, Iyy = 0;
+    compSecondMoment({overhang}, Ixx, Iyy);
+    double moment = std::min(Ixx * pow(SCALING_FACTOR, 4), Iyy * pow(SCALING_FACTOR, 4));
+    return moment / stability > 3.;
+}
+
 void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
 {
     bool tree_support_enable = m_object_config->enable_support.value && is_tree(m_object_config->support_type.value);
@@ -664,6 +687,8 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
     const int enforce_support_layers = config.enforce_support_layers.value;
     const double area_thresh_well_supported = SQ(scale_(6));
     const double length_thresh_well_supported = scale_(6);
+    const double length_thresh_small_overhang = scale_(2);
+    const double radius_thresh_small_overhang = 2.5 * extrusion_width_scaled;
     static const double sharp_tail_max_support_height = 16.f;
     // a region is considered well supported if the number of layers below it exceeds this threshold
     const int thresh_layers_below = 10 / config.layer_height;
@@ -677,20 +702,33 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
 
     // for small overhang removal
     struct OverhangCluster {
-        std::map<int, const ExPolygon*> layer_overhangs;
+        std::map<int, ExPolygons> layer_overhangs;
         ExPolygons merged_poly;
         BoundingBox merged_bbox;
         int min_layer = 1e7;
         int max_layer = 0;
         coordf_t offset = 0;
-        bool is_cantilever = false;
-        bool is_sharp_tail = false;
-        bool is_small_overhang = false;
+
+        OverhangType type = Normal;
+        bool         is_cantilever() { return type & Cantilever; }
+        bool         is_sharp_tail() { return type & SharpTail; }
+        bool         is_type(OverhangType type_mask) { return type & type_mask; }
+        void         set_type(OverhangType type_mask, bool is)
+        {
+            if (is)
+                type = OverhangType(type | type_mask);
+            else
+                type = OverhangType(type & (~type_mask));
+        }
         OverhangCluster(const ExPolygon* expoly, int layer_nr) {
             push_back(expoly, layer_nr);
         }
         void push_back(const ExPolygon* expoly, int layer_nr) {
-            layer_overhangs.emplace(layer_nr, expoly);
+            auto it = layer_overhangs.find(layer_nr);
+            if (it == layer_overhangs.end())
+                layer_overhangs.emplace(layer_nr, ExPolygons{*expoly});
+            else
+                layer_overhangs[layer_nr].emplace_back(*expoly);
             auto dilate1 = offset_ex(*expoly, offset);
             if (!dilate1.empty())
                 merged_poly = union_ex(merged_poly, dilate1);
@@ -705,42 +743,95 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
             if (layer_nr < 1) return false;
             auto it = layer_overhangs.find(layer_nr - 1);
             if (it == layer_overhangs.end()) return false;
-            const ExPolygon* overhang = it->second;
+            const ExPolygons overhangs = it->second;
 
             this->offset = offset;
             auto dilate1 = offset_ex(region, offset);
             BoundingBox bbox = get_extents(dilate1);
             if (!merged_bbox.overlap(bbox))
                 return false;
-            return overlaps({ *overhang }, dilate1);
+            return overlaps(overhangs, dilate1);
         }
         // it's basically the combination of push_back and intersects, but saves an offset_ex
         bool push_back_if_intersects(const ExPolygon& region, int layer_nr, coordf_t offset) {
             bool is_intersect = false;
+            this->offset      = offset;
             ExPolygons dilate1;
             BoundingBox bbox;
             do {
                 if (layer_nr < 1) break;
                 auto it = layer_overhangs.find(layer_nr - 1);
                 if (it == layer_overhangs.end()) break;
-                const ExPolygon* overhang = it->second;
-
-                this->offset = offset;
+                const ExPolygons overhangs = it->second;
                 dilate1 = offset_ex(region, offset);
                 if (dilate1.empty()) break;
                 bbox = get_extents(dilate1);
                 if (!merged_bbox.overlap(bbox))
                     break;
-                is_intersect = overlaps({ *overhang }, dilate1);
+                is_intersect = overlaps(overhangs, dilate1);
             } while (0);
             if (is_intersect) {
-                layer_overhangs.emplace(layer_nr, &region);
+                auto it = layer_overhangs.find(layer_nr);
+                if (it == layer_overhangs.end())
+                    layer_overhangs.emplace(layer_nr, ExPolygons{region});
+                else
+                    layer_overhangs[layer_nr].emplace_back(region);
                 merged_poly = union_ex(merged_poly, dilate1);
                 min_layer = std::min(min_layer, layer_nr);
                 max_layer = std::max(max_layer, layer_nr);
                 merged_bbox.merge(bbox);
             }
             return is_intersect;
+        }
+        void check_small_overhang(coordf_t extrusion_width_scaled, double length_thresh_small_overhang, double radius_thresh_small_overhang)
+        {
+            bool is_small_overhang = false;
+            if ((type & SharpTail) || (type & Cantilever)) {
+                set_type(Small, false);
+                return;
+            }
+
+            bool  all_layers_are_small = true;
+            float avg_width            = 0;
+            float avg_area             = 0;
+            int   num_layers           = 0;
+            for (auto it = layer_overhangs.begin(); it != layer_overhangs.end(); it++) {
+                const ExPolygons overhangs = it->second;
+                ExPolygons       erodel   = offset_ex(overhangs, -extrusion_width_scaled / 2);
+                coord_t          narrow_width = 0;
+                for (auto &poly : erodel) {
+                    Point bbox_sz = get_extents(poly).size();
+                    narrow_width  = std::max(narrow_width, std::min(bbox_sz.x(), bbox_sz.y()));
+                }
+                if (narrow_width > extrusion_width_scaled) all_layers_are_small = false;
+                avg_width += narrow_width;
+                avg_area += area(overhangs);
+                num_layers++;
+            }
+            avg_width /= num_layers;
+            avg_area /= num_layers;
+            is_small_overhang = all_layers_are_small && avg_width < extrusion_width_scaled / 2 && avg_area < SQ(length_thresh_small_overhang) && this->height() < 3;
+            if (is_small_overhang) {
+                set_type(Small, true);
+                return;
+            }
+
+            ExPolygons erodel = offset_ex(merged_poly, -radius_thresh_small_overhang);
+            Point      bbox_sz = get_extents(erodel).size();
+            if (erodel.empty() ||
+                (bbox_sz.x() < length_thresh_small_overhang && bbox_sz.y() < length_thresh_small_overhang && this->height() < length_thresh_small_overhang / 2)) {
+                is_small_overhang = true;
+                set_type(Small, true);
+            }
+        }
+
+        void check_polygon_node(float thresh_big_overhang, const ExPolygons &m_layer_outlines_below)
+        {
+            ExPolygons outlines_below_eroded = offset_ex(m_layer_outlines_below, -this->offset);
+            if (area(merged_poly) > SQ(thresh_big_overhang))
+                set_type(BigFlat, true);
+            else if (merged_bbox.size().any_comp(thresh_big_overhang, ">") && min_layer < 20)
+                if (!overlaps(merged_poly, outlines_below_eroded)) set_type(ThinPlate, true);
         }
     };
     std::vector<OverhangCluster> overhangClusters;
@@ -775,8 +866,25 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
                 // Filter out areas whose diameter that is smaller than extrusion_width, but we don't want to lose any details.
                 layer->lslices_extrudable = intersection_ex(layer->lslices, offset2_ex(layer->lslices, -extrusion_width_scaled / 2, extrusion_width_scaled));
                 layer->loverhangs.clear();
+                layer->loverhangs_with_type.clear();
             }
         });
+
+    // Pre-compute cumulative object outlines below each layer for BigFlat/ThinPlate classification.
+    // (Bambu has this in TreeSupportData constructor; here we compute it early because
+    //  m_ts_data is not yet allocated at detect_overhangs time — fixes "illegal access" crash.)
+    std::vector<ExPolygons> layer_outlines_below;
+    layer_outlines_below.reserve(m_object->layer_count());
+    for (size_t layer_nr = 0; layer_nr < m_object->layer_count(); layer_nr++) {
+        const Layer* layer = m_object->get_layer(layer_nr);
+        ExPolygons outline;
+        for (const ExPolygon& poly : layer->lslices)
+            poly.simplify(scale_(radius_sample_resolution), &outline);
+        if (layer_nr == 0)
+            layer_outlines_below.push_back(outline);
+        else
+            layer_outlines_below.push_back(union_ex(layer_outlines_below[layer_nr - 1], outline));
+    }
 
     typedef std::chrono::high_resolution_clock clock_;
     typedef std::chrono::duration<double, std::ratio<1> > second_;
@@ -963,7 +1071,7 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
         for (auto& overhang : overhangs_all_layers[layer_nr]) {
             OverhangCluster* cluster = find_and_insert_cluster(overhangClusters, overhang, layer_nr, extrusion_width_scaled);
             if (overlaps({ overhang }, layer->cantilevers))
-                cluster->is_cantilever = true;
+                cluster->set_type(Cantilever, true);
         }
     }
 
@@ -973,51 +1081,59 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
     m_object->project_and_append_custom_facets(false, EnforcerBlockerType::ENFORCER, enforcers, &m_vertical_enforcer_points);
     m_object->project_and_append_custom_facets(false, EnforcerBlockerType::BLOCKER, blockers);
 
-    if (is_auto(stype) && config_remove_small_overhangs) {
+    for (auto& cluster : overhangClusters) {
+        bool enforce_add = false;
         // remove small overhangs
-        for (auto& cluster : overhangClusters) {
+        if (is_auto(stype) && config_remove_small_overhangs) {
             // 3. check whether the small overhang is sharp tail
-            cluster.is_sharp_tail = false;
+            cluster.set_type(SharpTail, false);
             for (size_t layer_id = cluster.min_layer; layer_id <= cluster.max_layer; layer_id++) {
                 Layer* layer = m_object->get_layer(layer_id);
-                if (overlaps(layer->sharp_tails, cluster.merged_poly)) {
-                    cluster.is_sharp_tail = true;
+                if (overlaps(layer->sharp_tails, cluster.layer_overhangs[layer_id])) {
+                    cluster.set_type(SharpTail, true);
                     break;
                 }
             }
-
-            if (!cluster.is_sharp_tail && !cluster.is_cantilever) {
-                // 2. check overhang cluster size is smaller than 3.0 * fw_scaled
-                auto erode1 = offset_ex(cluster.merged_poly, -1 * extrusion_width_scaled);
-                Point bbox_sz = get_extents(erode1).size();
-                if (bbox_sz.x() < 2 * extrusion_width_scaled || bbox_sz.y() < 2 * extrusion_width_scaled) {
-                    cluster.is_small_overhang = true;
+            if (!enforcers.empty() && cluster.min_layer < enforcers.size()) {
+                for (size_t layer_id = cluster.min_layer; layer_id <= cluster.max_layer; layer_id++) {
+                    if (layer_id >= enforcers.size()) break;
+                    if (enforcers[layer_id].empty()) continue;
+                    if (overlaps(to_expolygons(enforcers[layer_id]), cluster.layer_overhangs[layer_id])) {
+                        enforce_add = true;
+                        break;
+                    }
                 }
             }
+
+            cluster.check_small_overhang(extrusion_width_scaled, length_thresh_small_overhang, radius_thresh_small_overhang);
 
 #ifdef SUPPORT_TREE_DEBUG_TO_SVG
             const Layer* layer1 = m_object->get_layer(cluster.min_layer);
             std::string fname = debug_out_path("overhangCluster_%d-%d_%.2f-%.2f_tail=%d_cantilever=%d_small=%d.svg",
                 cluster.min_layer, cluster.max_layer, layer1->print_z, m_object->get_layer(cluster.max_layer)->print_z,
-                cluster.is_sharp_tail, cluster.is_cantilever, cluster.is_small_overhang);
+                cluster.is_sharp_tail(), cluster.is_cantilever(), cluster.is_type(Small));
             SVG::export_expolygons(fname, {
                 { layer1->lslices, {"min_layer_lslices","red",0.5} },
                 { m_object->get_layer(cluster.max_layer)->lslices, {"max_layer_lslices","yellow",0.5} },
                 { cluster.merged_poly,{"overhang", "blue", 0.5} },
-                { cluster.is_cantilever? layer1->cantilevers: offset_ex(cluster.merged_poly, -1 * extrusion_width_scaled), {cluster.is_cantilever ? "cantilever":"erode1","green",0.5}} });
+                { cluster.is_cantilever() ? layer1->cantilevers : offset_ex(cluster.merged_poly, -1 * extrusion_width_scaled), {cluster.is_cantilever() ? "cantilever":"erode1","green",0.5}} });
 #endif
+        }
+
+        if (!cluster.is_type(Small) || enforce_add) {
+            cluster.check_polygon_node(m_support_params.thresh_big_overhang, layer_outlines_below[cluster.min_layer - 1]);
+            for (auto it = cluster.layer_overhangs.begin(); it != cluster.layer_overhangs.end(); it++) {
+                int       layer_nr = it->first;
+                ExPolygons overhangs = it->second;
+                if (cluster.is_type(Small)) {
+                    if (layer_nr >= enforcers.size() || enforcers[layer_nr].empty() || !overlaps(to_expolygons(enforcers[layer_nr]), overhangs)) continue;
+                    overhangs = intersection_ex(overhangs, enforcers[layer_nr]);
+                }
+                for (const auto& overhang : overhangs) add_overhang(m_object->get_layer(layer_nr), overhang, cluster.type);
+            }
         }
     }
 
-    for (auto& cluster : overhangClusters) {
-        if (cluster.is_small_overhang) continue;
-        // collect overhangs that's not small overhangs
-        for (auto it = cluster.layer_overhangs.begin(); it != cluster.layer_overhangs.end(); it++) {
-            int  layer_nr   = it->first;
-            auto p_overhang = it->second;
-            m_object->get_layer(layer_nr)->loverhangs.emplace_back(*p_overhang);
-        }
-    }
 
     int layers_with_overhangs = 0;
     int layers_with_enforcers = 0;
@@ -1048,46 +1164,82 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
         }
 
         if (layer_nr < blockers.size()) {
-            // Arthur: union_ is a must because after mirroring, the blocker polygons are in left-hand coordinates, ie clockwise,
-            // which are not valid polygons, and will be removed by offset_ex. union_ can make these polygons right.
+            // Arthur: union_ is a must because after mirroring, the blocker polygons are in left-hand coordinates,
+            // ie clockwise, which are not valid polygons, and will be removed by offset_ex. union_ makes them right.
             ExPolygons blocker = offset_ex(union_(blockers[layer_nr]), scale_(radius_sample_resolution));
-            layer->loverhangs = diff_ex(layer->loverhangs, blocker);
+            // filter loverhangs_with_type with blocker, propagating type to each resulting fragment
+            std::vector<std::pair<ExPolygon, int>> filtered;
+            for (auto& wt : layer->loverhangs_with_type) {
+                ExPolygons diffed = diff_ex({wt.first}, blocker);
+                for (auto& d : diffed) filtered.emplace_back(d, wt.second);
+            }
+            layer->loverhangs_with_type = std::move(filtered);
             layer->cantilevers = diff_ex(layer->cantilevers, blocker);
             sharp_tail_overhangs = diff_ex(sharp_tail_overhangs, blocker);
         }
 
         if (support_critical_regions_only && is_auto(stype)) {
-            layer->loverhangs.clear();  // remove oridinary overhangs, only keep cantilevers and sharp tails (added later)
-            append(layer->loverhangs, layer->cantilevers);
+            // Ported from Bambu: keep only enforced / cantilever / sharp tail areas
+            if (lower_layer == nullptr || enforcers.empty() || layer_nr >= enforcers.size() || enforcers[layer_nr].empty()) {
+                layer->loverhangs_with_type.clear();
+                for (const auto& cantilever : layer->cantilevers)
+                    add_overhang(layer, cantilever, OverhangType::Cantilever);
+            } else {
+                ExPolygons enforced_overhangs_scr = offset_ex(to_expolygons(enforcers[layer_nr]), enforcer_overhang_offset);
+                std::vector<std::pair<ExPolygon, int>> loverhangs_with_type_new;
+                ExPolygons bigflat;
+                for (auto& wt : layer->loverhangs_with_type) {
+                    ExPolygons overhangs;
+                    if (wt.second & OverhangType::Cantilever || wt.second & OverhangType::SharpTail)
+                        overhangs = {wt.first};
+                    else if (overlaps(enforced_overhangs_scr, wt.first))
+                        overhangs = intersection_ex(enforced_overhangs_scr, wt.first);
+                    if (!overhangs.empty()) {
+                        if (wt.second & OverhangType::BigFlat)
+                            append(bigflat, overhangs);
+                        else
+                            for (const auto& expoly : overhangs)
+                                loverhangs_with_type_new.emplace_back(expoly, wt.second);
+                    }
+                }
+                for (const auto& expoly : union_ex(bigflat)) {
+                    loverhangs_with_type_new.emplace_back(expoly, OverhangType::BigFlat);
+                }
+                layer->loverhangs_with_type = std::move(loverhangs_with_type_new);
+            }
         }
+
+        // add sharp tail overhangs via add_overhang (with SharpTail type)
+        for (const auto& area : sharp_tail_overhangs)
+            add_overhang(layer, area, OverhangType::SharpTail);
+
+        // enforcers now follow same logic as normal support. See STUDIO-3692
+        int nEnforced = 0;
+        if (layer_nr < enforcers.size() && lower_layer) {
+            ExPolygons enforced_overhangs   = intersection_ex(diff_ex(layer->lslices_extrudable, lower_layer->lslices_extrudable), enforcers[layer_nr]);
+            if (!enforced_overhangs.empty()) {
+                // FIXME this is a hack to make enforcers work on steep overhangs. See STUDIO-7538.
+                enforced_overhangs = diff_ex(offset_ex(enforced_overhangs, enforcer_overhang_offset), lower_layer->lslices_extrudable);
+                for (const auto& expoly : enforced_overhangs)
+                    add_overhang(layer, expoly, OverhangType::Normal);
+                nEnforced = enforced_overhangs.size();
+            }
+        }
+
+        // rebuild loverhangs from loverhangs_with_type (for bridge removal + debug SVG + export)
+        layer->loverhangs.clear();
+        for (const auto& wt : layer->loverhangs_with_type)
+            layer->loverhangs.emplace_back(wt.first);
 
         if (max_bridge_length > 0 && layer->loverhangs.size() > 0 && lower_layer) {
             // do not break bridge as the interface will be poor, see #4318
             bool break_bridge = false;
             m_object->remove_bridges_from_contacts(lower_layer, layer, extrusion_width_scaled, &layer->loverhangs, max_bridge_length, break_bridge);
         }
+        // Note: loverhangs_with_type is intentionally NOT synced after bridge removal.
+        // generate_initial_nodes iterates loverhangs_with_type, not loverhangs. (Bambu 976b5062c)
 
-		int nDetected = layer->loverhangs.size();
-        // enforcers now follow same logic as normal support. See STUDIO-3692
-        if (layer_nr < enforcers.size() && lower_layer) {
-            ExPolygons enforced_overhangs   = intersection_ex(diff_ex(layer->lslices_extrudable, lower_layer->lslices_extrudable), enforcers[layer_nr]);
-            if (!enforced_overhangs.empty()) {
-                // FIXME this is a hack to make enforcers work on steep overhangs. See STUDIO-7538.
-                enforced_overhangs = diff_ex(offset_ex(enforced_overhangs, enforcer_overhang_offset), lower_layer->lslices_extrudable);
-                append(layer->loverhangs, enforced_overhangs);
-            }
-        }
-        int nEnforced = layer->loverhangs.size();
-
-        // add sharp tail overhangs
-        append(layer->loverhangs, sharp_tail_overhangs);
-
-        // fill overhang_types
-        for (size_t i = 0; i < layer->loverhangs.size(); i++)
-            overhang_types.emplace(&layer->loverhangs[i], i < nDetected ? OverhangType::Detected :
-                i < nEnforced ? OverhangType::Enforced : OverhangType::SharpTail);
-
-        if (!layer->loverhangs.empty()) {
+        if (!layer->loverhangs_with_type.empty()) {
             layers_with_overhangs++;
             m_highest_overhang_layer = std::max(m_highest_overhang_layer, size_t(layer_nr));
         }
@@ -2100,10 +2252,9 @@ void TreeSupport::draw_circles()
                         if (node.need_extra_wall) need_extra_wall = true;
 
                         // merge overhang to get a smoother interface surface.
-                        // Do not merge when buildplate_only is on, because some underneath nodes may have been deleted.
-                        // Align with Bambu Studio: replace node circle with expanded overhang (not append).
-                        // The overhang provides a larger continuous surface for better infill.
-                        if (top_interface_layers > 0 && node.support_roof_layers_below > 0 && !on_buildplate_only) {
+                        // Only when overhang exists — circle nodes that descended through drop_nodes
+                        // lose their overhang, so keep the grown circle to preserve transition connectivity.
+                        if (top_interface_layers > 0 && (node.support_roof_layers_below > 1 || (node.support_roof_layers_below >= 0 && !node.is_sharp_tail)) && !on_buildplate_only) {
                             ExPolygons overhang_expanded;
                             if (node.overhang.contour.size() > 100 || node.overhang.holes.size()>1)
                                 overhang_expanded.emplace_back(node.overhang);
@@ -2121,13 +2272,13 @@ void TreeSupport::draw_circles()
 
                     if (obj_layer_nr>0 && node.distance_to_top < 0)
                         append(roof_gap_areas, area);
-                    else if (obj_layer_nr > 0 && node.support_roof_layers_below > 0
-                             && node.support_roof_layers_below <= config.tree_support_transition_layers.value)
+                    else if (top_interface_layers > 0 && obj_layer_nr > 0 && (node.support_roof_layers_below == 0 || node.support_roof_layers_below == 1) &&
+                             node.distance_to_top >= (int)top_interface_layers)
                     {
                         append(roof_1st_layer, area);
                         max_layers_above_roof1 = std::max(max_layers_above_roof1, node.dist_mm_to_top);
                     }
-                    else if (obj_layer_nr > 0 && node.support_roof_layers_below > 0)
+                    else if (top_interface_layers > 0 && obj_layer_nr > 0 && node.support_roof_layers_below > 0)
                     {
                         append(roof_areas, area);
                         max_layers_above_roof = std::max(max_layers_above_roof, node.dist_mm_to_top);
@@ -2148,9 +2299,7 @@ void TreeSupport::draw_circles()
                 roof_areas     = intersection_ex(roof_areas, m_machine_border);
                 roof_areas     = union_ex(roof_areas); // merge fragments into continuous surfaces (align with Bambu)
                 roof_1st_layer = diff_clipped(offset2_ex(roof_1st_layer, line_width_scaled, -line_width_scaled), get_collision(false));
-                // Note: Bambu does NOT apply union_ex to roof_1st_layer (only to roof_areas).
-                // union_ex would merge separate branch polygons into one continuous surface,
-                // producing a single large block that diverges from Bambu's per-branch transition strips.
+                roof_1st_layer = union_ex(roof_1st_layer); // merge fragments into continuous transition surface
 
                 // roof_areas and roof_1st_layer may intersect.
                 // Subtract roof_1st_layer from roof_areas so transition strips keep support body filament.
@@ -2480,6 +2629,7 @@ void TreeSupport::drop_nodes()
     const size_t bottom_interface_layers = config.support_interface_bottom_layers.value < 0 ? top_interface_layers : config.support_interface_bottom_layers.value;
     SupportNode::diameter_angle_scale_factor = diameter_angle_scale_factor;
     float        DO_NOT_MOVER_UNDER_MM       = is_slim ? 0 : 5;                     // do not move contact points under 5mm
+    const bool   bottom_expand_enabled      = config.tree_support_wall_count > 1 || config.tree_support_wall_count < 0;
 
     auto get_max_move_dist = [this, &config, tan_angle, wall_count, support_extrusion_width](const SupportNode *node, int power = 1) {
         if (node->max_move_dist == 0) {
@@ -2685,6 +2835,12 @@ void TreeSupport::drop_nodes()
                             node.merged_neighbours.insert(node.merged_neighbours.end(), neighbour_node->merged_neighbours.begin(), neighbour_node->merged_neighbours.end());
                             neighbour_node->valid = false;
                         }
+                        else if (is_inside_ex(node.overhang, neighbour)) {
+                            // Partial overlap: circle center inside polygon but not fully contained.
+                            // Adopt the circle branch radius as expansion target (ported from Bambu).
+                            if (node.overhang.contour.bounding_box().radius() < neighbour_radius)
+                                node.target_radius = std::max(node.target_radius, neighbour_node->radius);
+                        }
                     }
                 } else if (neighbours.size() == 1 && vsize2_with_unscale(neighbours[0] - node.position) < get_max_move_dist(p_node, 2) &&
                            mst.adjacent_nodes(neighbours[0]).size() == 1 &&
@@ -2756,19 +2912,50 @@ void TreeSupport::drop_nodes()
                 }
                 if (node.type == ePolygon) {
                     // polygon node do not merge or move
+                    if (node.overhang.contour.points.empty()) {
+                        p_node->valid = false;
+                        return;
+                    }
                     const bool to_buildplate = true;
-                    // keep only the part that won't be removed by the next layer
-                    ExPolygons overhangs_next = diff_clipped({ node.overhang }, get_collision(0, obj_layer_nr_next));
-                    for(auto& overhang:overhangs_next) {
+                    ExPolygons  overhangs_next{node.overhang};
+                    auto        poly_radius   = node.overhang.contour.bounding_box().radius();
+                    bool        offseted      = false;
+
+                    // Polygon support expansion (ported from Bambu Studio):
+                    // 1. bottom expansion enabled
+                    // 2. target_radius gate: small polygons or polygons near a merged circle branch
+                    if ((bottom_expand_enabled && node.print_z < DO_NOT_MOVER_UNDER_MM) ||
+                        (poly_radius < scale_(node.target_radius) || node.overhang.area() < 3. * SQ(scale_(node.target_radius)))) {
+                        overhangs_next = offset_ex({node.overhang}, scale_(max_move_distance / 2.));
+                        offseted       = true;
+                    }
+
+                    // Keep only the part that won't be removed by the next layer.
+                    overhangs_next = diff_clipped(overhangs_next, get_collision(0, obj_layer_nr_next));
+
+                    // Smooth the transition at the first contact layer.
+                    if (node.distance_to_top == 0) {
+                        overhangs_next      = offset2_ex(overhangs_next, scale_(max_move_distance), -scale_(max_move_distance));
+                        p_node->origin_area = node.overhang.area();
+                    }
+
+                    // Expand when entering the first transition layer (srlb == 1).
+                    if (m_support_params.num_top_interface_layers > 0 && obj_layer_nr_next > 0 && node.support_roof_layers_below == 1 &&
+                        node.distance_to_top >= (int)m_support_params.num_top_interface_layers)
+                        overhangs_next = safe_offset_inc(overhangs_next, scale_(max_move_distance), get_collision(0, obj_layer_nr_next), scale_(MIN_BRANCH_RADIUS * 1.75), 0, 1);
+
+                    for (auto &overhang : overhangs_next) {
+                        if (overhang.contour.points.empty()) continue;
                         Point        next_pt     = overhang.contour.centroid();
                         SupportNode *next_node   = m_ts_data->create_node(next_pt, p_node->distance_to_top + 1, obj_layer_nr_next, p_node->support_roof_layers_below - 1,
                                                                           to_buildplate, p_node, print_z_next, height_next);
                         next_node->max_move_dist = 0;
-                        next_node->overhang = std::move(overhang);
+                        next_node->target_radius = p_node->target_radius;
+                        next_node->overhang      = std::move(overhang);
+                        next_node->origin_area   = node.origin_area;
                         m_ts_data->m_mutex.lock();
                         contact_nodes[layer_nr_next].emplace_back(next_node);
                         m_ts_data->m_mutex.unlock();
-
                     }
                     return;
                 }
@@ -3196,6 +3383,10 @@ void TreeSupport::generate_contact_points()
     const coordf_t point_spread = scale_(config.tree_support_branch_distance.value);
     const coordf_t max_bridge_length = scale_(config.max_bridge_length.value);
     coord_t    radius_scaled         = scale_(base_radius);
+    const coordf_t extrusion_width = config.line_width.value;
+    coordf_t       xy_expansion    = scale_(config.support_expansion.value);
+    if (m_support_params.soluble_interface && xy_expansion < EPSILON) xy_expansion = scale_(2);
+
     bool       on_buildplate_only    = m_object_config->support_on_build_plate_only.value;
     const bool roof_enabled          = config.support_interface_top_layers.value > 0;
     const bool force_tip_to_roof = roof_enabled && m_support_params.soluble_interface;
@@ -3240,7 +3431,7 @@ void TreeSupport::generate_contact_points()
 
     size_t support_roof_layers = config.support_interface_top_layers.value;
     if (support_roof_layers > 0)
-        support_roof_layers += config.tree_support_transition_layers.value;
+        support_roof_layers += 1;
     coordf_t  thresh_angle = std::min(89.f, config.support_threshold_angle.value < EPSILON ? 30.f : config.support_threshold_angle.value);
     coordf_t  half_overhang_distance = scale_(tan(thresh_angle * M_PI / 180.0) * layer_height / 2);
 
@@ -3308,38 +3499,62 @@ void TreeSupport::generate_contact_points()
                     added = true;
                 };
                 return contact_node;
-                };
+            };
 
-            for (const auto& overhang_part : layer->loverhangs)  {
-                const auto& overhang_type = this->overhang_types[&overhang_part];
-                is_sharp_tail = overhang_type == OverhangType::SharpTail;
+            // Ported from Bambu 976b5062c + f9d99ec8c:
+            // Type-based classification replaces area-threshold binary cliff.
+            auto extrudable_collision = offset_ex(layer->lower_layer->lslices_extrudable, m_ts_data->m_xy_distance);
+            for (const auto& overhang_with_type : layer->loverhangs_with_type)  {
+                const auto &overhang_part = overhang_with_type.first;
+                const auto &overhang_type = overhang_with_type.second;
+                is_sharp_tail = overhang_type & OverhangType::SharpTail;
+                bool       add_interface  = (force_tip_to_roof || area(overhang_part) > minimum_roof_area);
+                const auto &relevant_forbidden = get_collision(0, layer_nr - 1);
+                ExPolygons overhangs{overhang_part};
                 ExPolygons overhangs_regular;
-                if (m_support_params.support_style == smsTreeHybrid && overhang_part.area() > m_support_params.thresh_big_overhang && !is_sharp_tail) {
-                    overhangs_regular           = offset_ex(intersection_ex({overhang_part}, m_ts_data->m_layer_outlines_below[layer_nr - 1]), radius_scaled);
-                    ExPolygons overhangs_normal = diff_ex({overhang_part}, overhangs_regular);
-                    if (area(overhangs_normal) > m_support_params.thresh_big_overhang) {
-                        // if the outside area is still big, we can need normal nodes
-                        for (auto &overhang : overhangs_normal) {
-                            BoundingBox  overhang_bounds = get_extents(overhang);
-                            double       radius          = unscale_(overhang_bounds.radius());
-                            Point        candidate       = overhang_bounds.center();
-                            SupportNode *contact_node    = insert_point(candidate, overhang, radius, true, true);
-                            contact_node->type           = ePolygon;
-                            curr_nodes.emplace_back(contact_node);
-                        }
-                    }else{
-                        // otherwise, all nodes should be circle nodes
-                        overhangs_regular = ExPolygons{overhang_part};
+                if (!is_sharp_tail && (config.support_expansion.value > EPSILON))
+                    overhangs = safe_offset_inc({overhang_part}, scale_(config.support_expansion.value), relevant_forbidden, scale_(MIN_BRANCH_RADIUS * 1.75), 0, 1);
+                if (m_support_params.support_style == smsTreeHybrid &&
+                    (overhang_type & (BigFlat | ThinPlate))) {
+                    overhangs_regular = intersection_ex(overhangs, offset_ex(m_ts_data->m_layer_outlines_below[layer_nr - 1], scale_(config.support_object_xy_distance.value)));
+                    ExPolygons overhangs_normal = offset2_ex(diff_ex({overhang_part}, overhangs_regular), scale_(extrusion_width), -scale_(extrusion_width));
+                    if (add_interface && xy_expansion > EPSILON && !is_sharp_tail)
+                        overhangs_normal = safe_offset_inc(overhangs_normal, xy_expansion,
+                                                           offset_ex(m_ts_data->m_layer_outlines_below[layer_nr - 1], scale_(config.support_object_xy_distance.value)),
+                                                           scale_(MIN_BRANCH_RADIUS * 1.75), 0, 1);
+                    // if the outside area is still big, we can need normal nodes
+                    coord_t gap_width = scale_(extrusion_width / 2.) + scale_(m_ts_data->m_xy_distance);
+                    ExPolygons overhangs_normal_split;
+                    for (auto &overhang : overhangs_normal) {
+                        ExPolygons sub_overhangs = overhang.split_expoly_with_holes(gap_width, get_collision(0, layer_nr));
+                        if (sub_overhangs.size() > 0)
+                            for (auto &sub : sub_overhangs) overhangs_normal_split.emplace_back(sub);
+                        else
+                            overhangs_normal_split.emplace_back(overhang);
                     }
-                } else {
-                    overhangs_regular = ExPolygons{overhang_part};
+                    for (auto &overhang : overhangs_normal_split) {
+                        if (!is_stable(layer->bottom_z(), overhang, 0) || overhang.area() < SQ(scale_(2.))) {
+                            ExPolygons unstable_overhangs = intersection_ex({overhang}, overhangs);
+                            overhangs_regular.insert(overhangs_regular.end(), unstable_overhangs.begin(), unstable_overhangs.end());
+                            continue;
+                        }
+                        BoundingBox  overhang_bounds = get_extents(overhang);
+                        double       radius          = unscale_(overhang_bounds.radius());
+                        Point        candidate       = overhang_bounds.center();
+                        SupportNode *contact_node    = insert_point(candidate, overhang, radius, true, true);
+                        if (!contact_node) continue;
+                        contact_node->type           = ePolygon;
+                        curr_nodes.emplace_back(contact_node);
+                    }
+                }
+                else{
+                    overhangs_regular = overhangs;
                 }
 
+                if (!is_sharp_tail && layer->lower_layer)
+                    overhangs_regular = diff_ex(overhangs_regular, extrudable_collision);
                 for (auto &overhang : overhangs_regular) {
-                    bool add_interface = (force_tip_to_roof || area(overhang) > minimum_roof_area);
-                    // Align with Bambu: only exclude tiny sharp_tails with non-soluble interface
-                    if (is_sharp_tail && !m_support_params.soluble_interface && area(overhang) < SQ(scale_(2.)))
-                        add_interface = false;
+                    if (is_sharp_tail && !m_support_params.soluble_interface && overhang.area() < SQ(scale_(2.))) add_interface = false;
                     BoundingBox overhang_bounds = get_extents(overhang);
                     double      radius          = std::clamp(unscale_(overhang_bounds.radius()), MIN_BRANCH_RADIUS, base_radius);
                     // add supports at corners for both auto and manual overhangs, github #2008

--- a/src/libslic3r/Support/TreeSupport.hpp
+++ b/src/libslic3r/Support/TreeSupport.hpp
@@ -125,6 +125,8 @@ struct SupportNode
     bool           is_sharp_tail   = false;
     bool           valid = true;
     ExPolygon      overhang; // when type==ePolygon, set this value to get original overhang area
+    coordf_t       origin_area   = 0.0;
+    coordf_t       target_radius = -1.;
 
     /*!
      * \brief The direction of the skin lines above the tip of the branch.
@@ -408,7 +410,14 @@ public:
      */
     ExPolygon m_machine_border;
 
-    enum OverhangType { Detected = 0, Enforced, SharpTail };
+    // Bitfield enum: a region can be multiple types simultaneously (e.g. BigFlat | SharpTail).
+    // Ported from Bambu 976b5062c. Use & for membership test, not ==.
+    enum OverhangType : uint8_t {
+        Normal = 0, SharpTail = 1,
+        Cantilever = 1 << 1, Small = 1 << 2,
+        BigFlat = 1 << 3, ThinPlate = 1 << 4,
+        SharpTailLowesst = 1 << 5
+    };
     std::map<const ExPolygon*, OverhangType> overhang_types;
     std::vector<std::pair<Vec3f, Vec3f>>      m_vertical_enforcer_points;
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2605,6 +2605,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("ironing_speed", "speed_settings_other_layers_speed#ironing-speed");
         optgroup->append_single_option_line("support_speed", "speed_settings_other_layers_speed#support");
         optgroup->append_single_option_line("support_interface_speed", "speed_settings_other_layers_speed#support-interface");
+        optgroup->append_single_option_line("support_transition_speed", "speed_settings_other_layers_speed#support-transition");
         optgroup = page->new_optgroup(L("Overhang speed"), L"param_overhang_speed", 15);
         optgroup->append_single_option_line("enable_overhang_speed", "speed_settings_overhang_speed#slow-down-for-overhang");
         optgroup->append_single_option_line("slowdown_for_curled_perimeters", "speed_settings_overhang_speed#slow-down-for-curled-perimeters");


### PR DESCRIPTION
# fix(support): port Bambu cantilever floating-contour detection to fix large ring overhangs being dropped

## Description

This PR ports the "fully-floating contour" cantilever detection logic from BambuStudio into `TreeSupport::detect_overhangs`, fixing a bug where **large-area, large-perimeter overhangs (e.g. tube-top rings, plates with hovering holes) were misclassified as small overhangs and lost all support** once `Remove small overhangs` was enabled.

### Problem

For tree support (auto), cantilever detection previously relied on a **single criterion**: the farthest point on the *outer* contour must be more than 3 mm from the lower-layer base. This criterion fails for two common geometries:

1. **Tube-top rings** — a ring overhang at the top of a tube/cylinder. The outer edge floats but is often < 3 mm from the lower layer, while the hole (tube interior) is fully supported.
2. **Plates with hovering holes** — a plate whose outer edge is supported but whose hole boundaries are fully floating (overhanging internal holes).

In both cases the overhang is then routed into `check_small_overhang`, where the Tier-2 "erode-empty" branch (`offset_ex(merged_poly, -2.5*extrusion_width).empty()`) fires because the ring/plate thickness is smaller than the erode radius. The cluster is tagged `Small` and dropped → no support is generated. The symptom worsens when `Support critical regions only` is also enabled, since non-critical types are filtered out on top of the small-overhang removal.

This contradicts the intent of both parameters: these regions are large-area / large-perimeter, not "small overhangs", and they are exactly the kind of structure that should be treated as a "critical region".

### Fix

Aligns the cantilever detection with BambuStudio (`TreeSupport.cpp:1004-1052`):

- Build `lower_layer_support_thresh = lower_polys` offset by 1 extrusion width.
- For **every contour of the overhang (outer contour + all holes)**: if all points are outside `lower_layer_support_thresh`, the contour is fully floating → flag the overhang as `Cantilever` (using `projection_onto` for the distance metric).
- The original `dist_max > 3 mm` path is preserved as a fallback when no fully-floating contour is found.

Once flagged as `Cantilever`:
- `check_small_overhang` returns early (the `type & Cantilever` guard at the top), so it is no longer misclassified as `Small`.
- Under `support_critical_regions_only`, `Cantilever` is one of the three retained "critical region" types, so support is kept.

This PR also brings two SharpTail checks in line with BambuStudio:
- Bottom-layer threshold uses `||` instead of `&&` (either dimension > 6 mm counts as non-sharp).
- Main-loop SharpTail detection gains the area/bbox double gate, the radius-erode rescue branch (for thin-but-wide rings that would otherwise be dropped by `check_small_overhang`), and the two-layers-below overlap suppression.

No new dependencies or helper functions are required — `is_inside_ex`, `projection_onto(ExPolygons, Point)`, `num_contours()` / `contour_or_hole()` all already exist in the codebase.

### Scope of change

Single file, `src/libslic3r/Support/TreeSupport.cpp` (+54 / -14). Behavior of other support types (normal auto support) is unchanged.

## Screenshots/Recordings/Graphs


### Decision flow (after fix)

```
overhang polygon
      |
      v
[1] SharpTail  -- requires no overlap with lower layer (floating)
      |  Case A/B have overlap (inside hole / under plate) -> excluded
      v
[2] Cantilever (FIXED)
      |  A) ANY contour (outer or hole) fully floats -> cantilever   [NEW]
      |  B) outer-contour farthest point > 3 mm       -> cantilever  [kept]
      |  Case A: outer floats -> A hits
      |  Case B: hole floats -> A hits
      v
[3] OverhangCluster build -- inherits type bits
      v
[4] check_small_overhang
      |  if (type & SharpTail || type & Cantilever) SKIP   [guard]
      |  -> already Cantilever, not classified small
      v
[5] generate support (add_overhang)
      |  + survives support_critical_regions_only filtering
```

## Tests

- **Build**: `cmake --build build --target libslic3r --config Release` — compiles cleanly, no warnings.

- **Regression**: The original `dist_max > 3 mm` criterion is retained as a fallback, so existing cantilever detection scenarios are unaffected. The two SharpTail alignment changes match BambuStudio exactly.

- **Manual validation**: Sliced the offending model — the ring/hole regions now receive tree support where they previously had none.

https://github.com/user-attachments/assets/706dd2ee-0019-4203-87ab-80a1c0181341


### Limitations / follow-ups

- The fix focuses on the cantilever classification itself. Larger structural differences vs. BambuStudio (enforcer/blocker pipeline, `m_ts_data`-based `layer_outlines_below`, the 7-arg `remove_bridges_from_contacts`) are intentionally **not** touched in this PR — see the analysis doc for details.