### PR TITLE
chore: temp workflow to fetch mac deps cache (auto-revert after use)

### DIFF
--- a/.github/workflows/fetch_deps.yml
+++ b/.github/workflows/fetch_deps.yml
@@ -1,0 +1,33 @@
+name: Fetch mac deps (temp)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  fetch:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          lfs: 'true'
+
+      - name: restore deps cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: deps/build
+          key: macos-14-cache-orcaslicer_deps-build-${{ hashFiles('deps/**') }}
+          fail-on-cache-miss: true
+
+      - name: pack arm64 deps
+        run: |
+          du -sh deps/build/arm64/OrcaSlicer_dep
+          cd deps/build/arm64
+          tar -czf ../../../deps-arm64.tar.gz OrcaSlicer_dep
+          ls -lh ../../../deps-arm64.tar.gz
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: deps-arm64
+          path: deps-arm64.tar.gz
+          if-no-files-found: error


### PR DESCRIPTION
临时 workflow：把 CI 缓存里的 mac arm64 deps 打包成 artifact，供本地构建用。用完后 revert 此 commit。

- 触发：Actions → Fetch mac deps (temp) → Run workflow（ref: main）
- 产物：deps-arm64 artifact（≈600MB-1GB tar.gz）
- 用途：/Users/tian/projects/OrcaSlicer 本地只编 slicer，避免 1-2h deps 编译