### PR TITLE
fix(mixed-filament): remap parent node filament after batch color match

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -856,6 +856,18 @@ void ObjectList::selected_object(ObjectDataViewModelNode* item)
 
 void ObjectList::update_filament_values_for_items_when_delete_filament(const size_t filament_id, const int replace_id)
 {
+    // During batch physical deletion (batch-match cleanup loop), skip the
+    // per-deletion config rewrite entirely.  Each iteration would shift
+    // config-level extruder references by ARRAY-INDEX decrement (a middle-
+    // deletion repack), which corrupts the kept-aware composite remap that
+    // cleanup applies ONCE after the loop: the remap is built over the
+    // PRE-deletion id space, so it can only repair references whose old ids
+    // are still intact.  The same guard already skips the per-deletion
+    // triangle-paint remap in Plater::on_filaments_delete; the composite
+    // pass (remap_model_filament_refs) then repairs paint AND config.
+    if (wxGetApp().plater()->batch_physical_deletion() > 0)
+        return;
+
     int replace_filament_id = replace_id == -1 ? 1 : (replace_id + 1);
     for (size_t i = 0; i < m_objects->size(); ++i) {
         wxDataViewItem item = m_objects_model->GetItemById(i);

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1984,6 +1984,19 @@ void apply_batch_match_to_model(const BatchMatchResult& result)
             }
         }
 
+        // Object-level extruder is remapped UNCONDITIONALLY (even when every
+        // volume owns its own extruder, so object_extruder_written stayed
+        // false).  The object list's parent-node colour swatch reads
+        // mo->config "extruder" directly (AddObject / update_filament_values_
+        // for_items), so a root node whose source slot is remapped must follow
+        // the match — otherwise it keeps the old source colour while its
+        // volumes migrate onto the new mixed slot ("root node colour wrong
+        // after batch match").  This also keeps the object-level default
+        // (inherited by any volume without an own extruder) consistent with
+        // the volumes that were remapped above.
+        if (obj_remap && !object_extruder_written)
+            mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(obj_it->second)));
+
         // Level 3: layer-object extruder (layer_config_ranges). A layer object
         // holds the user-assigned filament for a height range; remap it with
         // the same table used for volumes so it follows the match instead of

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8304,6 +8304,122 @@ static void extract_batch_kept_sets(const BatchMatchResult &result,
     }
 }
 
+// Apply a filament-id remap (1-based, composite_remap[old_id] = new_id) to BOTH
+// the model's triangle-level MMU paint and its config-level extruder references.
+// The config pass covers MODEL_PART and PARAMETER_MODIFIER volumes, the OBJECT
+// config ("extruder" is what the object list's parent-node colour swatch reads)
+// and layer_config_ranges — mirroring apply_batch_match_to_model so a match
+// never leaves a config reference stranded on a deleted slot.
+//
+// WHY THIS IS NEEDED: the per-deletion loop below (delete_filament with
+// skip_update=true) rewrites config-level extruder references by ARRAY-INDEX
+// decrement (every value > deleted_id is shifted down by one, treating the
+// deleted slot as a middle-index removal). That is correct for sequential
+// palette-slot deletion, but the batch match deletes NON-CONTIGUOUS ids with a
+// kept-aware remap (old 2/6/8/10 -> new 1..4), so the per-deletion shift would
+// corrupt surviving mixed virtual ids AND shift kept physical ids onto wrong
+// slots. The per-deletion rewrite is therefore SKIPPED during the batch loop
+// (ObjectList::update_filament_values_for_items_when_delete_filament guards on
+// batch_physical_deletion), and THIS composite pass — built over the
+// PRE-deletion id space — is the single authority that moves every reference:
+// paint, object/volume/modifier extruder, feature filaments, layer ranges.
+static void remap_model_filament_refs(const std::vector<unsigned int> &composite_remap,
+                                      size_t                           total_filaments)
+{
+    if (composite_remap.empty()) return;
+
+    // Per-filament feature settings (wall/infill/support filament) live on the
+    // object and volume configs.  The per-deletion rewrite of these keys is
+    // skipped during the batch loop (same reason as "extruder"), so the
+    // composite pass must move them by the same table: mapped != 0 -> follow;
+    // mapped == 0 -> the referenced filament was dropped -> erase (mirrors the
+    // per-deletion "key == deleted -> erase" rule).
+    static const char* FEATURE_KEYS[] = {"wall_filament", "sparse_infill_filament", "solid_infill_filament",
+                                         "support_filament", "support_interface_filament"};
+
+    EnforcerBlockerStateMap state_map;
+    for (size_t i = 0; i < state_map.size(); ++i)
+        state_map[i] = EnforcerBlockerType(i);
+    for (size_t i = 1; i < composite_remap.size() && i < state_map.size(); ++i) {
+        const unsigned int mapped = composite_remap[i];
+        if (mapped == 0 || mapped >= state_map.size() || mapped > total_filaments)
+            state_map[i] = EnforcerBlockerType::NONE;
+        else
+            state_map[i] = EnforcerBlockerType(mapped);
+    }
+
+    auto remap_feature_keys = [&](ModelConfig &cfg) {
+        for (const char *key : FEATURE_KEYS) {
+            if (!cfg.has(key)) continue;
+            const int old_id = cfg.opt_int(key);
+            if (old_id <= 0) continue;
+            if (size_t(old_id) >= composite_remap.size()) continue;
+            const unsigned int mapped = composite_remap[size_t(old_id)];
+            if (mapped == 0)
+                cfg.erase(key);
+            else if (mapped != static_cast<unsigned int>(old_id))
+                cfg.set_key_value(key, new ConfigOptionInt(static_cast<int>(mapped)));
+        }
+    };
+
+    for (ModelObject *mo : wxGetApp().model().objects) {
+        // Config-level references.  Object first (write once): every volume
+        // that inherits the object's extruder follows it through the same
+        // lookup, mirroring apply_batch_match_to_model.  mapped == 0 means the
+        // source slot was dropped by the match: erase the key so the object
+        // falls back to default (and inheriting volumes follow) instead of
+        // pointing at a deleted slot.
+        const ConfigOption *obj_opt     = mo->config.option("extruder");
+        const int           orig_obj_eid = (obj_opt ? obj_opt->getInt() : 0);
+        const unsigned int  obj_target  = (orig_obj_eid > 0 &&
+                                           size_t(orig_obj_eid) < composite_remap.size())
+                                              ? composite_remap[size_t(orig_obj_eid)] : 0;
+        if (obj_target != 0)
+            mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(obj_target)));
+        else if (obj_opt && obj_opt->getInt() > 0)
+            mo->config.erase("extruder");
+        remap_feature_keys(mo->config);
+        for (ModelVolume *mv : mo->volumes) {
+            const ModelVolumeType vt = mv->type();
+            if (vt != ModelVolumeType::MODEL_PART && vt != ModelVolumeType::PARAMETER_MODIFIER)
+                continue;
+            const ConfigOption *vol_opt = mv->config.option("extruder");
+            if (vol_opt && vol_opt->getInt() > 0) {
+                const unsigned int mapped = (size_t(vol_opt->getInt()) < composite_remap.size())
+                                                ? composite_remap[size_t(vol_opt->getInt())] : 0;
+                if (mapped != 0)
+                    mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(mapped)));
+                else
+                    mv->config.erase("extruder"); // source slot dropped -> inherit object
+            }
+            remap_feature_keys(mv->config);
+            // Triangle-level MMU paint (MODEL_PART only — modifiers carry none).
+            if (vt == ModelVolumeType::MODEL_PART && !mv->mmu_segmentation_facets.empty())
+                // Pass total_filaments (physical + mixed), NOT new_num_physical —
+                // remap_enforcer_block_types clips any state > max_type to NONE,
+                // and remapped mixed virtual ids (N+1..total) must survive.
+                mv->remap_extruder_ids(total_filaments, state_map);
+        }
+        // Layer-object extruders (layer_config_ranges) follow the same table so
+        // height-range filaments are not stranded on a deleted slot.  mapped==0
+        // -> the layer's filament was dropped: reset to default (0), mirroring
+        // the per-deletion reset-to-default rule for layers.
+        for (auto &lr : mo->layer_config_ranges) {
+            ModelConfig        &lcfg = lr.second;
+            const ConfigOption *lopt = lcfg.option("extruder");
+            if (!lopt) continue;
+            const int old_eid = lopt->getInt();
+            if (old_eid <= 0) continue;
+            if (size_t(old_eid) >= composite_remap.size()) continue;
+            const unsigned int mapped = composite_remap[size_t(old_eid)];
+            if (mapped == 0)
+                lcfg.set_key_value("extruder", new ConfigOptionInt(0));
+            else
+                lcfg.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(mapped)));
+        }
+    }
+}
+
 void Sidebar::cleanup_unused_filaments_after_batch_match(const BatchMatchResult &match_result,
                                                           std::function<void(int, int)> on_progress)
 {
@@ -8472,24 +8588,14 @@ void Sidebar::cleanup_unused_filaments_after_batch_match(const BatchMatchResult 
                                                 size_t(-1), kept_physical);
             const std::vector<unsigned int> composite_remap = pb->consume_last_filament_id_remap();
             if (!composite_remap.empty()) {
-                EnforcerBlockerStateMap state_map;
-                for (size_t i = 0; i < state_map.size(); ++i)
-                    state_map[i] = EnforcerBlockerType(i);
                 const size_t total_filaments = new_num_physical + pb->mixed_filaments.enabled_count();
-                for (size_t i = 1; i < composite_remap.size() && i < state_map.size(); ++i) {
-                    const unsigned int mapped = composite_remap[i];
-                    if (mapped == 0 || mapped >= state_map.size() || mapped > total_filaments)
-                        state_map[i] = EnforcerBlockerType::NONE;
-                    else
-                        state_map[i] = EnforcerBlockerType(mapped);
-                }
-                for (ModelObject* mo : wxGetApp().model().objects)
-                    for (ModelVolume* mv : mo->volumes)
-                        if (mv->type() == ModelVolumeType::MODEL_PART)
-                            // Pass total_filaments (physical + mixed), NOT new_num_physical —
-                            // remap_enforcer_block_types clips any state > max_type to NONE,
-                            // and remapped mixed virtual ids (N+1..total) must survive.
-                            mv->remap_extruder_ids(total_filaments, state_map);
+                // Single composite pass over paint AND config-level references
+                // (object root-node colour, volume/modifier extruder, feature
+                // filaments, layer ranges) — the per-deletion rewrite was
+                // skipped during the loop above.  Global per-filament feature
+                // keys in the plater config follow the same table.
+                remap_model_filament_refs(composite_remap, total_filaments);
+                wxGetApp().plater()->remap_config_filament_keys(composite_remap);
             }
         } else {
             // Safe fallback: delete one by one with full per-deletion update so each
@@ -8556,23 +8662,12 @@ void Sidebar::cleanup_unused_filaments_after_batch_match(const BatchMatchResult 
     }
 
     // Apply the mixed-deletion remap now that the rows are marked (T3 epoch).
-    // Mirrors the physical-deletion composite remap above.
+    // Mirrors the physical-deletion composite remap above — triangle paint AND
+    // config-level extruder references follow the same table.
     if (!mixed_deletion_remap.empty()) {
-        EnforcerBlockerStateMap state_map;
-        for (size_t i = 0; i < state_map.size(); ++i)
-            state_map[i] = EnforcerBlockerType(i);
         const size_t t3_total = pb->filament_presets.size() + pb->mixed_filaments.enabled_count();
-        for (size_t i = 1; i < mixed_deletion_remap.size() && i < state_map.size(); ++i) {
-            const unsigned int mapped = mixed_deletion_remap[i];
-            if (mapped == 0 || mapped >= state_map.size() || mapped > t3_total)
-                state_map[i] = EnforcerBlockerType::NONE;
-            else
-                state_map[i] = EnforcerBlockerType(mapped);
-        }
-        for (ModelObject* mo : wxGetApp().model().objects)
-            for (ModelVolume* mv : mo->volumes)
-                if (mv->type() == ModelVolumeType::MODEL_PART)
-                    mv->remap_extruder_ids(t3_total, state_map);
+        remap_model_filament_refs(mixed_deletion_remap, t3_total);
+        wxGetApp().plater()->remap_config_filament_keys(mixed_deletion_remap);
     }
 
     // Final authoritative serialization of the post-cleanup state (it must
@@ -8586,6 +8681,11 @@ void Sidebar::cleanup_unused_filaments_after_batch_match(const BatchMatchResult 
     // Rebuild panels once (skipped per-deletion in the loop above).
     update_mixed_filament_panel();
     update_color_mix_panel();
+    // Re-sync the object list filament column: the per-deletion
+    // update_filament_values_for_items_when_delete_filament was skipped during
+    // the batch loop (composite remap repaired the configs instead), so the
+    // list rows (incl. the parent-node colour swatches) still show stale ids.
+    obj_list()->update_objects_list_filament_column(pb->filament_presets.size());
     wxGetApp().plater()->update();
 }
 
@@ -21237,17 +21337,26 @@ void Plater::on_filaments_delete(size_t num_filaments, size_t filament_id, int r
     sidebar().on_filaments_delete(filament_id);
 
     // update global feature filament selections
-    static const char* keys[] = {"wall_filament", "sparse_infill_filament", "solid_infill_filament",
-                                 "support_filament", "support_interface_filament"};
-    for (auto key : keys)
-        if (p->config->has(key)) {
-            if (p->config->opt_int(key) == filament_id + 1)
-                (*(p->config)).erase(key);
-            else {
-                int new_value = p->config->opt_int(key) > filament_id ? p->config->opt_int(key) - 1 : p->config->opt_int(key);
-                (*(p->config)).set_key_value(key, new ConfigOptionInt(new_value));
+    // During batch physical deletion (batch-match cleanup loop) this
+    // per-deletion ARRAY-INDEX decrement is skipped: the batch deletes
+    // non-contiguous ids with a kept-aware composite remap, so a per-deletion
+    // shift would corrupt the surviving slots.  The composite pass
+    // (remap_model_filament_refs in cleanup_unused_filaments_after_batch_match)
+    // re-syncs these keys once after the loop — the same guard pattern as
+    // ObjectList::update_filament_values_for_items_when_delete_filament.
+    if (p->m_batch_physical_deletion == 0) {
+        static const char* keys[] = {"wall_filament", "sparse_infill_filament", "solid_infill_filament",
+                                     "support_filament", "support_interface_filament"};
+        for (auto key : keys)
+            if (p->config->has(key)) {
+                if (p->config->opt_int(key) == filament_id + 1)
+                    (*(p->config)).erase(key);
+                else {
+                    int new_value = p->config->opt_int(key) > filament_id ? p->config->opt_int(key) - 1 : p->config->opt_int(key);
+                    (*(p->config)).set_key_value(key, new ConfigOptionInt(new_value));
+                }
             }
-        }
+    }
 
     // update object/volume/support(object and volume) filament id
     sidebar().obj_list()->update_objects_list_filament_column_when_delete_filament(filament_id, num_filaments, replace_filament_id);
@@ -21267,6 +21376,29 @@ void Plater::on_filaments_delete(size_t num_filaments, size_t filament_id, int r
             if (item.type == CustomGCode::Type::ToolChange && item.extruder > filament_id)
                 item.extruder--;
         }
+    }
+}
+
+void Plater::remap_config_filament_keys(const std::vector<unsigned int> &composite_remap)
+{
+    if (composite_remap.empty() || p->config == nullptr)
+        return;
+
+    static const char* keys[] = {"wall_filament", "sparse_infill_filament", "solid_infill_filament",
+                                 "support_filament", "support_interface_filament"};
+    for (auto key : keys) {
+        if (!p->config->has(key))
+            continue;
+        const int old_id = p->config->opt_int(key);
+        if (old_id <= 0)
+            continue;
+        if (size_t(old_id) >= composite_remap.size())
+            continue;
+        const unsigned int mapped = composite_remap[size_t(old_id)];
+        if (mapped == 0)
+            p->config->erase(key); // referenced filament was dropped
+        else if (mapped != static_cast<unsigned int>(old_id))
+            p->config->set_key_value(key, new ConfigOptionInt(static_cast<int>(mapped)));
     }
 }
 

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -619,6 +619,14 @@ public:
     PrinterTechnology   printer_technology() const;
     const DynamicPrintConfig * config() const;
     bool                set_printer_technology(PrinterTechnology printer_technology);
+    // Batch-match cleanup: remap the GLOBAL per-filament feature keys
+    // (wall_filament / sparse_infill_filament / solid_infill_filament /
+    // support_filament / support_interface_filament) in the plater's config by
+    // a kept-aware composite remap.  The per-deletion array-index decrement of
+    // these keys is skipped during the batch deletion loop; this applies the
+    // single composite table instead.  composite_remap[old_id] = new_id
+    // (1-based); 0 means the referenced filament was dropped -> key erased.
+    void                remap_config_filament_keys(const std::vector<unsigned int> &composite_remap);
 
     //BBS
     void cut_selection_to_clipboard();

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -4600,6 +4600,13 @@ static void apply_config_layer_remap_mirror(
             }
         }
 
+        // Object-level extruder remapped UNCONDITIONALLY when the object's
+        // source slot is in the remap — the object list's parent-node colour
+        // swatch reads mo->config directly, so it must follow the match even
+        // when every volume owns its own extruder.
+        if (obj_remap && !object_extruder_written)
+            mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(obj_it->second)));
+
         for (auto& lr : mo->layer_config_ranges) {
             ModelConfig&         lcfg = lr.second;
             const ConfigOption*  lopt = lcfg.option("extruder");
@@ -4686,6 +4693,50 @@ TEST_CASE("apply config remap: modifier with own extruder is remapped alone", "[
     REQUIRE(obj->config.opt_int("extruder") == 1); // object untouched
 }
 
+TEST_CASE("apply config remap: object root-node colour follows the match even when all volumes own their extruder", "[MixedFilament][batch_apply]")
+{
+    // The object list's parent-node colour swatch reads mo->config "extruder"
+    // directly.  When every volume owns its own extruder (nothing inherits),
+    // the OLD apply loop never wrote the object config — so after the match
+    // the root node kept the old source colour while the volumes migrated to
+    // the new mixed slot.  apply now remaps the object config UNCONDITIONALLY
+    // whenever the object's source slot is in the remap.
+    Model model;
+    ModelObject *obj  = model.add_object();
+    ModelVolume  *part = obj->add_volume(make_cube(20., 20., 20.));
+    ModelVolume  *mod  = obj->add_volume(make_cube(20., 20., 20.), ModelVolumeType::PARAMETER_MODIFIER);
+    obj->config.set_key_value("extruder",  new ConfigOptionInt(5));
+    part->config.set_key_value("extruder", new ConfigOptionInt(5)); // owns it
+    mod->config.set_key_value("extruder",  new ConfigOptionInt(5)); // owns it
+
+    std::unordered_map<int, unsigned int> remap{{5, 7u}};
+    apply_config_layer_remap_mirror(model, remap);
+
+    // Root-node colour: object extruder follows the match...
+    REQUIRE(obj->config.opt_int("extruder") == 7);
+    // ...and the volumes were remapped on their own configs.
+    REQUIRE(part->config.opt_int("extruder") == 7);
+    REQUIRE(mod->config.opt_int("extruder")  == 7);
+    REQUIRE(part->extruder_id() == 7);
+    REQUIRE(mod->extruder_id()  == 7);
+}
+
+TEST_CASE("apply config remap: object NOT in remap stays untouched (root node keeps its colour)", "[MixedFilament][batch_apply]")
+{
+    // Unconditional object remap must NOT fire for objects whose source slot is
+    // not part of the match — e.g. an object already on the new mixed target
+    // before the match, or on a slot the match leaves alone.
+    Model model;
+    ModelObject *obj  = model.add_object();
+    obj->add_volume(make_cube(20., 20., 20.));
+    obj->config.set_key_value("extruder", new ConfigOptionInt(4)); // not in remap
+
+    std::unordered_map<int, unsigned int> remap{{5, 7u}};
+    apply_config_layer_remap_mirror(model, remap);
+
+    REQUIRE(obj->config.opt_int("extruder") == 4);
+}
+
 TEST_CASE("apply layer remap: hit is remapped, miss is left untouched", "[MixedFilament][batch_apply]")
 {
     // Level-3 (layer_config_ranges): a height range whose extruder is in the
@@ -4749,6 +4800,165 @@ TEST_CASE("manual-mode apply migrates unselected-physical painting off its slot"
 
     // THEN cleanup's kept-aware state_map is safe to map 3 -> 0 (nothing left on
     // 3 to drop) and 6 -> 2 (survivor's new slot). This is the fix's guarantee.
+}
+
+// ===========================================================================
+// cleanup composite remap (remap_model_filament_refs mirror)
+//
+// Production function: Sidebar::cleanup_unused_filaments_after_batch_match
+// (Plater.cpp) — the kept-aware composite remap that repairs BOTH triangle
+// paint AND config-level extruder references after the per-deletion
+// array-index decrement (update_filament_values_for_items_when_delete_filament)
+// has shifted object/volume/layer configs onto wrong slots. The config pass
+// exists so the object list's parent-node colour swatch (reads mo->config
+// "extruder" directly) and the volumes/layers render the POST-match slots.
+// ===========================================================================
+
+// Mirror of remap_model_filament_refs (Plater.cpp). Kept byte-faithful to the
+// production loop; a change there must surface here.
+static void remap_model_filament_refs_mirror(Model&                                   model,
+                                             const std::vector<unsigned int>&         composite_remap,
+                                             size_t                                   total_filaments)
+{
+    if (composite_remap.empty()) return;
+
+    static const char* FEATURE_KEYS[] = {"wall_filament", "sparse_infill_filament", "solid_infill_filament",
+                                         "support_filament", "support_interface_filament"};
+
+    EnforcerBlockerStateMap state_map;
+    for (size_t i = 0; i < state_map.size(); ++i)
+        state_map[i] = EnforcerBlockerType(i);
+    for (size_t i = 1; i < composite_remap.size() && i < state_map.size(); ++i) {
+        const unsigned int mapped = composite_remap[i];
+        if (mapped == 0 || mapped >= state_map.size() || mapped > total_filaments)
+            state_map[i] = EnforcerBlockerType::NONE;
+        else
+            state_map[i] = EnforcerBlockerType(mapped);
+    }
+
+    auto remap_feature_keys = [&](ModelConfig &cfg) {
+        for (const char *key : FEATURE_KEYS) {
+            if (!cfg.has(key)) continue;
+            const int old_id = cfg.opt_int(key);
+            if (old_id <= 0) continue;
+            if (size_t(old_id) >= composite_remap.size()) continue;
+            const unsigned int mapped = composite_remap[size_t(old_id)];
+            if (mapped == 0)
+                cfg.erase(key);
+            else if (mapped != static_cast<unsigned int>(old_id))
+                cfg.set_key_value(key, new ConfigOptionInt(static_cast<int>(mapped)));
+        }
+    };
+
+    for (ModelObject *mo : model.objects) {
+        const ConfigOption *obj_opt      = mo->config.option("extruder");
+        const int           orig_obj_eid = (obj_opt ? obj_opt->getInt() : 0);
+        const unsigned int  obj_target   = (orig_obj_eid > 0 &&
+                                            size_t(orig_obj_eid) < composite_remap.size())
+                                               ? composite_remap[size_t(orig_obj_eid)] : 0;
+        if (obj_target != 0)
+            mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(obj_target)));
+        else if (obj_opt && obj_opt->getInt() > 0)
+            mo->config.erase("extruder");
+        remap_feature_keys(mo->config);
+        for (ModelVolume *mv : mo->volumes) {
+            const ModelVolumeType vt = mv->type();
+            if (vt != ModelVolumeType::MODEL_PART && vt != ModelVolumeType::PARAMETER_MODIFIER)
+                continue;
+            const ConfigOption *vol_opt = mv->config.option("extruder");
+            if (vol_opt && vol_opt->getInt() > 0) {
+                const unsigned int mapped = (size_t(vol_opt->getInt()) < composite_remap.size())
+                                                ? composite_remap[size_t(vol_opt->getInt())] : 0;
+                if (mapped != 0)
+                    mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(mapped)));
+                else
+                    mv->config.erase("extruder");
+            }
+            remap_feature_keys(mv->config);
+            if (vt == ModelVolumeType::MODEL_PART && !mv->mmu_segmentation_facets.empty())
+                mv->remap_extruder_ids(total_filaments, state_map);
+        }
+        for (auto &lr : mo->layer_config_ranges) {
+            ModelConfig        &lcfg = lr.second;
+            const ConfigOption *lopt = lcfg.option("extruder");
+            if (!lopt) continue;
+            const int old_eid = lopt->getInt();
+            if (old_eid <= 0) continue;
+            if (size_t(old_eid) >= composite_remap.size()) continue;
+            const unsigned int mapped = composite_remap[size_t(old_eid)];
+            if (mapped == 0)
+                lcfg.set_key_value("extruder", new ConfigOptionInt(0));
+            else
+                lcfg.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(mapped)));
+        }
+    }
+}
+
+TEST_CASE("cleanup composite remap: config-level extruders follow the kept-aware remap (root-node colour)", "[MixedFilament][batch_apply]")
+{
+    // Scenario: manual subset [2,6,8,10] of 10 physicals, kept-aware remap
+    //   old 2 -> 1, 6 -> 2, 8 -> 3, 10 -> 4; others -> 0 (dropped).
+    // The per-deletion array-index decrement is SKIPPED during the batch loop,
+    // so the config references still hold their pre-deletion ids and the
+    // composite remap moves them to the post-match slots.  Object config is
+    // what the object list's parent-node colour swatch reads.
+    const std::vector<unsigned int> kept_aware = {0u, 0u, 1u, 0u, 0u, 0u, 2u, 0u, 3u, 0u, 4u}; // [1..10]
+
+    Model model;
+    ModelObject *obj  = model.add_object();
+    obj->config.set_key_value("extruder", new ConfigOptionInt(6)); // root-node colour source
+    ModelVolume *part = obj->add_volume(make_cube(20., 20., 20.));
+    part->config.set_key_value("extruder", new ConfigOptionInt(6));
+    ModelVolume *mod = obj->add_volume(make_cube(20., 20., 20.), ModelVolumeType::PARAMETER_MODIFIER);
+    mod->config.set_key_value("extruder", new ConfigOptionInt(8));
+    // Feature keys follow the same table; a dropped source is erased.
+    obj->config.set_key_value("wall_filament", new ConfigOptionInt(6));
+    part->config.set_key_value("support_filament", new ConfigOptionInt(4)); // dropped -> erased
+    obj->layer_config_ranges[t_layer_height_range{0.0, 1.0}].set_key_value("extruder", new ConfigOptionInt(10));
+    obj->layer_config_ranges[t_layer_height_range{1.0, 2.0}].set_key_value("extruder", new ConfigOptionInt(4)); // dropped -> must be removed
+
+    // Triangle paint on the part (facet on extruder 6) must follow 6 -> 2.
+    TriangleSelector selector(part->mesh());
+    selector.set_facet(0, EnforcerBlockerType(6));
+    REQUIRE(part->mmu_segmentation_facets.set(selector));
+
+    constexpr size_t new_total = 4; // 4 physical survivors, no mixed
+    remap_model_filament_refs_mirror(model, kept_aware, new_total);
+
+    // Root node colour follows the match.
+    REQUIRE(obj->config.opt_int("extruder") == 2);
+    // Volumes follow their own configs.
+    REQUIRE(part->config.opt_int("extruder") == 2);
+    REQUIRE(mod->config.opt_int("extruder")  == 3);
+    // Feature keys: kept source follows, dropped source erased.
+    REQUIRE(obj->config.opt_int("wall_filament") == 2);
+    REQUIRE_FALSE(part->config.has("support_filament"));
+    // Layer ranges follow; a dropped source is reset to default (0).
+    REQUIRE(obj->layer_config_ranges.at(t_layer_height_range{0.0, 1.0}).opt_int("extruder") == 4);
+    REQUIRE(obj->layer_config_ranges.at(t_layer_height_range{1.0, 2.0}).opt_int("extruder") == 0);
+    // Triangle paint moved to the new slot.
+    REQUIRE(part->mmu_segmentation_facets.has_facets(*part, EnforcerBlockerType(2)));
+    REQUIRE(!part->mmu_segmentation_facets.has_facets(*part, EnforcerBlockerType(6)));
+}
+
+TEST_CASE("cleanup composite remap: object on a dropped source falls back to default", "[MixedFilament][batch_apply]")
+{
+    // An object whose extruder references a slot the match dropped (mapped -> 0)
+    // has its key erased so it falls back to default; a volume referencing the
+    // dropped slot erases its own key and inherits the object.
+    const std::vector<unsigned int> kept_aware = {0u, 0u, 1u, 0u, 0u, 0u, 2u, 0u, 3u, 0u, 4u}; // [1..10]
+
+    Model model;
+    ModelObject *obj  = model.add_object();
+    obj->config.set_key_value("extruder", new ConfigOptionInt(4)); // dropped
+    ModelVolume *part = obj->add_volume(make_cube(20., 20., 20.));
+    part->config.set_key_value("extruder", new ConfigOptionInt(4)); // dropped
+
+    constexpr size_t new_total = 4;
+    remap_model_filament_refs_mirror(model, kept_aware, new_total);
+
+    REQUIRE_FALSE(obj->config.has("extruder"));   // back to default
+    REQUIRE_FALSE(part->config.has("extruder"));  // inherits object (default)
 }
 
 // ===========================================================================


### PR DESCRIPTION
fix(mixed-filament): remap parent node filament after batch color match

Batch color match applies a kept-aware composite remap that can move
physical slots onto non-contiguous ids and renumber mixed virtual ids,
but after Confirm the object list's parent-node colour swatches still
read the pre-match extruder: the old per-deletion rewrites were skipped
during the batch loop, and the final column refresh re-materialized
extruder 0 into objects left unset.

Rework the cleanup to apply one composite pass that moves every
config-level filament reference (object root-node extruder, volume /
modifier extruder, feature filament keys, layer ranges) through the
same remap table used for triangle paint:

- Sidebar::cleanup_unused_filaments_after_batch_match: build the
  composite state_map once and remap config references together with
  the model paint, for both the physical- and mixed-deletion passes
- Plater::remap_config_filament_keys: follow the same table for the
  global wall/infill/support filament settings in the plater config
- Plater::on_filaments_delete: skip the per-deletion array-index
  decrement of feature keys while the batch loop runs (same guard as
  the paint remap), so surviving slots are not corrupted before the
  composite pass
- refresh the object list filament column after cleanup so parent-node
  swatches show the post-remap extruder instead of stale ids
- MixedColorMatchHelpers::apply_batch_match_to_model: remap the object
  config unconditionally when the object's slot is in the match, so the
  root node follows even when every volume owns its own extruder

Adds mirror tests for the composite remap and the root-node colour
cases.