### PR TITLE
Fix missing overhang layers with supported counterbore bridging

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1884,17 +1884,13 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
 
                     if (!unsupported_filtered.empty()) {
 
-                        //add this directly to the infill list.
-                        // this will avoid to throw wrong offsets into a good polygons
-                        this->fill_surfaces->append(
-                            unsupported_filtered,
-                            stInternal);
-
-                        // When support is disabled, remove the bridge area from the model surface
-                        // to prevent unsupported perimeters. When support is enabled, keep the model
-                        // surface intact so that perimeters and overhang walls are generated normally.
                         if (!this->object_config->enable_support.value) {
-                            // store the results
+                            // Support is disabled: remove the bridge area from the model surface
+                            // to prevent unsupported perimeters, and add the full area to fill_surfaces
+                            // to ensure the gap is still filled.
+                            this->fill_surfaces->append(
+                                unsupported_filtered,
+                                stInternal);
                             last = diff_ex(last, unsupported_filtered, ApplySafetyOffset::Yes);
                             //remove "thin air" polygons (note: it assumes that all polygons below will be extruded)
                             for (int i = 0; i < last.size(); i++) {
@@ -1905,6 +1901,19 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
                                     last.erase(last.begin() + i);
                                     i--;
                                 }
+                            }
+                        } else {
+                            // Support is enabled: keep the model surface intact so that perimeters
+                            // and overhang walls are generated normally. Shrink the bridge fill area
+                            // inward by the perimeter zone width before appending, to avoid overlap
+                            // with the perimeter walls.
+                            int wall_loops = std::max(1, this->config->wall_loops.value);
+                            coord_t perimeter_zone = ext_perimeter_width / 2
+                                + perimeter_spacing * (wall_loops - 1)
+                                + perimeter_spacing / 2;
+                            ExPolygons fill_safe = offset_ex(unsupported_filtered, -perimeter_zone);
+                            if (!fill_safe.empty()) {
+                                this->fill_surfaces->append(fill_safe, stInternal);
                             }
                         }
                     }

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1840,7 +1840,10 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
                                     ExPolygons bridges_temp = offset2_ex(intersection_ex(last, diff_ex(unsupported_filtered, unbridgeable), ApplySafetyOffset::Yes), -ext_perimeter_width / 4, ext_perimeter_width / 4);
                                     //remove the overhangs section from the surface polygons
                                     ExPolygons reference = last;
-                                    last = diff_ex(last, unsupported_filtered);
+                                    // When support is enabled, do not remove the bridge area from the model surface,
+                                    // so that perimeters and overhang walls can still be generated for the supported overhang.
+                                    if (!this->object_config->enable_support.value)
+                                        last = diff_ex(last, unsupported_filtered);
                                     //ExPolygons no_bridge = diff_ex(offset_ex(unbridgeable, ext_perimeter_width * 3 / 2), last);
                                     //bridges_temp = diff_ex(bridges_temp, no_bridge);
                                     coordf_t offset_to_do = bridged_infill_margin;
@@ -1887,16 +1890,21 @@ void PerimeterGenerator::process_no_bridge(Surfaces& all_surfaces, coord_t perim
                             unsupported_filtered,
                             stInternal);
 
-                        // store the results
-                        last = diff_ex(last, unsupported_filtered, ApplySafetyOffset::Yes);
-                        //remove "thin air" polygons (note: it assumes that all polygons below will be extruded)
-                        for (int i = 0; i < last.size(); i++) {
-                            if (intersection_ex(support, ExPolygons() = { last[i] }).empty()) {
-                                this->fill_surfaces->append(
-                                    ExPolygons() = { last[i] },
-                                    stInternal);
-                                last.erase(last.begin() + i);
-                                i--;
+                        // When support is disabled, remove the bridge area from the model surface
+                        // to prevent unsupported perimeters. When support is enabled, keep the model
+                        // surface intact so that perimeters and overhang walls are generated normally.
+                        if (!this->object_config->enable_support.value) {
+                            // store the results
+                            last = diff_ex(last, unsupported_filtered, ApplySafetyOffset::Yes);
+                            //remove "thin air" polygons (note: it assumes that all polygons below will be extruded)
+                            for (int i = 0; i < last.size(); i++) {
+                                if (intersection_ex(support, ExPolygons() = { last[i] }).empty()) {
+                                    this->fill_surfaces->append(
+                                        ExPolygons() = { last[i] },
+                                        stInternal);
+                                    last.erase(last.begin() + i);
+                                    i--;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
# Description

This PR fixes an issue where enabling **Counterbore Hole Bridging - Partially Bridged** could cause overhang layers that contact support to be missing.

Root cause:
`PerimeterGenerator::process_no_bridge()` treated the counterbore bridging candidate area as a special fill area and removed it from the original surface (`last`). Since `last` is later used to generate perimeter and overhang wall paths, removing this area caused the model body overhang layer to disappear when support was enabled.

Changes:
- When support is enabled, `unsupported_filtered` is no longer removed from `last`, so the original model surface is preserved and perimeter/overhang wall paths can still be generated.
- For the post-processing fill path, support-enabled cases now shrink the extra counterbore fill area inward before appending it to `fill_surfaces`.
- The shrink distance is based on the perimeter occupied zone:
  `ext_perimeter_width / 2 + perimeter_spacing * (wall_loops - 1) + perimeter_spacing / 2`
- This keeps counterbore bridging fill while preventing it from interfering with inner/outer walls.
- Support-disabled behavior remains unchanged.
- No UI or configuration semantics are changed.
- The surface type remains `stInternal`; this PR does not change it to `stBottomBridge`.

# Screenshots/Recordings/Graphs

Before:
- With `counterbore_hole_bridging = chbBridges` and support enabled, the overhang layer touching support was missing.
- After preserving the surface, the fill could interfere with inner/outer wall paths.
<img width="2533" height="1350" alt="image" src="https://github.com/user-attachments/assets/e51b1775-6312-4c27-871b-cc4390099293" />
<img width="2550" height="1363" alt="image" src="https://github.com/user-attachments/assets/310a2b7a-8c2a-4afe-83fb-56376b794e7b" />


After:
- The overhang layer is preserved.
- Counterbore fill is still generated.
- The fill area is inset from the perimeter zone and no longer interferes with inner/outer walls.
<img width="2548" height="1374" alt="image" src="https://github.com/user-attachments/assets/40b7ccec-5da3-470f-9888-5bf74645ff22" />

# Tests

Verified with the reproduced 3MF model:

- `counterbore_hole_bridging = chbNone`
  - Layer 26 overhang layer exists as baseline.

- `counterbore_hole_bridging = chbBridges` with support enabled
  - Layer 26 overhang layer is preserved.
  - Counterbore fill remains present.
  - Fill no longer interferes with inner/outer walls.

- Support disabled with `chbBridges`
  - Original behavior is preserved.

Recommended regression checks:
- Compare `chbNone` and `chbBridges` on the same Z layer.
- Test different wall loop counts.
- Check `chbFilled` with support enabled if it shares the same post-processing path.