### PR TITLE
fix: dark mode refresh, text updates, anti-flicker, device-switch reason

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -3365,8 +3365,17 @@ msgstr "下载已取消"
 msgid "Download Failed"
 msgstr "下载失败"
 
-msgid "Insufficient disk space."
-msgstr "磁盘空间不足"
+msgid "Failed to download the file. Please check your network and try again."
+msgstr "文件下载失败，请检查网络后重试。"
+
+msgid "Device disconnected."
+msgstr "设备已断开连接"
+
+msgid "Waiting for device to upload"
+msgstr "等待设备上传"
+
+msgid "Insufficient storage space. Please free up space."
+msgstr "磁盘空间不足，请清理存储空间。"
 
 msgid "File was removed. Download canceled."
 msgstr "文件已被移除，下载中断"

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -4953,7 +4953,7 @@ void cancel_all_active_timelapse()
             release_date_index(ctx->files[i].date_index);
             if (ctx->popup && !ctx->popup->IsBeingDeleted()) {
                 ctx->popup->mark_task_error(ctx->row_offset + i,
-                    std::string(_L("File was removed. Download canceled.").ToUTF8().data()));
+                    std::string(_L("Device disconnected.").ToUTF8().data()));
             }
         }
     }
@@ -5337,7 +5337,7 @@ void SSWCP_UserLogin_Instance::sw_DownLoadFile()
             result["available"]  = si.available;
             m_res_data = result;
             m_status   = -1;
-            m_msg      = "insufficient_disk_space";
+            m_msg      = "Insufficient storage space. Please free up space.";
             send_to_js();
             finish_job();
             return;
@@ -5599,14 +5599,10 @@ void SSWCP_UserLogin_Instance::sw_DownLoadFile()
 
                 if (ctx->popup && !ctx->popup->IsBeingDeleted())
                 {
-                    // Map Http timeout to a friendly reason.
-                    bool is_timeout = error.find("timeout") != std::string::npos
-                                   || error.find("Timeout") != std::string::npos
-                                   || error.find("timed out") != std::string::npos;
-                    std::string reason = is_timeout
-                        ? std::string(_L("Network timeout").ToUTF8().data())
-                        : error;
-                    ctx->popup->mark_task_error(global_row, reason);
+                    // Always show a single friendly message — never expose the
+                    // raw Http error string to the UI.
+                    ctx->popup->mark_task_error(global_row,
+                        std::string(_L("Failed to download the file. Please check your network and try again.").ToUTF8().data()));
                 }
 
                 push_file_state(ctx, idx, "failed");
@@ -5697,7 +5693,7 @@ void SSWCP_UserLogin_Instance::sw_DownLoadFile()
                     return;
                 }
                 wxString status = ctx->is_wan
-                    ? _L("Waiting for device upload...")
+                    ? _L("Waiting for device to upload")
                     : _L("Downloading");
                 ctx->popup->set_task_status(ctx->row_offset + cur_idx,
                     wxString::FromUTF8(status.ToUTF8().data()));

--- a/src/slic3r/GUI/Timelapse/TimelapseDownloadPopup.cpp
+++ b/src/slic3r/GUI/Timelapse/TimelapseDownloadPopup.cpp
@@ -127,7 +127,7 @@ TimelapseTaskRow::TimelapseTaskRow(wxWindow* parent, const wxString& file_name)
     , m_state(State::Pending)
     , m_percent(0)
     , m_cancel_enabled(true)
-    , m_status_text(_L("Waiting..."))
+    , m_status_text(_L("Waiting for device to upload"))
 {
     SetBackgroundColour(bg_color());
     SetMinSize(wxSize(FromDIP(ROW_WIDTH), FromDIP(ROW_HEIGHT)));
@@ -218,14 +218,14 @@ void TimelapseTaskRow::set_state(State s)
 
     switch (s) {
         case State::Pending:
-            m_status_text = _L("Waiting...");
+            m_status_text = _L("Waiting for device to upload");
             m_percent = 0;
             m_cancel_enabled = true;
             m_cancel_btn->SetBitmap(create_scaled_bitmap("timelapse_cancel_active", this, CANCEL_SIZE));
             m_cancel_btn->SetCursor(wxCURSOR_HAND);
             break;
         case State::Downloading:
-            if (m_status_text.empty() || m_status_text == _L("Waiting...")) {
+            if (m_status_text.empty() || m_status_text == _L("Waiting for device to upload")) {
                 m_status_text = wxString::Format(_L("%d%%"), m_percent);
             }
             m_cancel_enabled = true;
@@ -256,7 +256,7 @@ void TimelapseTaskRow::set_state(State s)
 
     m_status_label->SetLabel(m_status_text);
     Layout();
-    Refresh();
+    Refresh(false);
 }
 
 void TimelapseTaskRow::set_progress(int percent)
@@ -633,6 +633,10 @@ void TimelapseDownloadPopup::dismiss_row(int index)
 
 void TimelapseDownloadPopup::reorder_rows()
 {
+    // Freeze/Thaw: reorder detaches all rows and re-creates dividers, which
+    // without freezing repaints on every detach/add — visible as flicker.
+    m_task_panel->Freeze();
+
     // Priority: downloading(1) > pending(0) > finished(2,3,4)
     // Only include visible rows.
     std::vector<int> order;
@@ -672,6 +676,7 @@ void TimelapseDownloadPopup::reorder_rows()
     }
     m_task_panel->Layout();
     Layout();
+    m_task_panel->Thaw();
 }
 
 void TimelapseDownloadPopup::position_bottom_right()


### PR DESCRIPTION
# Description

- Dark mode: refresh_dark_mode now Refresh() every child control explicitly
- Anti-flicker: reorder_rows Freeze/Thaw, set_state Refresh(false)
- Text: HTTP errors → "Failed to download file...", device switch → "Device disconnected.", Waiting → "Waiting for device to upload", disk space → "Insufficient storage space. Please free up space."
- Waiting... unified to "Waiting for device to upload"
- cancel_all no longer shows "File was removed" (that's for file delete)
