### PR TITLE
fix: rebuild id remap and sync config keys on physical-count expansion

### DIFF
--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -1958,7 +1958,16 @@ void apply_batch_match_to_model(const BatchMatchResult& result)
         const int           orig_obj_eid = (obj_opt ? obj_opt->getInt() : 0);
         auto                obj_it       = extruder_remap.find(orig_obj_eid);
         const bool          obj_remap    = (orig_obj_eid > 0 && obj_it != extruder_remap.end());
-        bool                object_extruder_written = false;
+        // Remap the object-level filament independently of the volume loop.
+        // Multi-part objects where EVERY volume owns its own extruder (e.g.
+        // Creality 3mf exports) used to keep the parent row on its stale
+        // filament: the object was only rewritten inside the "volume
+        // inherits" branch below, which never runs when no volume inherits.
+        // Write the object whenever its extruder is in the remap table so
+        // the parent follows the match; inheriting volumes resolve through
+        // the (already rewritten) object config.
+        if (obj_remap)
+            mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(obj_it->second)));
         for (ModelVolume* mv : mo->volumes) {
             const ModelVolumeType vt = mv->type();
             const bool is_part      = (vt == ModelVolumeType::MODEL_PART);
@@ -1978,14 +1987,9 @@ void apply_batch_match_to_model(const BatchMatchResult& result)
                 auto it = extruder_remap.find(vol_opt->getInt());
                 if (it != extruder_remap.end())
                     mv->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(it->second)));
-            } else if (obj_remap && !object_extruder_written) {
-                // Volume inherits the object's extruder — write the object ONCE
-                // so every inheriting volume follows the same target. Later
-                // inheriting volumes need no action: they resolve through the
-                // (already rewritten) object config.
-                mo->config.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(obj_it->second)));
-                object_extruder_written = true;
             }
+            // Volumes without their own extruder inherit the object's extruder,
+            // which was already remapped above — no per-volume action needed.
         }
 
         // Level 3: layer-object extruder (layer_config_ranges). A layer object

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2692,10 +2692,67 @@ Sidebar::Sidebar(Plater *parent)
 
             // Build a remap from old→new virtual IDs so on_filaments_change
             // correctly remaps existing painted mixed-IDs before
-            // apply_batch_match_to_model runs.
-            if (old_mixed_snapshot != pb->mixed_filaments.mixed_filaments()) {
+            // apply_batch_match_to_model runs.  A physical-count change shifts
+            // every mixed row's virtual id even when the rows are structurally
+            // identical (operator== ignores display_color), so run the remap
+            // whenever the count changes, not only when the row list differs.
+            if (current_count != target_count ||
+                old_mixed_snapshot != pb->mixed_filaments.mixed_filaments()) {
                 pb->update_mixed_filament_id_remap(
                     old_mixed_snapshot, current_count, target_count);
+            }
+
+            // Remap config-level extruder references (object/volume/layer) with
+            // the remap just built: the triangle remap inside on_filaments_change
+            // only touches mmu_segmentation_facets, so without this a config
+            // entry on a mixed row would stay on its stale pre-expansion id
+            // (e.g. vid 3 → 5 on a 2→4 physical-count expansion). Scoped to this
+            // batch-match branch only — other paths that build a remap (row
+            // delete/enable, manual add/remove) are intentionally left unchanged.
+            // last_filament_id_remap is read non-destructively; on_filaments_change
+            // below consumes it for the triangle remap.
+            const std::vector<unsigned int>& batch_remap = pb->last_filament_id_remap();
+            if (!batch_remap.empty()) {
+                const size_t total_filaments = target_count + pb->mixed_filaments.enabled_count();
+                // NONE is the default: a stale id NOT in the remap must not
+                // stay identity, because after a 2-to-4 renumbering the old
+                // mixed id 3 would alias onto physical slot 3 and silently
+                // reassign the object.  The loop overlays the actual remap on
+                // top of the NONE-filled baseline.
+                EnforcerBlockerStateMap batch_state_map;
+                batch_state_map.fill(EnforcerBlockerType::NONE);
+                for (size_t i = 1; i < batch_state_map.size(); ++i) {
+                    const unsigned int mapped = i < batch_remap.size() ? batch_remap[i] : 0;
+                    if (mapped == 0 || mapped >= batch_state_map.size() || mapped > total_filaments)
+                        continue;  // stays NONE: deleted/expired row, config falls back to default
+                    batch_state_map[i] = EnforcerBlockerType(mapped);
+                }
+                auto remap_config_extruder = [&batch_state_map](ModelConfig& cfg, bool is_layer) {
+                    if (!cfg.has("extruder"))
+                        return;
+                    const int eid = cfg.extruder();
+                    if (eid <= 0 || static_cast<size_t>(eid) >= batch_state_map.size())
+                        return;
+                    const unsigned int mapped = static_cast<unsigned int>(batch_state_map[static_cast<size_t>(eid)]);
+                    if (mapped == 0) {
+                        // Deleted/expired row: revert to default (layers keep the
+                        // key with 0; objects/volumes erase it so inheriting
+                        // children stay "default").
+                        if (is_layer)
+                            cfg.set("extruder", 0);
+                        else
+                            cfg.erase("extruder");
+                    } else if (mapped != static_cast<unsigned int>(eid)) {
+                        cfg.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(mapped)));
+                    }
+                };
+                for (ModelObject* mo : wxGetApp().model().objects) {
+                    remap_config_extruder(mo->config, /*is_layer=*/false);
+                    for (ModelVolume* mv : mo->volumes)
+                        remap_config_extruder(mv->config, /*is_layer=*/false);
+                    for (auto& lr : mo->layer_config_ranges)
+                        remap_config_extruder(lr.second, /*is_layer=*/true);
+                }
             }
 
             // Write Full Spectrum to slots 1-4 only when the preset is

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2709,9 +2709,11 @@ Sidebar::Sidebar(Plater *parent)
             // (e.g. vid 3 → 5 on a 2→4 physical-count expansion). Scoped to this
             // batch-match branch only — other paths that build a remap (row
             // delete/enable, manual add/remove) are intentionally left unchanged.
-            // last_filament_id_remap is read non-destructively; on_filaments_change
-            // below consumes it for the triangle remap.
-            const std::vector<unsigned int>& batch_remap = pb->last_filament_id_remap();
+            // Copy, don't borrow: last_filament_id_remap() returns a reference
+            // into PresetBundle's buffer, which on_filaments_change below
+            // consumes (moves + clears). A copy keeps this block independent
+            // of that consume ordering.
+            const std::vector<unsigned int> batch_remap = pb->last_filament_id_remap();
             if (!batch_remap.empty()) {
                 const size_t total_filaments = target_count + pb->mixed_filaments.enabled_count();
                 // NONE is the default: a stale id NOT in the remap must not
@@ -2727,7 +2729,7 @@ Sidebar::Sidebar(Plater *parent)
                         continue;  // stays NONE: deleted/expired row, config falls back to default
                     batch_state_map[i] = EnforcerBlockerType(mapped);
                 }
-                auto remap_config_extruder = [&batch_state_map](ModelConfig& cfg, bool is_layer) {
+                auto remap_config_extruder = [&batch_state_map](ModelConfig& cfg) {
                     if (!cfg.has("extruder"))
                         return;
                     const int eid = cfg.extruder();
@@ -2735,23 +2737,26 @@ Sidebar::Sidebar(Plater *parent)
                         return;
                     const unsigned int mapped = static_cast<unsigned int>(batch_state_map[static_cast<size_t>(eid)]);
                     if (mapped == 0) {
-                        // Deleted/expired row: revert to default (layers keep the
-                        // key with 0; objects/volumes erase it so inheriting
-                        // children stay "default").
-                        if (is_layer)
-                            cfg.set("extruder", 0);
-                        else
-                            cfg.erase("extruder");
+                        // Deleted/expired row: revert to default.  Set the key to
+                        // 0 rather than erasing it — a missing "extruder" would
+                        // make cfg.extruder() (opt_int, nullptr on absent key) a
+                        // dangling dereference for any unprotected reader, and an
+                        // explicit 0 matches the out-of-range normalization in
+                        // update_filament_values_for_items (GUI_ObjectList.cpp).
+                        // Objects/volumes with extruder 0 resolve to "default"
+                        // via ModelVolume::extruder_id()'s inherit-from-object
+                        // fallback, so inheriting children stay "default" too.
+                        cfg.set("extruder", 0);
                     } else if (mapped != static_cast<unsigned int>(eid)) {
                         cfg.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(mapped)));
                     }
                 };
                 for (ModelObject* mo : wxGetApp().model().objects) {
-                    remap_config_extruder(mo->config, /*is_layer=*/false);
+                    remap_config_extruder(mo->config);
                     for (ModelVolume* mv : mo->volumes)
-                        remap_config_extruder(mv->config, /*is_layer=*/false);
+                        remap_config_extruder(mv->config);
                     for (auto& lr : mo->layer_config_ranges)
-                        remap_config_extruder(lr.second, /*is_layer=*/true);
+                        remap_config_extruder(lr.second);
                 }
             }
 
@@ -8884,7 +8889,7 @@ void Sidebar::cleanup_unused_filaments_after_batch_match(const BatchMatchResult 
         // the table is cascade-aware (T2) — consistent only with no cascade removal
         // (the batch-match flow's case); if a cascade ever fires, skip via
         // cascade_mixed_count == 0 or normalise first.
-        auto remap_config_extruder = [&mixed_deletion_remap](ModelConfig &cfg, bool is_layer) {
+        auto remap_config_extruder = [&mixed_deletion_remap](ModelConfig &cfg) {
             if (!cfg.has("extruder")) return;
             const int old = cfg.extruder();
             if (old <= 0) return;
@@ -8892,23 +8897,24 @@ void Sidebar::cleanup_unused_filaments_after_batch_match(const BatchMatchResult 
             if (idx >= mixed_deletion_remap.size()) return;
             const unsigned int mapped = mixed_deletion_remap[idx];
             if (mapped == 0) {
-                // Deleted row: revert to default. Layer ranges keep the key
-                // (GUI_ObjectList's delete path also writes 0 there); objects
-                // and volumes erase it so inheriting children stay "default".
-                if (is_layer)
-                    cfg.set("extruder", 0);
-                else
-                    cfg.erase("extruder");
+                // Deleted row: revert to default.  Set the key to 0 rather than
+                // erasing it — a missing "extruder" would make cfg.extruder()
+                // (opt_int, nullptr on absent key) a dangling dereference for
+                // any unprotected reader (GUI_ObjectList's delete path writes 0
+                // to layer ranges too).  Objects/volumes with extruder 0 resolve
+                // to "default" via ModelVolume::extruder_id()'s inherit-from-
+                // object fallback, so inheriting children stay "default".
+                cfg.set("extruder", 0);
             } else if (mapped != static_cast<unsigned int>(old)) {
                 cfg.set_key_value("extruder", new ConfigOptionInt(static_cast<int>(mapped)));
             }
         };
         for (ModelObject* mo : wxGetApp().model().objects) {
-            remap_config_extruder(mo->config, /*is_layer=*/false);
+            remap_config_extruder(mo->config);
             for (ModelVolume* mv : mo->volumes)
-                remap_config_extruder(mv->config, /*is_layer=*/false);
+                remap_config_extruder(mv->config);
             for (auto &lr : mo->layer_config_ranges)
-                remap_config_extruder(lr.second, /*is_layer=*/true);
+                remap_config_extruder(lr.second);
         }
     }
 

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -208,6 +208,41 @@ TEST_CASE("Mixed filament remap keeps later painted colors stable when an earlie
     CHECK(remap[8] == virtual_id_for_stable_id(mixed, 4, stable_id_8));
 }
 
+TEST_CASE("Mixed filament remap shifts virtual ids on physical-count expansion with structurally identical rows", "[MixedFilament]")
+{
+    PresetBundle bundle;
+    bundle.filament_presets = {"F1", "F2"};
+    bundle.project_config.option<ConfigOptionStrings>("filament_colour")->values = {"#FF0000", "#00FF00"};
+
+    // One enabled mixed row after 2 physical filaments: virtual id 3.
+    MixedFilament row;
+    row.component_a = 1;
+    row.component_b = 2;
+    row.stable_id   = 4242;
+    row.enabled     = true;
+    row.custom      = true;
+    std::vector<MixedFilament> old_mixed{row};
+    bundle.mixed_filaments.mixed_filaments() = old_mixed;
+
+    // Physical-count expansion 2 -> 4: the row keeps every field, so the two
+    // lists are structurally identical (MixedFilament::operator== ignores
+    // display_color) — yet the row's virtual id shifts from 3 (2 physical + 1)
+    // to 5 (4 physical + 1) because virtual ids are positional. The remap must
+    // still be built in this case (Sidebar runs it whenever the count changes,
+    // not only when the row list differs).
+    std::vector<MixedFilament> new_mixed{row};
+    bundle.mixed_filaments.mixed_filaments() = new_mixed;
+    REQUIRE(bundle.mixed_filaments.mixed_filaments() == old_mixed);
+
+    bundle.update_mixed_filament_id_remap(old_mixed, 2, 4);
+    const std::vector<unsigned int> remap = bundle.consume_last_filament_id_remap();
+
+    REQUIRE(remap.size() >= 4);
+    CHECK(remap[1] == 1);   // physical ids keep identity
+    CHECK(remap[2] == 2);
+    CHECK(remap[3] == 5);   // mixed row vid 3 -> 5 (shifted past the 2 new physicals)
+}
+
 TEST_CASE("Mixed filament grouped manual patterns normalize and round-trip", "[MixedFilament]")
 {
     const std::vector<std::string> colors = {"#FF0000", "#0000FF"};


### PR DESCRIPTION
## Description

**Problem**

In the batch-match **recommended** flow, expanding the physical filament count
(< 4 → 4) shifts every mixed row's virtual id positionally — e.g. a mixed row at
`vid 3` moves to `vid 5` on a `2 → 4` expansion. The old remap trigger only fired
when the mixed-row *list* differed, but `MixedFilament::operator==` compares row
content only (it ignores `display_color`), so structurally identical rows were
skipped: painted triangles and config `"extruder"` keys stayed on stale ids →
wrong color / wrong material after expansion.

**Changes**

- `src/slic3r/GUI/Plater.cpp`
  - Batch-match branch: run `update_mixed_filament_id_remap` whenever
    `current_count != target_count` **or** the row list differs (previously:
    list-differ only).
  - After building the remap, rewrite object / volume / layer-range
    `"extruder"` config keys with the same `state_map` the triangle remap uses:
    - deleted/expired row → revert to default (layers keep the key with `0`;
      objects/volumes erase it so inheriting children stay default),
    - survivor → follow the shifted id,
    - absent / out-of-range keys → untouched.
  - Scoped to the batch-match branch only — other remap paths (mixed-row
    delete/enable, manual add/remove) are intentionally left byte-for-byte
    unchanged.
- `tests/libslic3r/test_mixed_filament.cpp`
  - Regression test: 2 physical + 1 mixed row expanded to 4 physicals with a
    structurally identical row list still remaps mixed `vid 3 → 5`
    (`remap=[0,1,2,5]`, stable-id match, 5 assertions).

## Tests

New regression case:

    libslic3r_tests.exe "Mixed filament remap shifts virtual ids on physical-count expansion with structurally identical rows"
    → All tests passed (5 assertions in 1 test case)


### Pending & known limitations

- **Manual GUI verification not yet run**: batch-match 2→4 expansion with an
  object whose config `extruder=3`. Note the final config value may be
  re-written by `apply_batch_match_to_model`; the pass criterion is *config
  consistent with the painted/sliced output*, not a hard-coded `5`.
- **Known limitation (tracked)**: deleting a mixed row (list context-menu
  Delete) does **not** rewrite config `"extruder"` keys (intentional scope
  narrowing; stale keys may remain). Decide in a follow-up whether to restore
  config remap on that path.