### PR TITLE
Fix mix filament bug01

### DIFF
--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1988,6 +1988,22 @@ void apply_batch_match_to_model(const BatchMatchResult& result, Print& print)
                 mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(new_eid)));
             }
         }
+
+        // Level 3: layer-object extruder (layer_config_ranges). A layer object
+        // holds the user-assigned filament for a height range; remap it with
+        // the same table used for volumes so it follows the match instead of
+        // being stranded on a physical slot that cleanup deletes
+        // (→ "layer filament >N reset to default").
+        for (auto& lr : mo->layer_config_ranges) {
+            ModelConfig&         lcfg = lr.second;
+            const ConfigOption*  lopt = lcfg.option("extruder");
+            if (!lopt) continue;
+            const int old_eid = lopt->getInt();
+            if (old_eid <= 0) continue;
+            auto lit = extruder_remap.find(old_eid);
+            if (lit == extruder_remap.end()) continue;
+            lcfg.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(lit->second)));
+        }
     }
 
     BOOST_LOG_TRIVIAL(info)

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1431,7 +1431,12 @@ std::vector<ModelColorEntry> extract_model_colors(const Print& print)
         if (!model_obj) continue;
 
         for (const ModelVolume* vol : model_obj->volumes) {
-            if (!vol || vol->type() != ModelVolumeType::MODEL_PART) continue;
+            if (!vol) continue;
+            // Include PARAMETER_MODIFIER so a modifier's user-chosen colour is
+            // collected too — mirrors load_model_colors and
+            // apply_batch_match_to_model, which also include modifiers.
+            const ModelVolumeType emc_vt = vol->type();
+            if (emc_vt != ModelVolumeType::MODEL_PART && emc_vt != ModelVolumeType::PARAMETER_MODIFIER) continue;
 
             for (int eid : vol->get_extruders()) {
                 if (eid < 1 || eid > MAX_EXTRUDER_ID) continue;
@@ -1930,28 +1935,58 @@ void apply_batch_match_to_model(const BatchMatchResult& result, Print& print)
 
     // Apply remap at two levels independently:
     //   1) MMU-painted: triangle-level extruder data via remap_extruder_ids
+    //      (only MODEL_PART volumes carry paint data)
     //   2) Config-level: volume/object config extruder assignment
+    //      Applies to MODEL_PART AND PARAMETER_MODIFIER (modifier) volumes.
+    //      A modifier keeps the colour the user picked in the object list; if
+    //      that colour's extruder is remapped by the match (e.g. physical slot
+    //      3 -> virtual mixed filament 7), the modifier must follow so its
+    //      displayed/printed colour stays the same hue.  Previously the loop
+    //      early-continued on non-MODEL_PART, dropping the modifier's colour
+    //      (it then fell back to the object's extruder, which itself may have
+    //      been remapped — surfacing as "colour reset to extruder 1").
     for (ModelObject* mo : wxGetApp().model().objects) {
+        // Object-level extruder is remapped once below if it is the effective
+        // extruder for any volume; track whether we already wrote it so a
+        // later modifier inheriting the object does not double-write.
+        bool object_extruder_written = false;
         for (ModelVolume* mv : mo->volumes) {
-            if (mv->type() != ModelVolumeType::MODEL_PART) continue;
+            const ModelVolumeType vt = mv->type();
+            const bool is_part      = (vt == ModelVolumeType::MODEL_PART);
+            const bool is_modifier  = (vt == ModelVolumeType::PARAMETER_MODIFIER);
 
-            // Level 1: triangle-level MMU data
-            if (!mv->mmu_segmentation_facets.empty())
-                mv->remap_extruder_ids(total_filaments, state_map);
+            // Level 1: triangle-level MMU data (MODEL_PART only).
+            if (is_part) {
+                if (!mv->mmu_segmentation_facets.empty())
+                    mv->remap_extruder_ids(total_filaments, state_map);
+            }
 
-            // Level 2: config-level extruder (always needed — even for
-            // painted volumes, get_extruders() includes extruder_id())
-            int old_eid = mv->extruder_id();
+            // Level 2: config-level extruder for parts and modifiers.
+            if (!is_part && !is_modifier) continue;
+
+            const int old_eid = mv->extruder_id(); // effective: volume config, else object config
             if (old_eid <= 0) continue;
             auto it = extruder_remap.find(old_eid);
             if (it == extruder_remap.end()) continue;
 
             const unsigned int new_eid = it->second;
             const ConfigOption* vol_opt = mv->config.option("extruder");
-            if (vol_opt && vol_opt->getInt() > 0)
+            const bool volume_has_own = (vol_opt && vol_opt->getInt() > 0);
+            if (volume_has_own) {
                 mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(new_eid)));
-            else
+            } else if (!object_extruder_written) {
+                // Volume inherits the object's extruder — write once on the
+                // object so every inheriting volume follows. Subsequent
+                // inheriting volumes that also need a (different) remap would
+                // now conflict; force them onto their own config instead.
                 mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(new_eid)));
+                object_extruder_written = true;
+            } else {
+                // Object already remapped by an earlier inheriting volume but
+                // this volume needs a different target — give it its own
+                // config entry so it does not inherit the wrong value.
+                mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(new_eid)));
+            }
         }
     }
 

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1431,12 +1431,7 @@ std::vector<ModelColorEntry> extract_model_colors(const Print& print)
         if (!model_obj) continue;
 
         for (const ModelVolume* vol : model_obj->volumes) {
-            if (!vol) continue;
-            // Include PARAMETER_MODIFIER so a modifier's user-chosen colour is
-            // collected too — mirrors load_model_colors and
-            // apply_batch_match_to_model, which also include modifiers.
-            const ModelVolumeType emc_vt = vol->type();
-            if (emc_vt != ModelVolumeType::MODEL_PART && emc_vt != ModelVolumeType::PARAMETER_MODIFIER) continue;
+            if (!vol || vol->type() != ModelVolumeType::MODEL_PART) continue;
 
             for (int eid : vol->get_extruders()) {
                 if (eid < 1 || eid > MAX_EXTRUDER_ID) continue;
@@ -1893,7 +1888,7 @@ std::vector<std::string> recommend_best_filament_combo(
     };
 }
 
-void apply_batch_match_to_model(const BatchMatchResult& result, Print& print)
+void apply_batch_match_to_model(const BatchMatchResult& result)
 {
     if (!result.success || result.mappings.empty()) return;
 
@@ -1946,46 +1941,46 @@ void apply_batch_match_to_model(const BatchMatchResult& result, Print& print)
     //      (it then fell back to the object's extruder, which itself may have
     //      been remapped — surfacing as "colour reset to extruder 1").
     for (ModelObject* mo : wxGetApp().model().objects) {
-        // Object-level extruder is remapped once below if it is the effective
-        // extruder for any volume; track whether we already wrote it so a
-        // later modifier inheriting the object does not double-write.
-        bool object_extruder_written = false;
+        // Pre-read the object's effective extruder ONCE, before iterating volumes.
+        // ModelVolume::extruder_id() falls back to the OBJECT config when a volume
+        // has no own "extruder", and this loop rewrites that object config — so
+        // calling extruder_id() again mid-loop would return the just-written value
+        // for later inheriting volumes, making two volumes that share the same
+        // source resolve different targets (order-dependent). Snapshotting the
+        // original object extruder eliminates that hazard: every inheriting volume
+        // (part or modifier) follows the same target, so their colours stay
+        // consistent — which is the whole point of including modifiers here.
+        const ConfigOption* obj_opt     = mo->config.option("extruder");
+        const int           orig_obj_eid = (obj_opt ? obj_opt->getInt() : 0);
+        auto                obj_it       = extruder_remap.find(orig_obj_eid);
+        const bool          obj_remap    = (orig_obj_eid > 0 && obj_it != extruder_remap.end());
+        bool                object_extruder_written = false;
         for (ModelVolume* mv : mo->volumes) {
             const ModelVolumeType vt = mv->type();
             const bool is_part      = (vt == ModelVolumeType::MODEL_PART);
             const bool is_modifier  = (vt == ModelVolumeType::PARAMETER_MODIFIER);
 
-            // Level 1: triangle-level MMU data (MODEL_PART only).
-            if (is_part) {
-                if (!mv->mmu_segmentation_facets.empty())
-                    mv->remap_extruder_ids(total_filaments, state_map);
-            }
+            // Level 1: triangle-level MMU data (MODEL_PART only — modifiers
+            // carry no paint data).
+            if (is_part && !mv->mmu_segmentation_facets.empty())
+                mv->remap_extruder_ids(total_filaments, state_map);
 
             // Level 2: config-level extruder for parts and modifiers.
             if (!is_part && !is_modifier) continue;
 
-            const int old_eid = mv->extruder_id(); // effective: volume config, else object config
-            if (old_eid <= 0) continue;
-            auto it = extruder_remap.find(old_eid);
-            if (it == extruder_remap.end()) continue;
-
-            const unsigned int new_eid = it->second;
             const ConfigOption* vol_opt = mv->config.option("extruder");
-            const bool volume_has_own = (vol_opt && vol_opt->getInt() > 0);
-            if (volume_has_own) {
-                mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(new_eid)));
-            } else if (!object_extruder_written) {
-                // Volume inherits the object's extruder — write once on the
-                // object so every inheriting volume follows. Subsequent
-                // inheriting volumes that also need a (different) remap would
-                // now conflict; force them onto their own config instead.
-                mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(new_eid)));
+            if (vol_opt && vol_opt->getInt() > 0) {
+                // Volume owns its extruder — remap it on the volume alone.
+                auto it = extruder_remap.find(vol_opt->getInt());
+                if (it != extruder_remap.end())
+                    mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(it->second)));
+            } else if (obj_remap && !object_extruder_written) {
+                // Volume inherits the object's extruder — write the object ONCE
+                // so every inheriting volume follows the same target. Later
+                // inheriting volumes need no action: they resolve through the
+                // (already rewritten) object config.
+                mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(obj_it->second)));
                 object_extruder_written = true;
-            } else {
-                // Object already remapped by an earlier inheriting volume but
-                // this volume needs a different target — give it its own
-                // config entry so it does not inherit the wrong value.
-                mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(new_eid)));
             }
         }
 

--- a/src/slic3r/GUI/MixedColorMatchHelpers.hpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.hpp
@@ -264,8 +264,7 @@ void populate_mixed_filaments_from_mappings(
 /// Apply matched recipes back to model painting data.
 /// Walks every volume's mmu_segmentation_facets and remaps original
 /// extruder_id→target_filament_id from the match result.
-void apply_batch_match_to_model(const BatchMatchResult& result,
-                                 Slic3r::Print&          print);
+void apply_batch_match_to_model(const BatchMatchResult& result);
 
 /// Recommend best 4-color filament combo from available presets.
 /// Pre-filters to Top-15 by single-color ΔE, then scores C(15,4)=1365 combos.

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -711,16 +711,7 @@ void MixedFilamentBatchDialog::load_model_colors()
 
     for (const ModelObject* mo : wxGetApp().model().objects) {
         for (const ModelVolume* mv : mo->volumes) {
-            if (!mv) continue;
-            // Include MODEL_PART and PARAMETER_MODIFIER (modifier) volumes.
-            // A modifier carries a user-chosen colour in the object list; that
-            // colour must also be matched and remapped, otherwise the modifier
-            // is stranded on its old physical-slot extruder after the palette
-            // is rewritten (the "modifier colour reset to extruder 1" bug).
-            // Other volume types (negative/support) have no meaningful colour.
-            const ModelVolumeType vt = mv->type();
-            if (vt != ModelVolumeType::MODEL_PART
-                && vt != ModelVolumeType::PARAMETER_MODIFIER) continue;
+            if (!mv || mv->type() != ModelVolumeType::MODEL_PART) continue;
 
             for (int eid : mv->get_extruders()) {
                 if (eid < 1 || eid > int(MAXIMUM_EXTRUDER_NUMBER)) continue;
@@ -747,51 +738,10 @@ void MixedFilamentBatchDialog::load_model_colors()
                 auto it = std::find_if(hex_to_eids.begin(), hex_to_eids.end(),
                     [&](const auto& p) { return p.first == hex_norm; });
                 if (it != hex_to_eids.end()) {
-                    // Avoid duplicate extruder ids for the same colour when a
-                    // modifier inherits the same extruder as a part.
-                    if (std::find(it->second.begin(), it->second.end(),
-                                  static_cast<unsigned int>(eid)) == it->second.end())
-                        it->second.push_back(static_cast<unsigned int>(eid));
+                    it->second.push_back(static_cast<unsigned int>(eid));
                 } else {
                     hex_to_eids.push_back({hex_norm.ToStdString(), {static_cast<unsigned int>(eid)}});
                 }
-            }
-        }
-
-        // Also collect layer-object extruders (layer_config_ranges) so a
-        // layer's filament — which may differ from any volume's — is a match
-        // source; otherwise apply_batch_match_to_model cannot remap it and it
-        // strands on a physical slot that cleanup deletes.
-        for (const auto& lr : mo->layer_config_ranges) {
-            const ModelConfig&  lcfg = lr.second;
-            const ConfigOption* lopt = lcfg.option("extruder");
-            if (!lopt) continue;
-            const int eid = lopt->getInt();
-            if (eid < 1 || eid > int(MAXIMUM_EXTRUDER_NUMBER)) continue;
-
-            std::string color_hex;
-            if (size_t(eid - 1) < co->values.size()) {
-                color_hex = co->values[size_t(eid - 1)];
-            } else {
-                const MixedFilament* mf = pb->mixed_filaments.mixed_filament_from_id(
-                    static_cast<unsigned int>(eid), num_physical);
-                if (mf && !mf->display_color.empty())
-                    color_hex = mf->display_color;
-            }
-            if (color_hex.empty()) continue;
-
-            wxColour c;
-            if (!try_parse_color_match_hex(color_hex, c)) continue;
-            const wxString hex_norm = normalize_color_match_hex(color_hex);
-
-            auto it = std::find_if(hex_to_eids.begin(), hex_to_eids.end(),
-                [&](const auto& p) { return p.first == hex_norm; });
-            if (it != hex_to_eids.end()) {
-                if (std::find(it->second.begin(), it->second.end(),
-                              static_cast<unsigned int>(eid)) == it->second.end())
-                    it->second.push_back(static_cast<unsigned int>(eid));
-            } else {
-                hex_to_eids.push_back({hex_norm.ToStdString(), {static_cast<unsigned int>(eid)}});
             }
         }
     }

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -711,7 +711,16 @@ void MixedFilamentBatchDialog::load_model_colors()
 
     for (const ModelObject* mo : wxGetApp().model().objects) {
         for (const ModelVolume* mv : mo->volumes) {
-            if (!mv || mv->type() != ModelVolumeType::MODEL_PART) continue;
+            if (!mv) continue;
+            // Include MODEL_PART and PARAMETER_MODIFIER (modifier) volumes.
+            // A modifier carries a user-chosen colour in the object list; that
+            // colour must also be matched and remapped, otherwise the modifier
+            // is stranded on its old physical-slot extruder after the palette
+            // is rewritten (the "modifier colour reset to extruder 1" bug).
+            // Other volume types (negative/support) have no meaningful colour.
+            const ModelVolumeType vt = mv->type();
+            if (vt != ModelVolumeType::MODEL_PART
+                && vt != ModelVolumeType::PARAMETER_MODIFIER) continue;
 
             for (int eid : mv->get_extruders()) {
                 if (eid < 1 || eid > int(MAXIMUM_EXTRUDER_NUMBER)) continue;
@@ -738,7 +747,11 @@ void MixedFilamentBatchDialog::load_model_colors()
                 auto it = std::find_if(hex_to_eids.begin(), hex_to_eids.end(),
                     [&](const auto& p) { return p.first == hex_norm; });
                 if (it != hex_to_eids.end()) {
-                    it->second.push_back(static_cast<unsigned int>(eid));
+                    // Avoid duplicate extruder ids for the same colour when a
+                    // modifier inherits the same extruder as a part.
+                    if (std::find(it->second.begin(), it->second.end(),
+                                  static_cast<unsigned int>(eid)) == it->second.end())
+                        it->second.push_back(static_cast<unsigned int>(eid));
                 } else {
                     hex_to_eids.push_back({hex_norm.ToStdString(), {static_cast<unsigned int>(eid)}});
                 }

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -757,6 +757,43 @@ void MixedFilamentBatchDialog::load_model_colors()
                 }
             }
         }
+
+        // Also collect layer-object extruders (layer_config_ranges) so a
+        // layer's filament — which may differ from any volume's — is a match
+        // source; otherwise apply_batch_match_to_model cannot remap it and it
+        // strands on a physical slot that cleanup deletes.
+        for (const auto& lr : mo->layer_config_ranges) {
+            const ModelConfig&  lcfg = lr.second;
+            const ConfigOption* lopt = lcfg.option("extruder");
+            if (!lopt) continue;
+            const int eid = lopt->getInt();
+            if (eid < 1 || eid > int(MAXIMUM_EXTRUDER_NUMBER)) continue;
+
+            std::string color_hex;
+            if (size_t(eid - 1) < co->values.size()) {
+                color_hex = co->values[size_t(eid - 1)];
+            } else {
+                const MixedFilament* mf = pb->mixed_filaments.mixed_filament_from_id(
+                    static_cast<unsigned int>(eid), num_physical);
+                if (mf && !mf->display_color.empty())
+                    color_hex = mf->display_color;
+            }
+            if (color_hex.empty()) continue;
+
+            wxColour c;
+            if (!try_parse_color_match_hex(color_hex, c)) continue;
+            const wxString hex_norm = normalize_color_match_hex(color_hex);
+
+            auto it = std::find_if(hex_to_eids.begin(), hex_to_eids.end(),
+                [&](const auto& p) { return p.first == hex_norm; });
+            if (it != hex_to_eids.end()) {
+                if (std::find(it->second.begin(), it->second.end(),
+                              static_cast<unsigned int>(eid)) == it->second.end())
+                    it->second.push_back(static_cast<unsigned int>(eid));
+            } else {
+                hex_to_eids.push_back({hex_norm.ToStdString(), {static_cast<unsigned int>(eid)}});
+            }
+        }
     }
 
     // If no model volumes provided extruders, fall back to the palette-index

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2636,7 +2636,7 @@ Sidebar::Sidebar(Plater *parent)
         }
         // Apply matched recipes to model painting data
         set_progress(5);
-        apply_batch_match_to_model(model_result, wxGetApp().plater()->fff_print());
+        apply_batch_match_to_model(model_result);
 
         // Remove physical/mixed filaments left unreferenced by the match. This is
         // ~96% of apply time (per-deletion combo rebuild). Map the deletion loop's

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -4552,6 +4552,158 @@ TEST_CASE("manual-mode painting on a selected physical survives with kept-aware 
     CHECK(!volume->mmu_segmentation_facets.has_facets(*volume, EnforcerBlockerType(6)));  // gone from old slot 6
 }
 
+// ===========================================================================
+// Modifier & layer-config remap (apply_batch_match_to_model Level-2 + Level-3)
+//
+// apply_batch_match_to_model lives in the GUI layer (depends on wxGetApp()) so
+// the test binary cannot link it. These tests mirror its Level-2 (volume/object
+// config extruder) and Level-3 (layer_config_ranges) passes over the REAL
+// libslic3r Model API — the same approach the manual-mode tests above use for
+// the triangle-painting pass. Keep the mirror byte-faithful to the production
+// loop (MixedColorMatchHelpers.cpp); a change there must surface here.
+//
+// Level-2 reads the object's extruder ONCE before iterating volumes (a
+// snapshot). ModelVolume::extruder_id() otherwise falls back to the OBJECT
+// config, which this loop rewrites mid-iteration — so re-reading it for a later
+// inheriting volume would resolve a different id than the first, making two
+// volumes that share one source diverge. The first test below pins that real
+// libslic3r contract; the rest pin the apply end-state.
+// ===========================================================================
+
+// Mirror of apply_batch_match_to_model's Level-2 (config) + Level-3 (layer)
+// passes (MixedColorMatchHelpers.cpp). Covers ONLY those two passes — the
+// Level-1 triangle-painting pass is exercised by the manual-mode tests above.
+static void apply_config_layer_remap_mirror(
+    Model&                                        model,
+    const std::unordered_map<int, unsigned int>&  extruder_remap)
+{
+    for (ModelObject* mo : model.objects) {
+        const ConfigOption* obj_opt      = mo->config.option("extruder");
+        const int           orig_obj_eid = (obj_opt ? obj_opt->getInt() : 0);
+        auto                obj_it       = extruder_remap.find(orig_obj_eid);
+        const bool          obj_remap    = (orig_obj_eid > 0 && obj_it != extruder_remap.end());
+        bool                object_extruder_written = false;
+        for (ModelVolume* mv : mo->volumes) {
+            const ModelVolumeType vt = mv->type();
+            const bool is_part      = (vt == ModelVolumeType::MODEL_PART);
+            const bool is_modifier  = (vt == ModelVolumeType::PARAMETER_MODIFIER);
+            if (!is_part && !is_modifier) continue;
+
+            const ConfigOption* vol_opt = mv->config.option("extruder");
+            if (vol_opt && vol_opt->getInt() > 0) {
+                auto it = extruder_remap.find(vol_opt->getInt());
+                if (it != extruder_remap.end())
+                    mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(it->second)));
+            } else if (obj_remap && !object_extruder_written) {
+                mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(obj_it->second)));
+                object_extruder_written = true;
+            }
+        }
+
+        for (auto& lr : mo->layer_config_ranges) {
+            ModelConfig&         lcfg = lr.second;
+            const ConfigOption*  lopt = lcfg.option("extruder");
+            if (!lopt) continue;
+            const int old_eid = lopt->getInt();
+            if (old_eid <= 0) continue;
+            auto lit = extruder_remap.find(old_eid);
+            if (lit == extruder_remap.end()) continue;
+            lcfg.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(lit->second)));
+        }
+    }
+}
+
+TEST_CASE("ModelVolume::extruder_id falls back to live object config (snapshot rationale)", "[MixedFilament][batch_apply]")
+{
+    // Pins the libslic3r contract that makes apply_batch_match_to_model pre-read
+    // the object extruder: a volume with no own "extruder" resolves
+    // extruder_id() through the OBJECT config, and that resolution is LIVE —
+    // rewriting the object config changes what a later inheriting volume
+    // resolves. Without a pre-loop snapshot, two inheriting volumes that share
+    // one source would resolve different targets once the loop writes the object
+    // config mid-iteration. Pure libslic3r — no mirror.
+    Model model;
+    ModelObject *obj  = model.add_object();
+    ModelVolume  *part = obj->add_volume(make_cube(20., 20., 20.));
+    ModelVolume  *mod  = obj->add_volume(make_cube(20., 20., 20.), ModelVolumeType::PARAMETER_MODIFIER);
+    obj->config.set_key_value("extruder", new ConfigOptionInt(5));
+
+    // Neither volume owns an extruder → both inherit the object's 5.
+    REQUIRE(part->extruder_id() == 5);
+    REQUIRE(mod->extruder_id()  == 5);
+
+    // Simulate the apply loop writing the object extruder for the FIRST
+    // inheriting volume (5 -> 7). The second inheriting volume now resolves 7
+    // — proving extruder_id() reads the CURRENT object config, not a snapshot.
+    obj->config.set_key_value("extruder", new ConfigOptionInt(7));
+    REQUIRE(part->extruder_id() == 7);
+    REQUIRE(mod->extruder_id()  == 7);
+}
+
+TEST_CASE("apply config remap: inheriting modifier follows object consistently", "[MixedFilament][batch_apply]")
+{
+    // The modifier-inclusion fix's core contract: a modifier that inherits the
+    // object's extruder must follow the SAME target as the part that inherits
+    // it, so their colours stay the same hue. remap {5 -> 7}; both volumes
+    // inherit object=5, so both must end on 7 — no divergence, regardless of
+    // mo->volumes ordering.
+    Model model;
+    ModelObject *obj  = model.add_object();
+    ModelVolume  *part = obj->add_volume(make_cube(20., 20., 20.));
+    ModelVolume  *mod  = obj->add_volume(make_cube(20., 20., 20.), ModelVolumeType::PARAMETER_MODIFIER);
+    obj->config.set_key_value("extruder", new ConfigOptionInt(5));
+
+    std::unordered_map<int, unsigned int> remap{{5, 7u}};
+    apply_config_layer_remap_mirror(model, remap);
+
+    // Object written once to 7; both inheriting volumes resolve 7.
+    REQUIRE(obj->config.opt_int("extruder") == 7);
+    REQUIRE(part->extruder_id() == 7);
+    REQUIRE(mod->extruder_id()  == 7);
+    // Neither volume gained its own config entry — they still inherit.
+    REQUIRE_FALSE(part->config.has("extruder"));
+    REQUIRE_FALSE(mod->config.has("extruder"));
+}
+
+TEST_CASE("apply config remap: modifier with own extruder is remapped alone", "[MixedFilament][batch_apply]")
+{
+    // A modifier that carries its own extruder (user picked a colour in the
+    // object list) is remapped on its OWN config only; the object and any other
+    // volume are untouched.
+    Model model;
+    ModelObject *obj  = model.add_object();
+    ModelVolume  *part = obj->add_volume(make_cube(20., 20., 20.));
+    ModelVolume  *mod  = obj->add_volume(make_cube(20., 20., 20.), ModelVolumeType::PARAMETER_MODIFIER);
+    obj->config.set_key_value("extruder",  new ConfigOptionInt(1)); // object default (not remapped)
+    part->config.set_key_value("extruder", new ConfigOptionInt(3));
+    mod->config.set_key_value("extruder",  new ConfigOptionInt(4));
+
+    std::unordered_map<int, unsigned int> remap{{3, 7u}, {4, 8u}};
+    apply_config_layer_remap_mirror(model, remap);
+
+    REQUIRE(part->extruder_id() == 7);
+    REQUIRE(mod->extruder_id()  == 8);
+    REQUIRE(obj->config.opt_int("extruder") == 1); // object untouched
+}
+
+TEST_CASE("apply layer remap: hit is remapped, miss is left untouched", "[MixedFilament][batch_apply]")
+{
+    // Level-3 (layer_config_ranges): a height range whose extruder is in the
+    // remap follows the match; one whose extruder is NOT in the remap stays put
+    // (so a layer on an unchanged slot is not reset to default by cleanup).
+    Model model;
+    ModelObject *obj = model.add_object();
+    obj->add_volume(make_cube(20., 20., 20.));
+    obj->layer_config_ranges[t_layer_height_range{0.0, 1.0}].set_key_value("extruder", new ConfigOptionInt(5));
+    obj->layer_config_ranges[t_layer_height_range{1.0, 2.0}].set_key_value("extruder", new ConfigOptionInt(9));
+
+    std::unordered_map<int, unsigned int> remap{{5, 7u}}; // 9 absent → miss
+    apply_config_layer_remap_mirror(model, remap);
+
+    REQUIRE(obj->layer_config_ranges.at(t_layer_height_range{0.0, 1.0}).opt_int("extruder") == 7);
+    REQUIRE(obj->layer_config_ranges.at(t_layer_height_range{1.0, 2.0}).opt_int("extruder") == 9);
+}
+
 TEST_CASE("manual-mode apply migrates unselected-physical painting off its slot", "[MixedFilament][batch_apply]")
 {
     // Validates the precondition for the kept-aware cleanup fix (fix-verification


### PR DESCRIPTION
fix(mixed-filament): 1. remap layer-object extruders in batch color match

The batch color match walked only MODEL_PART volumes, so a
PARAMETER_MODIFIER's user-chosen colour was dropped: the modifier kept its
old physical-slot extruder after the palette was rewritten, surfacing as
"modifier colour reset to extruder 1".

Include PARAMETER_MODIFIER alongside MODEL_PART in all three model-walking
sites of the match:
- load_model_colors: collect the modifier's colour/extruder as a match
  source; dedup its eid when it inherits the same extruder as a part;
- extract_model_colors: same inclusion for the helper path;
- apply_batch_match_to_model: Level 2 (config extruder) now remaps
  modifiers too. Level 1 (triangle MMU paint) stays MODEL_PART-only since
  modifiers carry no paint data. An object_extruder_written flag avoids
  double-writing the object extruder when several inheriting volumes
  follow it.

fix(mixed-filament): remap layer-object extruders in batch color match

Batch color match only remapped object/volume extruders and ignored
layer_config_ranges entirely. A layer object's filament stayed on its old
physical slot after the palette was rewritten, so when cleanup deleted the
unreferenced physical filaments the layer was reset to default — surfacing
as "layer filament >N lost / reset to default".

Include layer_config_ranges alongside volumes:
- apply_batch_match_to_model: add a Level-3 pass that remaps each layer
  object's extruder with the same extruder_remap used for volumes;
- load_model_colors: collect layer-object extruders as match sources too,
  so a layer whose filament no volume paints still gets matched and remapped.

