### PR TITLE
fix(support): port Bambu cantilever floating-contour detection to fix large ring overhangs being dropped

### DIFF
--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -977,11 +977,11 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
                 // check cantilever
                 auto lower_layer_support_thresh = offset_ex(lower_polys, extrusion_width_scaled, SUPPORT_SURFACES_OFFSET_PARAMETERS);
                 // lower_layer_offset may be very small, so we need to do max and then add 0.1
-                lower_layer_offseted            = offset_ex(lower_layer_offseted, scale_(std::max(extrusion_width - lower_layer_offset, 0.) + 0.1));
+                lower_layer_offseted = offset_ex(lower_layer_offseted, scale_(std::max(extrusion_width - lower_layer_offset, 0.) + 0.1));
                 for (ExPolygon& poly : overhangs_all_layers[layer_nr]) {
                     // check if there is some contour that is totally floating
                     bool   is_cantilever = false;
-                    double dist_max      = 0;
+                    double dist_max = 0;
                     for (size_t i = 0; i < poly.num_contours(); i++) {
                         Polygon contour      = poly.contour_or_hole(i);
                         bool    is_floating  = true;
@@ -996,14 +996,14 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
                         }
                         if (is_floating) {
                             is_cantilever = true;
-                            dist_max      = tmp_dist_max;
+                            dist_max = tmp_dist_max;
                             break;
                         }
                     }
                     if (!is_cantilever) {
                         dist_max = 0;
-                        auto     cluster_boundary_ex = intersection_ex(poly, lower_layer_offseted);
-                        Polygons cluster_boundary    = to_polygons(cluster_boundary_ex);
+                        auto cluster_boundary_ex = intersection_ex(poly, lower_layer_offseted);
+                        Polygons cluster_boundary = to_polygons(cluster_boundary_ex);
                         if (cluster_boundary.empty()) continue;
 
                         for (auto& pt : poly.contour.points) {

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -910,7 +910,7 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
                 if (layer->lower_layer == nullptr) {
                     for (auto& slice : layer->lslices_extrudable) {
                         auto bbox_size = get_extents(slice).size();
-                        if (!((bbox_size.x() > length_thresh_well_supported && bbox_size.y() > length_thresh_well_supported))
+                        if (!(bbox_size.x() > length_thresh_well_supported || bbox_size.y() > length_thresh_well_supported)
                             && g_config_support_sharp_tails) {
                             layer->sharp_tails.push_back(slice);
                             layer->sharp_tails_height.push_back(layer->height);
@@ -944,8 +944,21 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
                         bool  is_sharp_tail = false;
                         // 1. nothing below
                         // this is a sharp tail region if it's floating and non-ignorable
-                        if (!overlaps(offset_ex(expoly, 0.1 * extrusion_width_scaled), lower_polys)) {
+                        // The (area && bbox) gate excludes "large looped structures" but also catches
+                        // thin-but-wide rings (small area, large bbox), which would otherwise be dropped
+                        // by check_small_overhang and end up unsupported. Rescue them here: if eroding by
+                        // radius_thresh_small_overhang (the same radius small-overhang detection uses)
+                        // makes the polygon vanish, treat it as a sharp tail regardless of bbox.
+                        if (!overlaps(offset_ex(expoly, 0.1 * extrusion_width_scaled), lower_polys) &&
+                            area(expoly) < SQ(m_support_params.thresh_big_overhang) &&
+                            (get_extents(expoly).area() < SQ(m_support_params.thresh_big_overhang) ||
+                             offset_ex(expoly, -radius_thresh_small_overhang).empty())) {
                             is_sharp_tail = !offset_ex(expoly, -0.1 * extrusion_width_scaled).empty();
+                        }
+
+                        if (is_sharp_tail && lower_layer->lower_layer) {
+                            if (overlaps(offset_ex(expoly, 0.1 * extrusion_width_scaled), lower_layer->lower_layer->lslices_extrudable))
+                                is_sharp_tail = false;
                         }
 
                         if (is_sharp_tail) {
@@ -962,22 +975,49 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
 
 
                 // check cantilever
+                auto lower_layer_support_thresh = offset_ex(lower_polys, extrusion_width_scaled, SUPPORT_SURFACES_OFFSET_PARAMETERS);
                 // lower_layer_offset may be very small, so we need to do max and then add 0.1
-                lower_layer_offseted = offset_ex(lower_layer_offseted, scale_(std::max(extrusion_width - lower_layer_offset, 0.) + 0.1));
+                lower_layer_offseted            = offset_ex(lower_layer_offseted, scale_(std::max(extrusion_width - lower_layer_offset, 0.) + 0.1));
                 for (ExPolygon& poly : overhangs_all_layers[layer_nr]) {
-                    auto cluster_boundary_ex = intersection_ex(poly, lower_layer_offseted);
-                    Polygons cluster_boundary = to_polygons(cluster_boundary_ex);
-                    if (cluster_boundary.empty()) continue;
-                    double dist_max = 0;
-                    for (auto& pt : poly.contour.points) {
-                        double dist_pt = std::numeric_limits<double>::max();
-                        for (auto& ply : cluster_boundary) {
-                            double d = ply.distance_to(pt);
-                            dist_pt = std::min(dist_pt, d);
+                    // check if there is some contour that is totally floating
+                    bool   is_cantilever = false;
+                    double dist_max      = 0;
+                    for (size_t i = 0; i < poly.num_contours(); i++) {
+                        Polygon contour      = poly.contour_or_hole(i);
+                        bool    is_floating  = true;
+                        double  tmp_dist_max = 0;
+                        for (const auto& pt : contour.points) {
+                            if (is_inside_ex(lower_layer_support_thresh, pt)) {
+                                is_floating = false;
+                                break;
+                            } else {
+                                tmp_dist_max = std::max(tmp_dist_max, (projection_onto(lower_layer_support_thresh, pt) - pt).cast<double>().norm());
+                            }
                         }
-                        dist_max = std::max(dist_max, dist_pt);
+                        if (is_floating) {
+                            is_cantilever = true;
+                            dist_max      = tmp_dist_max;
+                            break;
+                        }
                     }
-                    if (dist_max > scale_(3)) {  // is cantilever if the farmost point is larger than 3mm away from base
+                    if (!is_cantilever) {
+                        dist_max = 0;
+                        auto     cluster_boundary_ex = intersection_ex(poly, lower_layer_offseted);
+                        Polygons cluster_boundary    = to_polygons(cluster_boundary_ex);
+                        if (cluster_boundary.empty()) continue;
+
+                        for (auto& pt : poly.contour.points) {
+                            double dist_pt = std::numeric_limits<double>::max();
+                            for (auto& ply : cluster_boundary) {
+                                double d = ply.distance_to(pt);
+                                dist_pt  = std::min(dist_pt, d);
+                            }
+                            dist_max = std::max(dist_max, dist_pt);
+                        }
+                        is_cantilever = dist_max > scale_(3);
+                    }
+                    // is cantilever if the farmost point is larger than 3mm away from base or some contour is totally floating
+                    if (is_cantilever) {
                         max_cantilever_dist = std::max(max_cantilever_dist, dist_max);
                         layer->cantilevers.emplace_back(poly);
                         BOOST_LOG_TRIVIAL(debug) << "found a cantilever cluster. layer_nr=" << layer_nr << dist_max;

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -983,8 +983,8 @@ void TreeSupport::detect_overhangs(bool check_support_necessity/* = false*/)
                     bool   is_cantilever = false;
                     double dist_max = 0;
                     for (size_t i = 0; i < poly.num_contours(); i++) {
-                        Polygon contour      = poly.contour_or_hole(i);
-                        bool    is_floating  = true;
+                        Polygon contour = poly.contour_or_hole(i);
+                        bool is_floating  = true;
                         double  tmp_dist_max = 0;
                         for (const auto& pt : contour.points) {
                             if (is_inside_ex(lower_layer_support_thresh, pt)) {


### PR DESCRIPTION
# fix(support): port Bambu cantilever floating-contour detection to fix large ring overhangs being dropped

## Description

This PR ports the "fully-floating contour" cantilever detection logic from BambuStudio into `TreeSupport::detect_overhangs`, fixing a bug where **large-area, large-perimeter overhangs (e.g. tube-top rings, plates with hovering holes) were misclassified as small overhangs and lost all support** once `Remove small overhangs` was enabled.

### Problem

For tree support (auto), cantilever detection previously relied on a **single criterion**: the farthest point on the *outer* contour must be more than 3 mm from the lower-layer base. This criterion fails for two common geometries:

1. **Tube-top rings** — a ring overhang at the top of a tube/cylinder. The outer edge floats but is often < 3 mm from the lower layer, while the hole (tube interior) is fully supported.
2. **Plates with hovering holes** — a plate whose outer edge is supported but whose hole boundaries are fully floating (overhanging internal holes).

In both cases the overhang is then routed into `check_small_overhang`, where the Tier-2 "erode-empty" branch (`offset_ex(merged_poly, -2.5*extrusion_width).empty()`) fires because the ring/plate thickness is smaller than the erode radius. The cluster is tagged `Small` and dropped → no support is generated. The symptom worsens when `Support critical regions only` is also enabled, since non-critical types are filtered out on top of the small-overhang removal.

This contradicts the intent of both parameters: these regions are large-area / large-perimeter, not "small overhangs", and they are exactly the kind of structure that should be treated as a "critical region".

### Fix

Aligns the cantilever detection with BambuStudio (`TreeSupport.cpp:1004-1052`):

- Build `lower_layer_support_thresh = lower_polys` offset by 1 extrusion width.
- For **every contour of the overhang (outer contour + all holes)**: if all points are outside `lower_layer_support_thresh`, the contour is fully floating → flag the overhang as `Cantilever` (using `projection_onto` for the distance metric).
- The original `dist_max > 3 mm` path is preserved as a fallback when no fully-floating contour is found.

Once flagged as `Cantilever`:
- `check_small_overhang` returns early (the `type & Cantilever` guard at the top), so it is no longer misclassified as `Small`.
- Under `support_critical_regions_only`, `Cantilever` is one of the three retained "critical region" types, so support is kept.

This PR also brings two SharpTail checks in line with BambuStudio:
- Bottom-layer threshold uses `||` instead of `&&` (either dimension > 6 mm counts as non-sharp).
- Main-loop SharpTail detection gains the area/bbox double gate, the radius-erode rescue branch (for thin-but-wide rings that would otherwise be dropped by `check_small_overhang`), and the two-layers-below overlap suppression.

No new dependencies or helper functions are required — `is_inside_ex`, `projection_onto(ExPolygons, Point)`, `num_contours()` / `contour_or_hole()` all already exist in the codebase.

### Scope of change

Single file, `src/libslic3r/Support/TreeSupport.cpp` (+54 / -14). Behavior of other support types (normal auto support) is unchanged.

## Screenshots/Recordings/Graphs


### Decision flow (after fix)

```
overhang polygon
      |
      v
[1] SharpTail  -- requires no overlap with lower layer (floating)
      |  Case A/B have overlap (inside hole / under plate) -> excluded
      v
[2] Cantilever (FIXED)
      |  A) ANY contour (outer or hole) fully floats -> cantilever   [NEW]
      |  B) outer-contour farthest point > 3 mm       -> cantilever  [kept]
      |  Case A: outer floats -> A hits
      |  Case B: hole floats -> A hits
      v
[3] OverhangCluster build -- inherits type bits
      v
[4] check_small_overhang
      |  if (type & SharpTail || type & Cantilever) SKIP   [guard]
      |  -> already Cantilever, not classified small
      v
[5] generate support (add_overhang)
      |  + survives support_critical_regions_only filtering
```

## Tests

- **Build**: `cmake --build build --target libslic3r --config Release` — compiles cleanly, no warnings.

- **Regression**: The original `dist_max > 3 mm` criterion is retained as a fallback, so existing cantilever detection scenarios are unaffected. The two SharpTail alignment changes match BambuStudio exactly.

- **Manual validation**: Sliced the offending model — the ring/hole regions now receive tree support where they previously had none.

https://github.com/user-attachments/assets/706dd2ee-0019-4203-87ab-80a1c0181341


### Limitations / follow-ups

- The fix focuses on the cantilever classification itself. Larger structural differences vs. BambuStudio (enforcer/blocker pipeline, `m_ts_data`-based `layer_outlines_below`, the 7-arg `remove_bridges_from_contacts`) are intentionally **not** touched in this PR — see the analysis doc for details.