### PR TITLE
fix: mixed-filament issues including painting remap and UI updates

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -15374,11 +15374,14 @@ msgstr "多色"
 msgid "Color Mixing Match"
 msgstr "混色匹配"
 
+msgid "Color Mixing Match is unavailable when only one filament is added to Filament Management."
+msgstr "耗材管理列表仅存在单条耗材时，无法启用混色匹配功能。"
+
 msgid "Color mapping list limit reached (max 64 colors). Excess colors will be removed."
 msgstr "颜色映射列表已达上限（64 色），超出颜色将被移除。"
 
 msgid "Automatically calculate the color mixing scheme that best matches the original model colors and complete color mapping.\nNote:\n1.Color mixing match is based on the official recommended CMYG filaments. The matched colors may differ from the original model.\n2.The order of the Color Mapping list may differ from that of the Color Mixing list."
-msgstr "自动计算最接近原模型颜色的混色方案，并一键完成颜色映射。\n提示：\n① 混色匹配基于官方推荐的 CMYG 耗材进行计算，匹配结果可能与模型原始颜色存在差异。\n②  颜色映射列表中的顺序可能与耗材混色列表的顺序不同。"
+msgstr "自动计算最接近原模型颜色的混色方案，并一键完成颜色映射。\n提示：\n1.混色匹配基于官方推荐的 CMYG 耗材进行计算，匹配结果可能与模型原始颜色存在差异。\n2.颜色映射列表中的顺序可能与耗材混色列表的顺序不同。"
 
 msgid "No model detected. Import a multi-color model to continue."
 msgstr "未检测到模型，请先导入多色模型。"

--- a/resources/profiles/Snapmaker/process/0.10 Color Mixing @Snapmaker U1 (0.4 nozzle).json
+++ b/resources/profiles/Snapmaker/process/0.10 Color Mixing @Snapmaker U1 (0.4 nozzle).json
@@ -5,7 +5,7 @@
     "from": "system",
     "setting_id": "GP103",
     "instantiation": "true",
-    "description": "Compared with the default profile of a 0.4 mm nozzle, it has a smaller layer height, lower speeds and acceleration, and the sparse infill pattern is Gyroid. So, it results in almost negligible layer lines and much higher printing quality, but much longer printing time.",
+    "description": "Using a smaller layer height than the default 0.4 mm nozzle profile produces smoother color transitions. Print time will increase.",
     "default_acceleration": "4000",
     "gap_infill_speed": "230",
     "inner_wall_speed": "150",

--- a/src/libslic3r/MixedFilament.cpp
+++ b/src/libslic3r/MixedFilament.cpp
@@ -2033,6 +2033,64 @@ void MixedFilamentManager::add_batch_custom_filaments(
 }
 
 // --------------------------------------------------------------------------
+// build_mixed_deletion_painting_remap  (pure, testable)
+// --------------------------------------------------------------------------
+std::vector<unsigned int> MixedFilamentManager::build_mixed_deletion_painting_remap(
+    size_t                           num_physical,
+    size_t                           t2_total_filaments,
+    const std::vector<unsigned int>& deleted_t2_vids)
+{
+    // Empty input -> identity (caller should also short-circuit, but stay safe).
+    // Size for the identity return so callers can iterate without a separate check.
+    std::vector<unsigned int> remap(t2_total_filaments + 1, 0u);
+    if (deleted_t2_vids.empty()) {
+        for (size_t i = 1; i <= t2_total_filaments; ++i)
+            remap[i] = static_cast<unsigned int>(i);
+        return remap;
+    }
+
+    // Sort + dedup a local copy so the offset count is correct regardless of
+    // caller order, and so duplicate ids do not inflate the shift.
+    std::vector<unsigned int> sorted_deleted = deleted_t2_vids;
+    std::sort(sorted_deleted.begin(), sorted_deleted.end());
+    sorted_deleted.erase(std::unique(sorted_deleted.begin(), sorted_deleted.end()),
+                         sorted_deleted.end());
+
+    for (size_t old_vid = 1; old_vid <= t2_total_filaments; ++old_vid) {
+        if (old_vid <= num_physical) {
+            // Physical slots are never renumbered by a mixed-only deletion.
+            remap[old_vid] = static_cast<unsigned int>(old_vid);
+            continue;
+        }
+        // deleted_below = count of deleted vids strictly less than old_vid;
+        // since sorted_deleted is ascending, std::lower_bound gives that count.
+        const auto it = std::lower_bound(sorted_deleted.begin(), sorted_deleted.end(),
+                                         static_cast<unsigned int>(old_vid));
+        const size_t deleted_below = static_cast<size_t>(it - sorted_deleted.begin());
+
+        const bool is_deleted = (it != sorted_deleted.end() && *it == static_cast<unsigned int>(old_vid));
+        if (is_deleted) {
+            remap[old_vid] = 0u; // NONE — the deleted row itself.
+        } else {
+            // New T3 id = old T2 id minus the number of deleted rows below it.
+            // deleted_below < old_vid always holds (all deleted vids are >= num_physical+1
+            // and we are past num_physical), so the subtraction cannot underflow here,
+            // but guard defensively against a caller that passes a physical id in the
+            // delete set.
+            if (deleted_below >= old_vid) {
+                BOOST_LOG_TRIVIAL(warning)
+                    << "build_mixed_deletion_painting_remap: deleted_below=" << deleted_below
+                    << " >= old_vid=" << old_vid << " (unexpected); mapping to NONE";
+                remap[old_vid] = 0u;
+            } else {
+                remap[old_vid] = static_cast<unsigned int>(old_vid - deleted_below);
+            }
+        }
+    }
+    return remap;
+}
+
+// --------------------------------------------------------------------------
 // compute_redundant_filaments  (pure, testable)
 // --------------------------------------------------------------------------
 

--- a/src/libslic3r/MixedFilament.hpp
+++ b/src/libslic3r/MixedFilament.hpp
@@ -387,6 +387,30 @@ public:
     static std::string format_surface_offset_token(float value);
     static double      mixed_filament_reference_nozzle_mm(unsigned int component_a, unsigned int component_b, const std::vector<double> &nozzle_diameters);
 
+    // Build the T2(pre-delete) -> T3(post-delete) painting remap for the batch-
+    // match cleanup path that marks redundant mixed rows deleted. Virtual IDs
+    // are enumerated over *enabled* rows, so deleting a row renumbers every
+    // higher survivor down by one; the model's painted facets still hold the
+    // pre-deletion IDs and must be remapped or they resolve to the wrong row.
+    //
+    // Rule (per old_vid in T2 space):
+    //   old_vid in deleted_t2_vids        -> 0          (NONE; the deleted row)
+    //   old_vid <= num_physical           -> old_vid    (physical slots: identity)
+    //   else                              -> old_vid - count(deleted vids < old_vid)
+    //
+    // num_physical:        physical filament count (unchanged by mixed-only deletion).
+    // t2_total_filaments:  total filament count BEFORE deletion (physical + enabled mixed).
+    // deleted_t2_vids:     1-based virtual IDs of the rows being deleted (any order).
+    // Returns:             vector of size t2_total_filaments + 1; remap[0] is unused (0).
+    //
+    // Pure function: no stable_id lookup, no (a,b) pair fallback, no dependence on the
+    // MixedFilament payload. The offset math is the whole computation, which is why it
+    // is unit-testable without the GUI cleanup harness.
+    static std::vector<unsigned int> build_mixed_deletion_painting_remap(
+        size_t                            num_physical,
+        size_t                            t2_total_filaments,
+        const std::vector<unsigned int>&  deleted_t2_vids);
+
     // ---- Accessors ------------------------------------------------------
 
     const std::vector<MixedFilament> &mixed_filaments() const { return m_mixed; }

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -1583,18 +1583,23 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
     // in darkModeColorFor. If it ever renders incorrectly on Windows, remove it
     // and rely on the spacing already in the sizer (AddSpacer pattern), as the
     // other two cards do.
+    //
+    // 8 DIP gap above/below via AddSpacer: divider needs wxLEFT|wxRIGHT=16, and
+    // wxBoxSizer's single border value can't express 8-v / 16-h in one flag.
+    s->AddSpacer(FromDIP(8));
     {
         auto* divider = new wxPanel(m_preview_card, wxID_ANY, wxDefaultPosition, wxSize(-1, 1));
         divider->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#F3F4F6")));
-        s->Add(divider, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(16));
+        s->Add(divider, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(16));
     }
+    s->AddSpacer(FromDIP(8));
 
     // Centered controls: Plate (prev arrow + label + combo + next arrow) | View (label + combo)
     {
         auto* crow = new wxBoxSizer(wxHORIZONTAL);
         m_btn_tray_prev = new ScalableButton(m_preview_card, wxID_ANY, "filament_picker_left_arrow");
         m_btn_tray_prev->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { on_tray_nav(-1); });
-        crow->Add(m_btn_tray_prev, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(6));
+        crow->Add(m_btn_tray_prev, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(10));
 
         auto* plate_lbl = new wxStaticText(m_preview_card, wxID_ANY, _L("Plate"));
         plate_lbl->SetFont(Label::Body_12);
@@ -1619,11 +1624,11 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
             update_nav_arrow_state();
             refresh_previews();
         });
-        crow->Add(m_tray_combo, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(6));
+        crow->Add(m_tray_combo, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(10));
 
         m_btn_tray_next = new ScalableButton(m_preview_card, wxID_ANY, "filament_picker_right_arrow");
         m_btn_tray_next->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { on_tray_nav(1); });
-        crow->Add(m_btn_tray_next, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(24));
+        crow->Add(m_btn_tray_next, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(48));
 
         auto* view_lbl = new wxStaticText(m_preview_card, wxID_ANY, _L("View"));
         view_lbl->SetFont(Label::Body_12);
@@ -1648,7 +1653,8 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
         m_view_combo->Bind(wxEVT_COMBOBOX, &MixedFilamentBatchDialog::on_view_changed, this);
         crow->Add(m_view_combo, 0, wxALIGN_CENTER_VERTICAL);
 
-        s->Add(crow, 0, wxALIGN_CENTER_HORIZONTAL | wxALL, FromDIP(16));
+        // wxTOP dropped: 8 DIP gap to divider is provided by the AddSpacer above.
+        s->Add(crow, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
     }
 
     m_preview_card->SetSizer(s);
@@ -1707,36 +1713,40 @@ void MixedFilamentBatchDialog::build_footer()
     auto* top_line = new wxPanel(btn_panel, wxID_ANY, wxDefaultPosition, wxSize(-1, 1));
     top_line->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#F0F0F0")));
     panel_sizer->Add(top_line, 0, wxEXPAND);
-    panel_sizer->AddSpacer(FromDIP(12));
 
-    // Progress row (added before the button row so it renders ABOVE the buttons). Hidden by
-    // default; set_match_buttons_state(true) reveals it. Parented to btn_panel and inside
-    // the footer's VERTICAL sizer so the white footer bg extends under it and the whole
-    // footer grows/shrinks as a unit when the progress row is shown/hidden.
-    auto* progress_row = new wxBoxSizer(wxHORIZONTAL);
-    // Progress bar — native wxGauge, 6px tall per Figma (node 27624:65433). Width grows to
-    // fill the row (proportion=1); the "Stop Matching" button beside it takes its natural width.
-    m_progress_bar = new wxGauge(btn_panel, wxID_ANY, 100, wxDefaultPosition, wxSize(FromDIP(200), FromDIP(6)),
-                                  wxGA_HORIZONTAL | wxGA_SMOOTH);
-    m_progress_bar->SetValue(0);
-    m_progress_bar->Hide();
-    progress_row->Add(m_progress_bar, 1, wxALIGN_CENTER_VERTICAL);
-    // "Stop Matching" — inline button to the right of the progress bar. Terminates the
-    // in-flight match without closing the dialog (cancel_batch_match only sets the flag;
-    // the worker drains and handle_batch_match_result restores idle state). Figma spec:
-    // bg #F8F7F7, text #242424, 4px corner radius, thin border.
-    m_btn_stop_match = new Button(btn_panel, _L("Stop Matching"));
-    m_btn_stop_match->SetMinSize(wxSize(FromDIP(96), FromDIP(28)));
-    m_btn_stop_match->SetCornerRadius(FromDIP(4));
-    m_btn_stop_match->SetBorderWidth(FromDIP(1));
-    m_btn_stop_match->SetFont(Label::Body_14);
-    m_btn_stop_match->SetBorderColorNormal(wxColour("#DBDBDB"));
-    m_btn_stop_match->SetBackgroundColorNormal(wxColour("#F8F7F7"));
-    m_btn_stop_match->SetTextColorNormal(wxColour("#242424"));
-    m_btn_stop_match->Hide();
-    m_btn_stop_match->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { cancel_batch_match(); });
-    progress_row->Add(m_btn_stop_match, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(12));
-    panel_sizer->Add(progress_row, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(20));
+    // Progress block (gauge + Stop Matching, hidden when idle). The 44-DIP spacer pins the row
+    // height so the button centers with 8 DIP padding top and bottom. The gap to Cancel/Confirm is
+    // outside the block so it survives the idle collapse.
+    {
+        auto* block = new wxBoxSizer(wxVERTICAL);
+        auto* progress_row = new wxBoxSizer(wxHORIZONTAL);
+        progress_row->Add(0, FromDIP(44), 0);
+        m_progress_bar = new wxGauge(btn_panel, wxID_ANY, 100, wxDefaultPosition, wxSize(FromDIP(200), FromDIP(6)),
+                                      wxGA_HORIZONTAL | wxGA_SMOOTH);
+        m_progress_bar->SetMinSize(wxSize(FromDIP(200), FromDIP(6)));
+        m_progress_bar->SetValue(0);
+        m_progress_bar->Hide();
+        progress_row->Add(m_progress_bar, 1, wxALIGN_CENTER_VERTICAL);
+        m_btn_stop_match = new Button(btn_panel, _L("Stop Matching"));
+        m_btn_stop_match->SetMinSize(wxSize(FromDIP(96), FromDIP(28)));
+        m_btn_stop_match->SetCornerRadius(FromDIP(4));
+        m_btn_stop_match->SetBorderWidth(FromDIP(1));
+        m_btn_stop_match->SetFont(Label::Body_14);
+        m_btn_stop_match->SetBorderColorNormal(wxColour("#DBDBDB"));
+        m_btn_stop_match->SetBackgroundColorNormal(wxColour("#F8F7F7"));
+        m_btn_stop_match->SetTextColorNormal(wxColour("#242424"));
+        m_btn_stop_match->Hide();
+        m_btn_stop_match->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { cancel_batch_match(); });
+        progress_row->Add(m_btn_stop_match, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(18));
+        block->Add(progress_row, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(20));
+        m_progress_divider = new wxPanel(btn_panel, wxID_ANY, wxDefaultPosition, wxSize(-1, 1));
+        m_progress_divider->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#F0F0F0")));
+        m_progress_divider->Hide();
+        block->Add(m_progress_divider, 0, wxEXPAND);
+        panel_sizer->Add(block, 0, wxEXPAND);
+        block->ShowItems(false);
+        m_progress_block = block;
+    }
     panel_sizer->AddSpacer(FromDIP(12));
 
     auto* btn_sizer = new wxBoxSizer(wxHORIZONTAL);
@@ -1928,10 +1938,17 @@ void MixedFilamentBatchDialog::set_match_buttons_state(bool matching)
     if (matching) {
         m_progress_bar->Show();
         m_progress_bar->SetValue(0);
-        if (m_btn_stop_match) m_btn_stop_match->Show();
+        if (m_btn_stop_match)   m_btn_stop_match->Show();
+        if (m_progress_divider) m_progress_divider->Show();
+        // Re-show the block's spacers/sub-sizers (collapsed by the ShowItems(false) below).
+        if (m_progress_block)   m_progress_block->ShowItems(true);
     } else {
         m_progress_bar->Hide();
-        if (m_btn_stop_match) m_btn_stop_match->Hide();
+        if (m_btn_stop_match)   m_btn_stop_match->Hide();
+        if (m_progress_divider) m_progress_divider->Hide();
+        // Collapse the whole block — widgets + the 12 DIP gap — to 0 so the idle
+        // footer stays 61 DIP (button 36 + 12/12 padding + 1px hairline).
+        if (m_progress_block)   m_progress_block->ShowItems(false);
     }
     // Footer height changes with the progress row visibility — re-layout so Cancel/Confirm
     // stay pinned to the bottom edge and there's no stale gap or clipping.

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -2357,11 +2357,8 @@ void MixedFilamentBatchDialog::launch_background_match()
         // return-code model (result.success / error_code) and its whole call chain
         // has no throw sites, so no exception handling is needed here.
         //
-        // Per-component weight bounds are mode-dependent:
-        //   - RECOMMENDED: [kMinComponentPercent(0), kMaxComponentPercent(70)]
-        //   - MANUAL: [15, 100] — keep the 15% floor so a mix always has minimum
-        //     participation, allow >70% (surfaces as advisory via
-        //     check_manual_recipe_ratio after the match).
+        // Per-component weight bounds: min is shared (kMinComponentPercent); max is
+        // mode-dependent — MANUAL allows >70% (advisory via check_manual_recipe_ratio).
         //
         // check_compatible is false for BOTH modes. RECOMMENDED needs none: its
         // physical_colors come from a single Full Spectrum preset (one PLA spool,
@@ -2371,7 +2368,7 @@ void MixedFilamentBatchDialog::launch_background_match()
         // preset_bundle->filament_presets unsynchronized from here, racing the UI
         // thread (data-race UB). The slice gate (Plater::has_incompatible_mixed_
         // filament_in_use) still blocks genuinely incompatible mixes at slice time.
-        const int match_min = (matching_method == MANUAL) ? 15 : kMinComponentPercent;
+        const int match_min = kMinComponentPercent; // shared floor for both modes
         const int match_max = (matching_method == MANUAL) ? 100 : kMaxComponentPercent;
         if (!unmatched_colors.empty()) {
             auto sub_result = batch_match_model_colors(unmatched_colors, physical_colors, match_min, match_max, cancel_token,

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -1888,6 +1888,35 @@ void MixedFilamentBatchDialog::set_match_buttons_state(bool matching)
     // bail out at any time (idle / matching / match-completed-pending-confirm).
     m_btn_cancel_match->Enable(true);
     m_btn_confirm->Enable(!matching && m_match_completed && m_result.success);
+
+    // Lock upper-region controls while a match runs. start_batch_match() snapshots the match
+    // inputs on the UI thread and the worker receives them by value, so this is not a thread-
+    // safety measure — it keeps the combos consistent with the inputs the in-flight match used,
+    // and stops mid-match edits from mutating m_tray_index / m_manual_filament_count, which the
+    // post-match restore re-reads via update_nav_arrow_state() / update_add_remove_buttons().
+    // Cancel stays enabled (set above) so the user can still bail out.
+    //
+    // Enabling a hidden combo (e.g. m_filament_combo[] in RECOMMENDED mode) is a harmless no-op.
+    if (m_method_combo) m_method_combo->Enable(!matching);
+    if (m_tray_combo)   m_tray_combo->Enable(!matching);
+    if (m_view_combo)   m_view_combo->Enable(!matching);
+    for (int i = 0; i < 4; ++i)
+        if (m_filament_combo[i]) m_filament_combo[i]->Enable(!matching);
+    // Button-type controls have state-dependent enable conditions (tray arrows depend on
+    // m_tray_index; add/remove depend on m_manual_filament_count). Disable them directly while
+    // matching, and on restore delegate to the existing helpers so the boundary conditions are
+    // recomputed correctly — NOT a blanket Enable(!matching), which would leave e.g. the prev
+    // arrow enabled at plate 1.
+    if (matching) {
+        if (m_btn_tray_prev)       m_btn_tray_prev->Disable();
+        if (m_btn_tray_next)       m_btn_tray_next->Disable();
+        if (m_btn_remove_filament) m_btn_remove_filament->Disable();
+        if (m_btn_add_filament)    m_btn_add_filament->Disable();
+    } else {
+        update_nav_arrow_state();    // prev/next re-enabled per m_tray_index
+        update_add_remove_buttons(); // add/remove re-enabled per m_manual_filament_count
+    }
+
     if (matching) {
         m_progress_bar->Show();
         m_progress_bar->SetValue(0);
@@ -2573,6 +2602,15 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
 
 void MixedFilamentBatchDialog::update_mapping_legend()
 {
+    // Freeze the legend panel for the whole clear+rebuild so wxMSW doesn't repaint after
+    // every child create/destroy (up to 64 rows × 4 sub-windows = hundreds of partial
+    // paints → visible flicker). RAII guarantees Thaw on every exit path, including
+    // exceptions (harness cpp-wxwidgets §132). Held for the whole function: Refresh()
+    // calls issued while frozen are coalesced and flushed at Thaw (the destructor at
+    // scope exit), so the rebuilt card repaints in one pass. m_legend_panel is the direct
+    // parent of every new row window, so freezing it (which propagates to children) is
+    // the minimal effective scope — same idiom as ConfigWizard / PresetComboBoxes.
+    wxWindowUpdateLocker no_updates(m_legend_panel);
     // Clear(true) deletes row windows immediately (vs deferred Destroy), so their
     // pixel regions are released before repaint — same pattern as rebuild_legend.
     m_legend_sizer->Clear(true);
@@ -2695,7 +2733,9 @@ void MixedFilamentBatchDialog::update_mapping_legend()
     }
     // Card grows with content (no inner scroller); re-layout the legend panel + card so they
     // reflect the new row count, then re-layout the scrolled region so its virtual (scrollable)
-    // extent tracks the new card height and downstream positioning stays correct.
+    // extent tracks the new card height and downstream positioning stays correct. The Layout()
+    // and Refresh() calls run while still frozen — they coalesce, and the whole card repaints
+    // in one pass when no_updates Thaws at function exit.
     m_legend_panel->Layout();
     m_mapping_card->Layout();
     m_mapping_card->Refresh();

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -116,14 +116,14 @@ static constexpr int MATCH_PREVIEW_DIP = 227;
 // RoundedPreviewPanel — a fixed-size square panel that draws a rounded-corner
 // thumbnail with an overlay badge ("Original Model" / "After Match").
 //
-// Rounded corners: the panel is first filled entirely with white (parent card bg),
-// then a rounded-rect wxRegion clip is applied via SetDeviceClippingRegion before
-// drawing the rounded background (#E7E7E7) + thumbnail + badge.  The four corners
-// keep their white fill and sit transparently over the parent card.
+// Rounded corners: paint the real background (card white via SetBackgroundColour +
+// dc.Clear()), then clip to a rounded rect and draw the rounded background (#E7E7E7)
+// + thumbnail + badge inside it. The background is a real opaque window background,
+// not a colour-matching fake — dc.Clear() is bounded to this window's backing store,
+// so the four corners can't bleed onto sibling UI on macOS.
 //
-// Uses plain wxDC (not wxGraphicsContext) to stay in the same coordinate space as
+// Plain wxDC (not wxGraphicsContext) stays in the same coordinate space as
 // wxAutoBufferedPaintDC — no antialias transform, no off-by-one clipping artifacts.
-// Child-window safe on all platforms: no SetWindowRgn, no SetShape.
 // ---------------------------------------------------------------------------
 
 class RoundedPreviewPanel : public wxPanel
@@ -136,6 +136,13 @@ public:
         , m_badge_label(badge_label)
     {
         SetBackgroundStyle(wxBG_STYLE_PAINT);
+        // Opaque window bg = parent card white. Marks the panel opaque so the macOS
+        // compositor stops blending it over siblings, and fixes the colour dc.Clear()
+        // paints. Wrapped in darkModeColorFor so dark mode maps it to the dialog's
+        // dark window-bg slot (#2D2D31) — the light-mode value is plain white, so any
+        // equivalent white (wxColour("#FFFFFF") / *wxWHITE / wxColour(255,255,255))
+        // resolves to the same map entry (gDarkColors keys by RGBA value, not string).
+        SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
         SetMinSize(wxSize(FromDIP(side_dip), FromDIP(side_dip)));
         Bind(wxEVT_PAINT, &RoundedPreviewPanel::on_paint, this);
         // DPI change: the placeholder SVG (ScalableBitmap) caches its raster at the
@@ -175,11 +182,11 @@ private:
         const wxColour card_white = StateColor::darkModeColorFor(wxColour("#FFFFFF"));
         const wxColour panel_bg   = StateColor::darkModeColorFor(wxColour(231, 231, 231));
 
-        // Step 1 — fill ENTIRE panel with white (parent card background).
-        // The four corners keep this color and read as transparent over the card.
-        dc.SetBrush(wxBrush(card_white));
-        dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.DrawRectangle(wxRect(sz));
+        // Step 1 — real background, not a faked-transparent white square. dc.Clear()
+        // writes only into this window's own backing store, which the compositor bounds
+        // to the window geometry — so the corners read as the card but can't bleed.
+        dc.SetBackground(wxBrush(card_white));
+        dc.Clear();
 
         // Step 2 — build a rounded-rect clip region:
         //   black rounded-rect on white → region = black interior
@@ -217,9 +224,8 @@ private:
                 dc.DrawBitmap(draw_bmp, (sz.x - bw) / 2, (sz.y - bh) / 2, false);
         }
 
-        // Step 5 — badge (white text on gray bg, top-left)
-        dc.DestroyClippingRegion();
-
+        // Step 5 — badge (white text on gray bg, top-left), drawn inside the rounded
+        // clip so it's hard-bounded to the thumbnail area.
         dc.SetFont(Label::Body_12);
         const wxSize text_sz = dc.GetTextExtent(m_badge_label);
         const int pad_x = FromDIP(8);
@@ -232,6 +238,8 @@ private:
         dc.DrawRectangle(badge);
         dc.SetTextForeground(*wxWHITE);
         dc.DrawText(m_badge_label, badge.x + pad_x, badge.y + pad_y);
+
+        dc.DestroyClippingRegion();
     }
 };
 

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
@@ -261,6 +261,12 @@ private:
 
     // Progress
     wxGauge* m_progress_bar = nullptr;
+    // Container sizer holding the progress row (bar + Stop Matching) AND its lower hairline
+    // divider. Show/Hide as a unit so the whole block — including the 12 DIP gaps around it —
+    // collapses to 0 in the idle state, keeping the footer at 61 DIP. Individual Show() calls
+    // on m_progress_bar / m_btn_stop_match would leave the sizer spacers occupying space.
+    wxSizer* m_progress_block = nullptr;
+    wxPanel* m_progress_divider = nullptr;
 
     wxScrolledWindow* m_scrolled_content = nullptr;
 };

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2342,7 +2342,7 @@ Sidebar::Sidebar(Plater *parent)
         const std::vector<std::string> colors = co ? co->values : std::vector<std::string>{};
         if (colors.size() < 2) {
             RichMessageDialog dlg(this,
-                _L("Please add at least 2 filaments to use batch color matching."),
+                _L("Color Mixing Match is unavailable when only one filament is added to Filament Management."),
                 _L("Color Mixing Match"), wxOK);
             dlg.SetOKLabel(_L("Got it"));
             dlg.CentreOnScreen();
@@ -8501,6 +8501,30 @@ void Sidebar::cleanup_unused_filaments_after_batch_match(const BatchMatchResult 
         }
     }
 
+    // Deleting mixed rows renumbers every higher survivor down by one (virtual
+    // ids enumerate over *enabled* rows). Painted facets still hold the old ids,
+    // so without this remap they resolve to the wrong row — the merged-slot
+    // regression. Computed in the T2 epoch (rows still enabled), applied after
+    // the mark loop in T3.
+    std::vector<unsigned int> mixed_deletion_remap;
+    if (!redundant_mixed_stable_ids.empty()) {
+        const size_t cur_num_physical = pb->filament_presets.size();
+        const std::unordered_set<uint64_t> to_delete(redundant_mixed_stable_ids.begin(),
+                                                      redundant_mixed_stable_ids.end());
+        // Enumerate enabled rows in order to find each redundant row's T2 vid.
+        std::vector<unsigned int> deleted_t2_vids;
+        unsigned int vid = static_cast<unsigned int>(cur_num_physical) + 1;
+        for (const MixedFilament& mf : mfs) {
+            if (!mf.enabled || mf.deleted) continue;
+            if (mf.stable_id != 0 && to_delete.count(mf.stable_id) > 0)
+                deleted_t2_vids.push_back(vid);
+            ++vid;
+        }
+        const size_t t2_total = cur_num_physical + pb->mixed_filaments.enabled_count();
+        mixed_deletion_remap = MixedFilamentManager::build_mixed_deletion_painting_remap(
+            cur_num_physical, t2_total, deleted_t2_vids);
+    }
+
     // Mark the redundant mixed rows that survived the physical deletions
     // (the non-cascade ones).  Match by stable_id against the CURRENT m_mixed
     // — `mfs` still refers to the same (now-rebuilt) vector object.
@@ -8529,6 +8553,26 @@ void Sidebar::cleanup_unused_filaments_after_batch_match(const BatchMatchResult 
             mf.deleted = true;
             mf.enabled = false;
         }
+    }
+
+    // Apply the mixed-deletion remap now that the rows are marked (T3 epoch).
+    // Mirrors the physical-deletion composite remap above.
+    if (!mixed_deletion_remap.empty()) {
+        EnforcerBlockerStateMap state_map;
+        for (size_t i = 0; i < state_map.size(); ++i)
+            state_map[i] = EnforcerBlockerType(i);
+        const size_t t3_total = pb->filament_presets.size() + pb->mixed_filaments.enabled_count();
+        for (size_t i = 1; i < mixed_deletion_remap.size() && i < state_map.size(); ++i) {
+            const unsigned int mapped = mixed_deletion_remap[i];
+            if (mapped == 0 || mapped >= state_map.size() || mapped > t3_total)
+                state_map[i] = EnforcerBlockerType::NONE;
+            else
+                state_map[i] = EnforcerBlockerType(mapped);
+        }
+        for (ModelObject* mo : wxGetApp().model().objects)
+            for (ModelVolume* mv : mo->volumes)
+                if (mv->type() == ModelVolumeType::MODEL_PART)
+                    mv->remap_extruder_ids(t3_total, state_map);
     }
 
     // Final authoritative serialization of the post-cleanup state (it must

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6744,11 +6744,6 @@ void Sidebar::update_mixed_filament_panel(bool sync_manager)
             if (canvas == nullptr || !canvas->is_initialized())
                 return;
             canvas->update_volumes_colors_by_extruder();
-            // Push new colors into the active painting gizmo (legend + painted facets).
-            // Direct update_data(), not update_gizmos_on_off_state(): the latter runs
-            // refresh_on_off_state(), which deactivates the painting gizmo when the
-            // selection is not a single full instance.
-            canvas->get_gizmos_manager().update_data();
             canvas->render();
         };
 
@@ -15306,8 +15301,7 @@ void Plater::priv::on_filament_color_changed(wxCommandEvent &event)
 
     // Regenerate mixed filaments and refresh the mixed panel only. Color
     // changes do not alter filament IDs, so the full on_filaments_change()
-    // path is unnecessary and can re-enter UI rebuilds mid-update. The painting
-    // gizmo is refreshed via update_data() in refresh_model_canvas_colors below.
+    // path is unnecessary and can re-enter UI rebuilds mid-update.
     wxGetApp().preset_bundle->update_multi_material_filament_presets();
     sidebar->update_mixed_filament_panel();
     sidebar->update_color_mix_panel();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2472,11 +2472,15 @@ Sidebar::Sidebar(Plater *parent)
                     old_mixed_snapshot, current_count, target_count);
             }
 
-            // Assign the Full Spectrum filament preset to slots 1-4 so the
-            // combobox displays the preset name instead of F1-F4 fallback.
+            // Write Full Spectrum to slots 1-4 only when the preset is
+            // selectable under the current printer (present + visible +
+            // compatible, matching the filament combobox filter).
             const std::string full_spectrum_preset = full_spectrum_preset_name();
-            for (size_t i = 0; i < std::min<size_t>(4, target_count); ++i)
-                pb->set_filament_preset(i, full_spectrum_preset);
+            const Preset*     fs_preset = pb->filaments.find_preset(full_spectrum_preset);
+            if (fs_preset != nullptr && fs_preset->is_visible && fs_preset->is_compatible) {
+                for (size_t i = 0; i < std::min<size_t>(4, target_count); ++i)
+                    pb->set_filament_preset(i, full_spectrum_preset);
+            }
 
             wxGetApp().plater()->on_filaments_change(static_cast<int>(target_count));
         } else {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6744,6 +6744,11 @@ void Sidebar::update_mixed_filament_panel(bool sync_manager)
             if (canvas == nullptr || !canvas->is_initialized())
                 return;
             canvas->update_volumes_colors_by_extruder();
+            // Push new colors into the active painting gizmo (legend + painted facets).
+            // Direct update_data(), not update_gizmos_on_off_state(): the latter runs
+            // refresh_on_off_state(), which deactivates the painting gizmo when the
+            // selection is not a single full instance.
+            canvas->get_gizmos_manager().update_data();
             canvas->render();
         };
 
@@ -15301,7 +15306,8 @@ void Plater::priv::on_filament_color_changed(wxCommandEvent &event)
 
     // Regenerate mixed filaments and refresh the mixed panel only. Color
     // changes do not alter filament IDs, so the full on_filaments_change()
-    // path is unnecessary and can re-enter UI rebuilds mid-update.
+    // path is unnecessary and can re-enter UI rebuilds mid-update. The painting
+    // gizmo is refreshed via update_data() in refresh_model_canvas_colors below.
     wxGetApp().preset_bundle->update_multi_material_filament_presets();
     sidebar->update_mixed_filament_panel();
     sidebar->update_color_mix_panel();

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -4761,3 +4761,168 @@ TEST_CASE("preview colors: virtual slot beyond base vector is padded gray", "[Mi
     CHECK(out[1] == 0x80808080u);
     CHECK(out[2] == 0x80808080u);
 }
+
+// ============================================================================
+// [MixedFilament][deletion_remap] — build_mixed_deletion_painting_remap
+//
+// Regression coverage for the batch-match cleanup bug where deleting redundant
+// mixed rows (after duplicate-recipe merge) re-enumerates the virtual IDs of
+// the remaining rows, but the model's painted facets kept the old (pre-deletion)
+// IDs, so they resolved to the wrong mixed filament — the last merged slot
+// appeared to fall back to color #1.
+//
+// The fix extracts the T2(pre-delete)→T3(post-delete) painting remap into a
+// pure, library-testable function. These are SPEC tests (the math is defined
+// independently of any runtime), not characterization tests, so a hand-written
+// expected value is a valid oracle here (differential-oracle harness §5).
+//
+// Mapping rule under test, for each old_vid in T2 space:
+//   old_vid ∈ deleted_vids               -> 0   (NONE; the row itself)
+//   old_vid <= num_physical              -> old_vid (physical slots are identity)
+//   else                                 -> old_vid - count(deleted_vids < old_vid)
+// Return vector is sized t2_total_filaments + 1 (1-based; index 0 is unused/0).
+// ===========================================================================
+
+TEST_CASE("build_mixed_deletion_painting_remap: single middle delete shifts tail down by one", "[MixedFilament][deletion_remap]")
+{
+    // The reported scenario: 4 physicals, mixed rows v5..v14. After duplicate-
+    // recipe merge, v9 is redundant and gets deleted. Every vid > 9 must shift
+    // down by one; v9 itself maps to NONE.
+    const size_t num_physical = 4;
+    const size_t t2_total     = 14; // 4 physical + 10 mixed (v5..v14)
+    const std::vector<unsigned int> deleted = {9};
+
+    const auto remap = MixedFilamentManager::build_mixed_deletion_painting_remap(num_physical, t2_total, deleted);
+
+    REQUIRE(remap.size() == t2_total + 1);
+    CHECK(remap[0] == 0u); // unused index
+    // Physical slots: identity.
+    CHECK(remap[1] == 1u);
+    CHECK(remap[2] == 2u);
+    CHECK(remap[3] == 3u);
+    CHECK(remap[4] == 4u);
+    // Mixed slots before the deleted one: identity.
+    CHECK(remap[5] == 5u);
+    CHECK(remap[6] == 6u);
+    CHECK(remap[7] == 7u);
+    CHECK(remap[8] == 8u);
+    // Deleted slot itself -> NONE.
+    CHECK(remap[9] == 0u);
+    // Mixed slots after the deleted one: shift down by one.
+    CHECK(remap[10] == 9u);
+    CHECK(remap[11] == 10u);
+    CHECK(remap[12] == 11u);
+    CHECK(remap[13] == 12u);
+    CHECK(remap[14] == 13u);
+}
+
+TEST_CASE("build_mixed_deletion_painting_remap: multiple deletes accumulate offset", "[MixedFilament][deletion_remap]")
+{
+    // Delete v7 and v9 out of v5..v14. Each survivor's new id subtracts the
+    // number of deleted vids strictly less than it.
+    const size_t num_physical = 4;
+    const size_t t2_total     = 14;
+    const std::vector<unsigned int> deleted = {7, 9};
+
+    const auto remap = MixedFilamentManager::build_mixed_deletion_painting_remap(num_physical, t2_total, deleted);
+
+    REQUIRE(remap.size() == t2_total + 1);
+    CHECK(remap[0] == 0u);
+    // Physical + pre-first-delete mixed: identity.
+    CHECK(remap[5] == 5u);
+    CHECK(remap[6] == 6u);
+    // Deleted.
+    CHECK(remap[7] == 0u);
+    // v8: one deleted vid (7) below it -> 8-1 = 7.
+    CHECK(remap[8] == 7u);
+    // Deleted.
+    CHECK(remap[9] == 0u);
+    // v10..v14: two deleted vids (7,9) below each -> subtract 2.
+    CHECK(remap[10] == 8u);
+    CHECK(remap[11] == 9u);
+    CHECK(remap[12] == 10u);
+    CHECK(remap[13] == 11u);
+    CHECK(remap[14] == 12u);
+}
+
+TEST_CASE("build_mixed_deletion_painting_remap: physical slots never move", "[MixedFilament][deletion_remap]")
+{
+    // Even with mixed deletes, the physical range [1..num_physical] is identity.
+    const size_t num_physical = 4;
+    const size_t t2_total     = 8;
+    const std::vector<unsigned int> deleted = {5, 6};
+
+    const auto remap = MixedFilamentManager::build_mixed_deletion_painting_remap(num_physical, t2_total, deleted);
+
+    REQUIRE(remap.size() == t2_total + 1);
+    CHECK(remap[1] == 1u);
+    CHECK(remap[2] == 2u);
+    CHECK(remap[3] == 3u);
+    CHECK(remap[4] == 4u);
+}
+
+TEST_CASE("build_mixed_deletion_painting_remap: deleted vids map to NONE", "[MixedFilament][deletion_remap]")
+{
+    const size_t num_physical = 4;
+    const size_t t2_total     = 10;
+    const std::vector<unsigned int> deleted = {6, 8};
+
+    const auto remap = MixedFilamentManager::build_mixed_deletion_painting_remap(num_physical, t2_total, deleted);
+
+    CHECK(remap[6] == 0u);
+    CHECK(remap[8] == 0u);
+}
+
+TEST_CASE("build_mixed_deletion_painting_remap: delete all mixed leaves only physicals", "[MixedFilament][deletion_remap]")
+{
+    // Deleting every mixed row: the survivors are the physicals alone, all
+    // unchanged; every mixed vid maps to NONE.
+    const size_t num_physical = 4;
+    const size_t t2_total     = 7; // 4 physical + 3 mixed (v5,v6,v7)
+    const std::vector<unsigned int> deleted = {5, 6, 7};
+
+    const auto remap = MixedFilamentManager::build_mixed_deletion_painting_remap(num_physical, t2_total, deleted);
+
+    REQUIRE(remap.size() == t2_total + 1);
+    CHECK(remap[1] == 1u);
+    CHECK(remap[2] == 2u);
+    CHECK(remap[3] == 3u);
+    CHECK(remap[4] == 4u);
+    CHECK(remap[5] == 0u);
+    CHECK(remap[6] == 0u);
+    CHECK(remap[7] == 0u);
+}
+
+TEST_CASE("build_mixed_deletion_painting_remap: empty delete list is identity (short-circuit)", "[MixedFilament][deletion_remap]")
+{
+    // No deletes -> every vid maps to itself. This is the no-op path cleanup
+    // must take without running a remap pass over the whole model.
+    const size_t num_physical = 4;
+    const size_t t2_total     = 10;
+    const std::vector<unsigned int> deleted;
+
+    const auto remap = MixedFilamentManager::build_mixed_deletion_painting_remap(num_physical, t2_total, deleted);
+
+    REQUIRE(remap.size() == t2_total + 1);
+    for (size_t i = 1; i <= t2_total; ++i)
+        CHECK(remap[i] == static_cast<unsigned int>(i));
+}
+
+TEST_CASE("build_mixed_deletion_painting_remap: unsorted delete input is tolerated", "[MixedFilament][deletion_remap]")
+{
+    // Robustness: caller may supply vids in any order; the function must sort
+    // internally so the offset count is correct. Same expectation as the
+    // ordered {7,9} case.
+    const size_t num_physical = 4;
+    const size_t t2_total     = 14;
+    const std::vector<unsigned int> deleted = {9, 7}; // descending input
+
+    const auto remap = MixedFilamentManager::build_mixed_deletion_painting_remap(num_physical, t2_total, deleted);
+
+    REQUIRE(remap.size() == t2_total + 1);
+    CHECK(remap[7] == 0u);
+    CHECK(remap[8] == 7u); // one delete below
+    CHECK(remap[9] == 0u);
+    CHECK(remap[10] == 8u); // two deletes below
+    CHECK(remap[14] == 12u);
+}


### PR DESCRIPTION
# Description

Phase 2 color mixing match (Color Mixing Match) cleanup fixes. The upstream `feat_mix_filament_Phase2` branch already contains the main batch-match flow (merged via earlier PRs); this PR delivers the remaining 7 fix commits: **painting remap after redundant mixed-row deletion (merged-slot regression), MANUAL-mode floor aligned 15% → 0%, Full Spectrum preset write-back gating, and several batch-match dialog UI fixes**.

## Changes

### 1. Painting remap after redundant mixed-row deletion (bug fix)
- **Problem**: after duplicate-recipe merge, redundant mixed rows are marked deleted; virtual IDs enumerate over *enabled* rows, so deleting a row renumbers every higher survivor down by one — but painted facets on the model still hold the pre-deletion IDs and resolve to the wrong mixed row, with the last merged slot falling back to filament 1
- **Fix**: extracted pure function `MixedFilamentManager::build_mixed_deletion_painting_remap()` (`src/libslic3r/MixedFilament.cpp:2035`) computing the T2(pre-delete) → T3(post-delete) mapping (deleted rows → NONE, physical slots identity, survivors `old − count(deleted < old)`), applied in the cleanup path after the mark loop (`Plater.cpp:8509`).
- **Tests**: 7 new `[MixedFilament][deletion_remap]` unit tests (single/multiple/all deletes, empty-list short-circuit, unsorted input, physical slots never move, deleted → NONE).

### 2. MANUAL match floor 15% → 0%
- `kMinComponentPercent` is now the shared floor for both modes. The 15% hard floor blocked legitimate near-pure recipes users intentionally configure in manual mode; the >70% cap is still enforced as advisory via `check_manual_recipe_ratio` (`MixedFilamentBatchDialog.cpp:2425`). RECOMMENDED mode behavior is unchanged.

### 3. Full Spectrum preset write-back gating
- Slots 1–4 are only written when the preset is selectable under the current printer (present + visible + compatible, matching the filament combobox filter) (`Plater.cpp:2475`), so the combobox no longer shows a wrong name when it can't be selected.

### 4. Batch-match dialog UI fixes
- `set_match_buttons_state`: locks upper-region controls (method/tray/view/filament combos + tray nav / add-remove buttons) while a match runs, preventing mid-match input edits from corrupting the post-match restore; Cancel stays enabled. Button restore delegates to `update_nav_arrow_state()` / `update_add_remove_buttons()` so boundary conditions are recomputed correctly (`MixedFilamentBatchDialog.cpp:1909`).
- `RoundedPreviewPanel` now paints a real opaque window background (`SetBackgroundColour` + `dc.Clear()`), fixing the macOS compositor blending the four corners over siblings (`MixedFilamentBatchDialog.cpp:139`).
- Footer progress block (gauge + Stop + hairline divider) collapses as a unit so the idle footer stays pinned at 61 DIP (`MixedFilamentBatchDialog.cpp:1716`; new `m_progress_block`/`m_progress_divider` in `.hpp`).
- Mapping legend rebuild wrapped in `wxWindowUpdateLocker` to eliminate per-row flicker on wxMSW (`MixedFilamentBatchDialog.cpp:2630`).

> **Note**: the painting-gizmo-refresh-on-color-change commit was reverted before merge (`094d7c12f2`) — `update_data()` re-runs the whole gizmo state (common gizmo data, Flatten hack, Object Manipulation) on every color change across all `refresh_model_canvas_colors` call sites. A narrower painting-only refresh may be re-introduced later if the stale-gizmo issue is confirmed.

### 5. Copy
- Single-filament entry prompt reworded to "Color Mixing Match is unavailable when only one filament is added to Filament Management." with zh_CN sync (`Plater.cpp:2345`, `.po`).
- 0.10 Color Mixing process preset description rewritten ("smaller layer height → smoother color transitions").

## Files changed
| File | Description |
|---|---|
| `src/libslic3r/MixedFilament.cpp/.hpp` | `build_mixed_deletion_painting_remap` pure function |
| `src/slic3r/GUI/MixedFilamentBatchDialog.cpp/.hpp` | dialog UI fixes, manual floor, legend freeze |
| `src/slic3r/GUI/Plater.cpp` | copy, preset write-back gating, cleanup remap |
| `tests/libslic3r/test_mixed_filament.cpp` | +7 deletion_remap cases |
| `resources/profiles/Snapmaker/process/0.10 Color Mixing @Snapmaker U1 (0.4 nozzle).json` | preset description |
| `localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po` | zh_CN sync |

# Screenshots/Recordings/Graphs

<!-- If needed: footer collapse idle vs matching, legend rebuild before/after -->

# Tests

- 7 new deterministic `[MixedFilament][deletion_remap]` unit tests in `tests/libslic3r/test_mixed_filament.cpp` (single/multiple/all deletes, empty list, unsorted input, physical-slot invariance, deleted → NONE).
- Regression: painted facets no longer fall back after mixed-row deletion; near-pure MANUAL recipes (e.g. 99/1) match successfully.
- GUI interactions (footer collapse, legend flicker) are manual smoke items.
