### PR TITLE
fix: improve WebView initialization and API key injection for Flutter web

### DIFF
--- a/src/slic3r/GUI/PrinterWebView.cpp
+++ b/src/slic3r/GUI/PrinterWebView.cpp
@@ -129,21 +129,37 @@ void PrinterWebView::SendAPIKey()
         return;
     m_apikey_sent   = true;
     wxString script = wxString::Format(R"(
-    // Check if window.fetch exists before overriding
-    if (window.fetch) {
-        const originalFetch = window.fetch;
-        window.fetch = function(input, init = {}) {
-            init.headers = init.headers || {};
-            init.headers['X-API-Key'] = '%s';
-            return originalFetch(input, init);
+    (function() {
+        var apiKey = '%s';
+        // Override fetch to inject X-API-Key header
+        if (window.fetch) {
+            var originalFetch = window.fetch;
+            window.fetch = function(input, init) {
+                init = init || {};
+                init.headers = init.headers || {};
+                if (!init.headers['X-API-Key']) {
+                    init.headers['X-API-Key'] = apiKey;
+                }
+                return originalFetch(input, init);
+            };
+        }
+        // Override XMLHttpRequest to inject X-API-Key header
+        var OrigXHR = window.XMLHttpRequest;
+        var newXHR = function() {
+            var xhr = new OrigXHR();
+            var origOpen = xhr.open;
+            xhr.open = function(method, url) {
+                origOpen.apply(xhr, arguments);
+                xhr.setRequestHeader('X-API-Key', apiKey);
+            };
+            return xhr;
         };
-    }
+        window.XMLHttpRequest = newXHR;
+    })();
 )",
                                        m_apikey);
-    m_browser->RemoveAllUserScripts();
 
-    m_browser->AddUserScript(script);
-    m_browser->Reload();
+    WebView::RunScript(m_browser, script);
 }
 
 void PrinterWebView::OnError(wxWebViewEvent &evt)

--- a/src/slic3r/GUI/PrinterWebView.cpp
+++ b/src/slic3r/GUI/PrinterWebView.cpp
@@ -72,8 +72,7 @@ void PrinterWebView::load_url(wxString& url, wxString apikey)
     if (m_browser == nullptr)
         return;
     m_apikey = apikey;
-    m_apikey_sent = false;
-    
+
     if (url.find("path=2") != std::string::npos) {
         wxGetApp().fltviews().add_printer_view(this, url, apikey);
     } else {
@@ -125,11 +124,14 @@ void PrinterWebView::OnClose(wxCloseEvent& evt)
 
 void PrinterWebView::SendAPIKey()
 {
-    if (m_apikey_sent || m_apikey.IsEmpty())
+    if (m_apikey.IsEmpty())
         return;
-    m_apikey_sent   = true;
+    // Re-inject on every document load (e.g. context-menu Reload). Idempotent
+    // marker avoids stacking fetch/XHR wrappers if LOADED fires more than once.
     wxString script = wxString::Format(R"(
     (function() {
+        if (window.__sm_apikey_hooked) return;
+        window.__sm_apikey_hooked = true;
         var apiKey = '%s';
         // Override fetch to inject X-API-Key header
         if (window.fetch) {

--- a/src/slic3r/GUI/PrinterWebView.hpp
+++ b/src/slic3r/GUI/PrinterWebView.hpp
@@ -54,7 +54,6 @@ private:
     wxWebView* m_browser;
     long m_zoomFactor;
     wxString m_apikey;
-    bool m_apikey_sent;
 
     // DECLARE_EVENT_TABLE()
 };

--- a/src/slic3r/GUI/WebPreprintDialog.cpp
+++ b/src/slic3r/GUI/WebPreprintDialog.cpp
@@ -24,17 +24,12 @@ WebPreprintDialog::WebPreprintDialog()
                      "/web/flutter_web/index.html?path=5");
     SetBackgroundColour(*wxWHITE);
 
-    // Create the webview
-
-    // 语言判断
-    wxString target_url = wxGetApp().get_international_url(m_prePrint_url);
-
-    m_browser = WebView::CreateWebView(this, target_url);
+    // Create the webview with about:blank; the actual page will be loaded by run()
+    m_browser = WebView::CreateWebView(this, "about:blank");
     if (m_browser == nullptr) {
         wxLogError("Could not init m_browser");
         return;
     }
-    //m_browser->Hide();
 
     // Connect the webview events
     Bind(wxEVT_WEBVIEW_NAVIGATING, &WebPreprintDialog::OnNavigationRequest, this, m_browser->GetId());

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -95,7 +95,6 @@ WebViewPanel::WebViewPanel(wxWindow *parent)
         wxLogError("Could not init m_browser");
         return;
     }
-    m_browser->Hide();
     SetSizer(topsizer);
 
     topsizer->Add(m_browser, wxSizerFlags().Expand().Proportion(1));
@@ -603,7 +602,6 @@ void WebViewPanel::OnNavigationRequest(wxWebViewEvent& evt)
     */
 void WebViewPanel::OnNavigationComplete(wxWebViewEvent& evt)
 {
-    m_browser->Show();
     Layout();
     BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << ": " << evt.GetTarget().ToUTF8().data();
     if (wxGetApp().get_mode() == comDevelop)


### PR DESCRIPTION
## Summary
Fixes several WebView issues that affect Flutter web page loading and API authentication.

## Changes

### 1. `PrinterWebView.cpp` — Extend API key injection to XMLHttpRequest
Previously only `window.fetch` was overridden to inject the `X-API-Key` header. This missed requests made via `XMLHttpRequest` (used by some Flutter web builds). The fix:
- Adds an `XMLHttpRequest` override that injects `X-API-Key` into every request
- Wraps both overrides in an IIFE for proper scoping
- Uses `WebView::RunScript()` to execute the script directly instead of `AddUserScript()` + `Reload()`, which was causing unnecessary page reloads

### 2. `WebPreprintDialog.cpp` — Fix early URL loading
Changed initial page load from the translated Flutter URL to `"about:blank"`. The actual page is now loaded later by the `run()` method after the dialog is fully initialized. This prevents a race condition where the page loaded before the WebView was ready.

### 3. `WebViewDialog.cpp` — Remove unnecessary hide/show
Removed `m_browser->Hide()` at construction and `m_browser->Show()` in `OnNavigationComplete`. The hide/show pair was left over from an older pattern and could cause a visual flicker or brief blank state on load.
