### PR TITLE
fix: adversarial review fixes for PR #640

### DIFF
--- a/src/slic3r/GUI/DownloadManager.cpp
+++ b/src/slic3r/GUI/DownloadManager.cpp
@@ -18,9 +18,11 @@ namespace Slic3r { namespace GUI {
 
 std::string DownloadManager::get_unique_file_path(const boost::filesystem::path& file_path)
 {
+    // file_path should be the complete absolute path: directory + filename
     std::string original_path = file_path.string();
     BOOST_LOG_TRIVIAL(debug) << boost::format("DownloadManager::get_unique_file_path: Checking path '%1%'") % original_path;
 
+    // Check if file exists, if not return original path
     if (!boost::filesystem::exists(file_path)) {
         BOOST_LOG_TRIVIAL(debug) << boost::format("DownloadManager::get_unique_file_path: File does not exist, returning original path '%1%'") % original_path;
         return original_path;
@@ -35,24 +37,32 @@ std::string DownloadManager::get_unique_file_path(const boost::filesystem::path&
     std::string name_without_ext;
     if (extension.empty()) {
         name_without_ext = filename;
+        BOOST_LOG_TRIVIAL(debug) << boost::format("DownloadManager::get_unique_file_path: No extension found, filename='%1%'") % filename;
     } else {
         name_without_ext = filename.substr(0, filename.size() - extension.size());
+        BOOST_LOG_TRIVIAL(debug) << boost::format("DownloadManager::get_unique_file_path: filename='%1%', extension='%2%', name_without_ext='%3%'")
+            % filename % extension % name_without_ext;
     }
 
+    // Generate unique filename with Windows-style numbering: filename(1).ext, filename(2).ext, etc.
     size_t version = 1;
     boost::filesystem::path unique_path;
     do {
         std::string new_filename;
         if (extension.empty()) {
+            // No extension: filename(1), filename(2), etc.
             new_filename = name_without_ext + "(" + std::to_string(version) + ")";
         } else {
+            // Has extension: filename(1).ext, filename(2).ext, etc.
             new_filename = name_without_ext + "(" + std::to_string(version) + ")" + extension;
         }
         unique_path = parent_dir / new_filename;
+        BOOST_LOG_TRIVIAL(debug) << boost::format("DownloadManager::get_unique_file_path: Trying version %1%: '%2%'") % version % unique_path.string();
         version++;
-    } while (boost::filesystem::exists(unique_path) && version < 10000);
+    } while (boost::filesystem::exists(unique_path) && version < 10000);  // Safety limit
 
     if (version >= 10000) {
+        // If we hit the limit, log a warning and return a timestamp-based name
         BOOST_LOG_TRIVIAL(warning) << boost::format("DownloadManager::get_unique_file_path: Too many duplicate files for '%1%', using timestamp-based name")
             % original_path;
         std::string timestamp = std::to_string(std::time(nullptr));
@@ -71,13 +81,13 @@ std::string DownloadManager::get_unique_file_path(const boost::filesystem::path&
 }
 
 // ============================================================================
-// WCP Download Interface
+// WCP Download Interface (for Web-to-PC communication)
 // ============================================================================
 size_t DownloadManager::start_wcp_download(const std::string& file_url,
                                              const std::string& file_name,
                                              std::shared_ptr<SSWCP_Instance> wcp_instance,
                                              bool use_original_event_id) {
-    return start_wcp_download(file_url, file_name, wcp_instance, use_original_event_id, true, "");
+    return start_wcp_download(file_url, file_name, wcp_instance, use_original_event_id, false, "");
 }
 
 size_t DownloadManager::start_wcp_download(const std::string& file_url,
@@ -91,12 +101,18 @@ size_t DownloadManager::start_wcp_download(const std::string& file_url,
     size_t task_id = m_next_task_id++;
 
     auto downloadPath = wxGetApp().app_config->get("download_path");
+#ifdef _WIN32
+    boost::filesystem::path dest_folder(boost::nowide::widen(downloadPath));
+#else
     boost::filesystem::path dest_folder(downloadPath);
+#endif
     boost::filesystem::create_directories(dest_folder);
     boost::filesystem::path dest_file = dest_folder / file_name;
 
+    // Generate unique file path if file already exists
     std::string dest_path = get_unique_file_path(dest_file);
 
+    // Update file_name if it was changed due to duplicate
     std::string actual_file_name = boost::filesystem::path(dest_path).filename().string();
 
     auto task = std::make_shared<DownloadTask>(task_id,
@@ -111,12 +127,13 @@ size_t DownloadManager::start_wcp_download(const std::string& file_url,
     m_tasks[task_id] = task;
 
     task->state = DownloadTaskState::Downloading;
+
     start_download_impl(task);
     return task_id;
 }
 
 // ============================================================================
-// Internal Download Interface
+// Internal Download Interface (for PC internal use)
 // ============================================================================
 size_t DownloadManager::start_internal_download(const std::string& file_url,
                                                  const std::string& file_name,
@@ -130,8 +147,14 @@ size_t DownloadManager::start_internal_download(const std::string& file_url,
 
     boost::filesystem::path dest_file_path;
     if (boost::filesystem::is_directory(dest_path_obj) || dest_path_obj.filename().empty()) {
+        // dest_path is a directory, need to append file_name
+        BOOST_LOG_TRIVIAL(debug) << boost::format("DownloadManager::start_internal_download: dest_path '%1%' is a directory, appending file_name '%2%'")
+            % dest_path % file_name;
         dest_file_path = dest_path_obj / file_name;
     } else {
+        // dest_path is already a complete file path (directory + filename)
+        BOOST_LOG_TRIVIAL(debug) << boost::format("DownloadManager::start_internal_download: dest_path '%1%' is a complete file path")
+            % dest_path;
         dest_file_path = dest_path_obj;
     }
 
@@ -148,6 +171,7 @@ size_t DownloadManager::start_internal_download(const std::string& file_url,
     m_tasks[task_id] = task;
 
     task->state = DownloadTaskState::Downloading;
+
     start_download_impl(task);
 
     return task_id;
@@ -156,12 +180,18 @@ size_t DownloadManager::start_internal_download(const std::string& file_url,
 size_t DownloadManager::start_internal_download(const std::string& file_url,
                                                  const std::string& file_name,
                                                  DownloadCallbacks callbacks) {
+    // Get default download path
     auto downloadPath = wxGetApp().app_config->get("download_path");
+#ifdef _WIN32
+    boost::filesystem::path dest_folder(boost::nowide::widen(downloadPath));
+#else
     boost::filesystem::path dest_folder(downloadPath);
+#endif
     boost::filesystem::create_directories(dest_folder);
 
     boost::filesystem::path dest_file = dest_folder / file_name;
 
+    // Generate unique file path if file already exists
     std::string dest_path = get_unique_file_path(dest_file);
 
     return start_internal_download(file_url, file_name, dest_path, std::move(callbacks));
@@ -169,24 +199,33 @@ size_t DownloadManager::start_internal_download(const std::string& file_url,
 
 size_t DownloadManager::start_internal_download(const std::string& file_url,
                                                  const std::string& file_name,
-                                                 const std::string& dest_path,
                                                  DownloadCallbacks callbacks,
                                                  bool need_decrypt,
                                                  const std::string& sn) {
+    // Get default download path
+    auto downloadPath = wxGetApp().app_config->get("download_path");
+#ifdef _WIN32
+    boost::filesystem::path dest_folder(boost::nowide::widen(downloadPath));
+#else
+    boost::filesystem::path dest_folder(downloadPath);
+#endif
+    if (!sn.empty()) {
+        dest_folder /= sn;
+    }
+    boost::filesystem::create_directories(dest_folder);
+
+    boost::filesystem::path dest_file = dest_folder / file_name;
+
+    // Generate unique file path if file already exists
+    std::string dest_path = get_unique_file_path(dest_file);
 
     std::lock_guard<std::mutex> lock(m_tasks_mutex);
     size_t task_id = m_next_task_id++;
 
-    boost::filesystem::path dest_path_obj(dest_path);
-    boost::filesystem::create_directories(dest_path_obj);
-
-    boost::filesystem::path dest_file_path = dest_path_obj / file_name;
-    std::string unique_dest_path = get_unique_file_path(dest_file_path);
-
     auto task = std::make_shared<DownloadTask>(task_id,
                                                 file_url,
                                                 file_name,
-                                                unique_dest_path,
+                                                dest_path,
                                                 std::move(callbacks),
                                                 need_decrypt,
                                                 sn);
@@ -203,13 +242,18 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
 
     wxGetApp().CallAfter([this, task]() {
         try {
+            // Step 1: Create Http object
             Http http = Http::get(task->file_url);
-            http.timeout_max(0);
 
-            http.on_progress([this, task](Http::Progress progress, bool& cancel) {
+        http.timeout_max(0);
+
+        // Step 2: Set progress callback
+        http.on_progress([this, task](Http::Progress progress, bool& cancel) {
+                // Check if task is canceled or already cleaned up
                 {
                     std::lock_guard<std::mutex> lock(m_tasks_mutex);
                     if (m_tasks.find(task->task_id) == m_tasks.end()) {
+                        // Task has been cleaned up, cancel the download
                         cancel = true;
                         return;
                     }
@@ -227,6 +271,7 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
 
                 std::lock_guard<std::mutex> lock(m_tasks_mutex);
 
+                // Double-check task still exists after acquiring lock
                 if (m_tasks.find(task->task_id) == m_tasks.end()) {
                     cancel = true;
                     return;
@@ -242,6 +287,7 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
                 }
                 task->percent = percent;
 
+                // Throttle progress updates: update every 5% or every second
                 auto now = std::chrono::steady_clock::now();
                 bool should_update = false;
 
@@ -255,6 +301,7 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
                 if (should_update) {
                     last_upd = now;
                     wxGetApp().CallAfter([this, task, percent, progress]() {
+                        // Check if task still exists before sending update
                         std::lock_guard<std::mutex> lock(m_tasks_mutex);
                         if (m_tasks.find(task->task_id) != m_tasks.end() &&
                             task->state != DownloadTaskState::Canceled) {
@@ -264,9 +311,12 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
                 }
             });
 
+            // Step 3: Set complete callback
             http.on_complete([this, task](std::string body, unsigned status) {
                 wxGetApp().CallAfter([this, task, body]() {
+                    // Check if task still exists and is not canceled (without lock to avoid deadlock with cleanup_task)
                     if (task->state == DownloadTaskState::Canceled) {
+                        // Task has been canceled, ignore completion
                         BOOST_LOG_TRIVIAL(debug) << "DownloadManager: Ignoring complete callback for canceled task " << task->task_id;
                         return;
                     }
@@ -277,10 +327,12 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
                     }
 
                     try {
+                        // Save file
                         boost::nowide::ofstream file(task->dest_path, std::ios::binary);
                         if (!file.is_open()) {
                             std::string error_msg = "Failed to open file for writing: " + task->dest_path;
                             BOOST_LOG_TRIVIAL(error) << "DownloadManager: " << error_msg;
+                            // Flush logs immediately for critical errors
                             Slic3r::flush_logs();
                             send_error_update(task, error_msg);
                             cleanup_task(task->task_id);
@@ -291,6 +343,7 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
                         if (file.fail()) {
                             std::string error_msg = "Failed to write file: " + task->dest_path;
                             BOOST_LOG_TRIVIAL(error) << "DownloadManager: " << error_msg << ", body size: " << body.size();
+                            // Flush logs immediately for critical errors
                             Slic3r::flush_logs();
                             file.close();
                             send_error_update(task, error_msg);
@@ -311,8 +364,8 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
                                 return;
                             }
 
-                            try { boost::filesystem::remove(enc_path); } catch (...) {}
-                            try { boost::filesystem::rename(tmp_path, enc_path); } catch (...) {}
+                            boost::filesystem::remove(enc_path);
+                            boost::filesystem::rename(tmp_path, enc_path);
 
                             task->decrypt_path = enc_path;
                         }
@@ -323,7 +376,8 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
                         cleanup_task(task->task_id);
                     } catch (std::exception& e) {
                         std::string error_msg = std::string("File write exception: ") + e.what();
-                        BOOST_LOG_TRIVIAL(error) << "DownloadManager: " << error_msg;
+                        BOOST_LOG_TRIVIAL(error) << "DownloadManager: " << error_msg << ", file: " << task->dest_path;
+                        // Flush logs immediately for critical errors
                         Slic3r::flush_logs();
                         send_error_update(task, error_msg);
                         cleanup_task(task->task_id);
@@ -331,14 +385,22 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
                 });
             });
 
+            // Step 4: Set error callback
             http.on_error([this, task](std::string body, std::string error, unsigned status) {
                 wxGetApp().CallAfter([this, task, error, status]() {
+                    // Check if task was canceled (without lock to avoid deadlock with cleanup_task)
                     if (task->state == DownloadTaskState::Canceled) {
+                        // Task was canceled, ignore error callback (cancel already handled cleanup)
+                        BOOST_LOG_TRIVIAL(debug) << "DownloadManager: Ignoring error callback for canceled task " << task->task_id;
                         return;
                     }
 
                     std::string error_msg = boost::str(boost::format("HTTP error: %1% (status: %2%)") % error % status);
-                    BOOST_LOG_TRIVIAL(error) << "DownloadManager: " << error_msg;
+                    BOOST_LOG_TRIVIAL(error) << "DownloadManager: " << error_msg
+                        << ", URL: " << task->file_url
+                        << ", file: " << task->file_name
+                        << ", dest: " << task->dest_path;
+                    // Flush logs immediately for critical errors to ensure they are written
                     Slic3r::flush_logs();
                     task->state = DownloadTaskState::Error;
                     task->error_message = error;
@@ -347,11 +409,15 @@ void DownloadManager::start_download_impl(std::shared_ptr<DownloadTask> task) {
                 });
             });
 
+            // Step 5: Start download and save Http::Ptr for cancellation
             task->http_object = http.perform();
 
         } catch (std::exception& e) {
             std::string error_msg = std::string("Download exception: ") + e.what();
-            BOOST_LOG_TRIVIAL(error) << "DownloadManager: " << error_msg;
+            BOOST_LOG_TRIVIAL(error) << "DownloadManager: " << error_msg
+                << ", URL: " << task->file_url
+                << ", file: " << task->file_name
+                << ", dest: " << task->dest_path;
             task->state = DownloadTaskState::Error;
             task->error_message = e.what();
             send_error_update(task, e.what());
@@ -377,7 +443,18 @@ bool DownloadManager::cancel_download(size_t task_id) {
             if (task->http_object) {
                 task->http_object->cancel();
             }
+
+            // Only for WCP downloads
+            if (task->is_wcp_download()) {
+                wcp_to_destroy = task->wcp_instance.lock();
+            } else {
+                task->callbacks.on_error = nullptr;
+                task->callbacks.on_progress = nullptr;
+                task->callbacks.on_complete = nullptr;
+            }
+
             std::string partial_path = task->dest_path;
+            // Cleanup task directly (already holding the lock, don't call cleanup_task)
             m_tasks.erase(task_id);
             m_last_percent.erase(task_id);
             m_last_update.erase(task_id);
@@ -397,6 +474,7 @@ bool DownloadManager::cancel_download(size_t task_id) {
     return true;
 }
 
+// this function not currently in use
 bool DownloadManager::pause_download(size_t task_id) {
     std::lock_guard<std::mutex> lock(m_tasks_mutex);
     auto it = m_tasks.find(task_id);
@@ -407,6 +485,7 @@ bool DownloadManager::pause_download(size_t task_id) {
     return false;
 }
 
+// this function not currently in use
 bool DownloadManager::resume_download(size_t task_id) {
     std::lock_guard<std::mutex> lock(m_tasks_mutex);
     auto it = m_tasks.find(task_id);
@@ -416,6 +495,7 @@ bool DownloadManager::resume_download(size_t task_id) {
     return false;
 }
 
+// this function not currently in use
 DownloadTaskState DownloadManager::get_task_state(size_t task_id) {
     std::lock_guard<std::mutex> lock(m_tasks_mutex);
     auto it = m_tasks.find(task_id);
@@ -425,6 +505,7 @@ DownloadTaskState DownloadManager::get_task_state(size_t task_id) {
     return DownloadTaskState::Error;
 }
 
+// this function not currently in use
 std::shared_ptr<DownloadTask> DownloadManager::get_task(size_t task_id) {
     std::lock_guard<std::mutex> lock(m_tasks_mutex);
     auto it = m_tasks.find(task_id);
@@ -434,6 +515,7 @@ std::shared_ptr<DownloadTask> DownloadManager::get_task(size_t task_id) {
     return nullptr;
 }
 
+// this function not currently in use
 std::vector<std::shared_ptr<DownloadTask>> DownloadManager::get_all_tasks() {
     std::lock_guard<std::mutex> lock(m_tasks_mutex);
     std::vector<std::shared_ptr<DownloadTask>> result;
@@ -484,6 +566,7 @@ void DownloadManager::send_wcp_progress_update(std::shared_ptr<DownloadTask> tas
         } else {
             header["event_id"] = wcp->m_event_id + "_progress";
         }
+
         header["command"] = "download_progress";
         wcp->m_header = header;
 
@@ -495,6 +578,7 @@ void DownloadManager::call_internal_progress_callback(std::shared_ptr<DownloadTa
                                                       int percent,
                                                       size_t downloaded,
                                                       size_t total) {
+
     if (task->callbacks.on_progress && task->state != DownloadTaskState::Canceled) {
         task->callbacks.on_progress(task->task_id, percent, downloaded, total);
     }
@@ -511,6 +595,7 @@ void DownloadManager::send_complete_update(std::shared_ptr<DownloadTask> task,
 
 void DownloadManager::send_wcp_complete_update(std::shared_ptr<DownloadTask> task,
                                                  const std::string& file_path) {
+
     if (!task->use_original_event_id) {
         return;
     }
@@ -534,6 +619,7 @@ void DownloadManager::send_wcp_complete_update(std::shared_ptr<DownloadTask> tas
 
 void DownloadManager::call_internal_complete_callback(std::shared_ptr<DownloadTask> task,
                                                        const std::string& file_path) {
+
     if (task->callbacks.on_complete && task->state != DownloadTaskState::Canceled) {
         task->callbacks.on_complete(task->task_id, file_path);
     }
@@ -550,6 +636,7 @@ void DownloadManager::send_error_update(std::shared_ptr<DownloadTask> task,
 
 void DownloadManager::send_wcp_error_update(std::shared_ptr<DownloadTask> task,
                                               const std::string& error) {
+
     if (!task->use_original_event_id) {
         return;
     }
@@ -571,6 +658,7 @@ void DownloadManager::send_wcp_error_update(std::shared_ptr<DownloadTask> task,
 
 void DownloadManager::call_internal_error_callback(std::shared_ptr<DownloadTask> task,
                                                     const std::string& error) {
+
     if (task->callbacks.on_error && task->state != DownloadTaskState::Canceled) {
         task->callbacks.on_error(task->task_id, error);
     }

--- a/src/slic3r/GUI/DownloadManager.hpp
+++ b/src/slic3r/GUI/DownloadManager.hpp
@@ -139,7 +139,6 @@ public:
 
     size_t start_internal_download(const std::string& file_url,
                                     const std::string& file_name,
-                                    const std::string& dest_path,
                                     DownloadCallbacks callbacks,
                                     bool need_decrypt,
                                     const std::string& sn);

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -577,9 +577,7 @@ void desktop_open_any_folderEx(const std::string& path)
 void desktop_open_folder(const std::string& path)
 {
 #ifdef _WIN32
-    boost::filesystem::path dir_path(path);
-    dir_path.make_preferred();
-    wxString widepath = from_path(dir_path);
+    wxString widepath = wxString::FromUTF8(path);
     wxString cmd = L"explorer \"" + widepath + L"\"";
     ::wxExecute(cmd, wxEXEC_ASYNC, nullptr);
 #elif __APPLE__

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -5309,11 +5309,19 @@ void SSWCP_UserLogin_Instance::sw_DownLoadFile()
 
     // Compute save_path and check disk space BEFORE responding to flutter.
     const std::string& sn = files[0].sn;
-    boost::filesystem::path save_path_fs =
-        boost::filesystem::path(wxGetApp().app_config->get("download_path")) / sn;
+#ifdef _WIN32
+    boost::filesystem::path save_path_fs(boost::nowide::widen(wxGetApp().app_config->get("download_path")));
+#else
+    boost::filesystem::path save_path_fs(wxGetApp().app_config->get("download_path"));
+#endif
+    save_path_fs /= sn;
     boost::system::error_code mk_ec;
     boost::filesystem::create_directories(save_path_fs, mk_ec);
+#ifdef _WIN32
+    std::string save_path = boost::nowide::narrow(save_path_fs.wstring());
+#else
     std::string save_path = save_path_fs.string();
+#endif
 
     if (mk_ec) {
         // Download path invalid (e.g. configured USB drive was removed).
@@ -5660,7 +5668,7 @@ void SSWCP_UserLogin_Instance::sw_DownLoadFile()
             };
 
             ctx->current_task_id = DownloadManager::getInstance().start_internal_download(
-                url, info.file_name, ctx->save_path,
+                url, info.file_name,
                 std::move(callbacks), info.mode == "wan", info.sn);
         };
 

--- a/src/slic3r/Utils/FileDecrypt.cpp
+++ b/src/slic3r/Utils/FileDecrypt.cpp
@@ -11,6 +11,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/log/trivial.hpp>
+#include <boost/nowide/fstream.hpp>
 
 namespace Slic3r {
 
@@ -55,7 +56,7 @@ bool decrypt_file_aes_cbc(const std::string& input_path,
                           int iterations,
                           const std::string& output_path)
 {
-    std::ifstream ifs(input_path, std::ios::binary | std::ios::ate);
+    boost::nowide::ifstream ifs(input_path, std::ios::binary | std::ios::ate);
     if (!ifs.is_open()) {
         BOOST_LOG_TRIVIAL(error) << "FileDecrypt: cannot open input file: " << input_path;
         return false;
@@ -127,7 +128,7 @@ bool decrypt_file_aes_cbc(const std::string& input_path,
 
     const int total_len = out_len + final_len;
 
-    std::ofstream ofs(output_path, std::ios::binary);
+    boost::nowide::ofstream ofs(output_path, std::ios::binary);
     if (!ofs.is_open()) {
         BOOST_LOG_TRIVIAL(error) << "FileDecrypt: cannot open output file: " << output_path;
         return false;


### PR DESCRIPTION
# Description

- FileDecrypt: std::fstream → boost::nowide::fstream for non-ASCII paths
- DownloadManager: restore formatting, cancel_download WCP cleanup + callback nulling, need_decrypt default false, path encoding with nowide::widen
- SSWCP: save_path encoding with nowide::widen/narrow
- GUI: desktop_open_folder use wxString::FromUTF8 instead of ACP path
- remove silent catch (...) on remove/rename
- remove unnecessary dest_path param from start_internal_download encryption overload
- restore error log details (URL/file/dest)