### PR TITLE
fix: reword auto color-match nozzle-diameter block message

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -15399,8 +15399,8 @@ msgstr "自动计算最接近原模型颜色的混色方案，并一键完成颜
 msgid "No model detected. Import a multi-color model to continue."
 msgstr "未检测到模型，请先导入多色模型。"
 
-msgid "Automatic color mixing match is not supported with the current nozzle diameter. Use Manual mode or switch to a 0.4 mm nozzle."
-msgstr "当前喷嘴直径不支持混色自动匹配。请使用手动匹配，或更换为 0.4mm 喷嘴。"
+msgid "Automatic color mixing matching is not supported for the current nozzle diameter. Please use manual matching or replace with a smaller-size nozzle."
+msgstr "当前喷嘴直径不支持混色自动匹配。请使用手动匹配，或更换为更小尺寸喷嘴。"
 
 msgid "Updating the Filaments and Color Mixing list..."
 msgstr "正在更新耗材列表和混色列表……"

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -2258,7 +2258,7 @@ void MixedFilamentBatchDialog::start_batch_match()
     // unaffected (user picks filaments from the current list, palette-agnostic).
     if (m_matching_method == RECOMMENDED && !full_spectrum_preset_exists_for_current_nozzle()) {
         RichMessageDialog dlg(this,
-            _L("Automatic color mixing match is not supported with the current nozzle diameter. Use Manual mode or switch to a 0.4 mm nozzle."),
+            _L("Automatic color mixing matching is not supported for the current nozzle diameter. Please use manual matching or replace with a smaller-size nozzle."),
             _L("Color Mixing Match"), wxOK);
         dlg.SetOKLabel(_L("Got it"));
         dlg.CentreOnScreen();


### PR DESCRIPTION
Replace the hardcoded "0.4 mm nozzle" hint with a generic smaller-size
nozzle wording, since any preset-defined nozzle size is auto-supported.
Sync the zh_CN translation to match the updated source string.