### PR TITLE
fix: keep support interface intact with variable layer heights

### DIFF
--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -3157,6 +3157,15 @@ void PrintObjectSupportMaterial::trim_support_layers_by_object(
                     if (object_layer.bottom_z() > support_layer.print_z + gap_extra_above - EPSILON)
                         break;
 
+                    // Skip the object layer directly supported by this top contact layer: its lslices
+                    // cover the overhang itself, so trimming by it would cut away the contact area.
+                    // With variable layer heights the synchronised gap is shorter than the configured
+                    // gap, so this layer used to fall inside the trimming window and removed ~80% of
+                    // the contact surface.
+                    if (support_layer.layer_type == SupporLayerType::TopContact &&
+                        i == support_layer.idx_object_layer_above)
+                        continue;
+
                     bool is_overlap = is_layers_overlap(support_layer, object_layer);
                     for (const ExPolygon& expoly : object_layer.lslices) {
                         // BBS


### PR DESCRIPTION
## Summary

Fixes support interface being fragmented (only ~21% area remaining) when variable layer heights are enabled on a model with a large overhang.

## Root cause

`trim_support_layers_by_object` trims top contact layers using object layer lslices. With variable layer heights, the synchronised gap (`sync_gap_with_object_layer`) is shorter than the configured gap, so the object layer directly supported by the contact layer falls inside the trimming window. That layer's lslices cover the overhang region itself and trimmed ~80% of the contact area, leaving only fragmented support interface mixed with base support.

## Fix

Skip the object layer directly supported by a top contact layer (`i == support_layer.idx_object_layer_above`) when collecting trimming polygons. This keeps the contact layer intact; fixed layer height behavior is unchanged (verified via debug logs: interface area 1.59e15 covers base fully, base_after = 0).

## Verification

- Variable layer height: support interface restored to full coverage
- Fixed layer height: no regression (interface coverage 100%, no base residue)

## Impact

- `src/libslic3r/Support/SupportMaterial.cpp` (12 lines added)
- Applies to normal (non-tree) supports; tree support path is unaffected (its trim function operates on print support layers without layer_type/idx members).