### PR TITLE
Fix bed temperature to take the max over all used filaments in mixed …

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2301,7 +2301,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream& file, ThumbnailsGenerato
                 file.write(full_config);
 
             // SoftFever: write compatiple image
-            int first_layer_bed_temperature = get_bed_temperature(0, true, print.config().curr_bed_type);
+            int first_layer_bed_temperature = get_bed_temperature_max(print, true);
             file.write_format("; first_layer_bed_temperature = %d\n", first_layer_bed_temperature);
             file.write_format("; first_layer_temperature = %d\n", print.config().nozzle_temperature_initial_layer.get_at(0));
             file.write("; CONFIG_BLOCK_END\n\n");
@@ -2652,8 +2652,12 @@ void GCode::_do_export(Print& print, GCodeOutputStream& file, ThumbnailsGenerato
         this->placeholder_parser().set("bbl_bed_temperature_gcode", new ConfigOptionBool(false));
         this->placeholder_parser().set("bed_temperature_initial_layer", new ConfigOptionInts(*first_bed_temp_opt));
         this->placeholder_parser().set("bed_temperature", new ConfigOptionInts(*bed_temp_opt));
-        this->placeholder_parser().set("bed_temperature_initial_layer_single",
-                                       new ConfigOptionInt(first_bed_temp_opt->get_at(initial_extruder_id)));
+        // BBS: the single bed temperature value accommodates the highest-temperature filament of the print
+        // (max over all used extruders instead of the initial extruder only).
+        int bed_temp_single = 0;
+        for (const unsigned int extruder_id : print.extruders())
+            bed_temp_single = std::max(bed_temp_single, first_bed_temp_opt->get_at(extruder_id));
+        this->placeholder_parser().set("bed_temperature_initial_layer_single", new ConfigOptionInt(bed_temp_single));
         this->placeholder_parser().set("bed_temperature_initial_layer_vector", new ConfigOptionString());
         this->placeholder_parser().set("chamber_temperature", new ConfigOptionInts(m_config.chamber_temperature));
         this->placeholder_parser().set("overall_chamber_temperature", new ConfigOptionInt(max_chamber_temp));
@@ -2725,7 +2729,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream& file, ThumbnailsGenerato
                                                                        initial_extruder_id);
     if (print.config().gcode_flavor != gcfKlipper) {
         // Set bed temperature if the start G-code does not contain any bed temp control G-codes.
-        this->_print_first_layer_bed_temperature(file, print, machine_start_gcode, initial_extruder_id, true);
+        this->_print_first_layer_bed_temperature(file, print, machine_start_gcode, true);
         // Set extruder(s) temperature before and after start G-code.
         this->_print_first_layer_extruder_temperatures(file, print, machine_start_gcode, initial_extruder_id, false);
     }
@@ -2900,7 +2904,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream& file, ThumbnailsGenerato
                                                                                             print.config().printing_by_object_gcode.value,
                                                                                             initial_extruder_id);
                     // Set first layer bed and extruder temperatures, don't wait for it to reach the temperature.
-                    this->_print_first_layer_bed_temperature(file, print, printing_by_object_gcode, initial_extruder_id, false);
+                    this->_print_first_layer_bed_temperature(file, print, printing_by_object_gcode, false);
                     this->_print_first_layer_extruder_temperatures(file, print, printing_by_object_gcode, initial_extruder_id, false);
                     file.writeln(printing_by_object_gcode);
                 }
@@ -3083,7 +3087,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream& file, ThumbnailsGenerato
             file.write(full_config);
 
         // SoftFever: write compatiple info
-        int first_layer_bed_temperature = get_bed_temperature(0, true, print.config().curr_bed_type);
+        int first_layer_bed_temperature = get_bed_temperature_max(print, true);
         file.write_format("; first_layer_bed_temperature = %d\n", first_layer_bed_temperature);
         file.write_format("; bed_shape = %s\n", print.full_print_config().opt_serialize("printable_area").c_str());
         file.write_format("; first_layer_temperature = %d\n", print.config().nozzle_temperature_initial_layer.get_at(0));
@@ -3518,9 +3522,26 @@ void GCode::print_machine_envelope(GCodeOutputStream& file, Print& print)
 // BBS
 int GCode::get_bed_temperature(const int extruder_id, const bool is_first_layer, const BedType bed_type) const
 {
-    std::string             bed_temp_key = is_first_layer ? get_bed_temp_1st_layer_key(bed_type) : get_bed_temp_key(bed_type);
+    // Fall back to PEI temps for bed types without dedicated temp options (e.g. btDefault),
+    // mirroring the placeholder setup in _do_export.
+    std::string bed_temp_key = is_first_layer ? get_bed_temp_1st_layer_key(bed_type) : get_bed_temp_key(bed_type);
+    if (bed_temp_key.empty())
+        bed_temp_key = is_first_layer ? get_bed_temp_1st_layer_key(btPEI) : get_bed_temp_key(btPEI);
     const ConfigOptionInts* bed_temp_opt = m_config.option<ConfigOptionInts>(bed_temp_key);
     return bed_temp_opt->get_at(extruder_id);
+}
+
+// BBS
+// Max bed temperature over all used extruders (object/support/wipe tower/brim-introduced extruders),
+// so a compatible mixed print (e.g. PLA 65C + TPU 35C) always runs the highest bed temperature.
+// A value of 0 means the filament does not support the current bed type, and is naturally skipped by max().
+int GCode::get_bed_temperature_max(const Print& print, const bool is_first_layer) const
+{
+    int max_bed_temp = 0;
+    for (const unsigned int extruder_id : print.extruders())
+        max_bed_temp = std::max(
+            max_bed_temp, get_bed_temperature(extruder_id, is_first_layer, print.config().curr_bed_type));
+    return max_bed_temp;
 }
 
 // Write 1st layer bed temperatures into the G-code.
@@ -3528,21 +3549,15 @@ int GCode::get_bed_temperature(const int extruder_id, const bool is_first_layer,
 // M140 - Set Extruder Temperature
 // M190 - Set Extruder Temperature and Wait
 void GCode::_print_first_layer_bed_temperature(
-    GCodeOutputStream& file, Print& print, const std::string& gcode, unsigned int first_printing_extruder_id, bool wait)
+    GCodeOutputStream& file, Print& print, const std::string& gcode, bool wait)
 {
-    // Initial bed temperature based on the first extruder.
-    // BBS
-    std::vector<int> temps_per_bed;
-    int              bed_temp = get_bed_temperature(first_printing_extruder_id, true, print.config().curr_bed_type);
+    // BBS: bed temperature accommodates the highest-temperature filament of the print
+    // (max over all used extruders instead of the first printing extruder only).
+    int bed_temp = get_bed_temperature_max(print, true);
 
     // Is the bed temperature set by the provided custom G-code?
     int  temp_by_gcode     = -1;
     bool temp_set_by_gcode = custom_gcode_sets_temperature(gcode, 140, 190, false, temp_by_gcode);
-    // BBS
-#if 0
-    if (temp_set_by_gcode && temp_by_gcode >= 0 && temp_by_gcode < 1000)
-        temp = temp_by_gcode;
-#endif
 
     // Always call m_writer.set_bed_temperature() so it will set the internal "current" state of the bed temp as if
     // the custom start G-code emited these.
@@ -4954,8 +4969,9 @@ LayerResult GCode::process_layer(const Print& print,
                 gcode += m_writer.set_temperature(temperature, false, extruder.id());
         }
 
-        // BBS
-        int bed_temp = get_bed_temperature(first_extruder_id, false, print.config().curr_bed_type);
+        // BBS: bed temperature accommodates the highest-temperature filament of the print
+        // (max over all used extruders instead of the first extruder of this layer only).
+        int bed_temp = get_bed_temperature_max(print, false);
         gcode += m_writer.set_bed_temperature(bed_temp);
         // Mark the temperature transition from 1st to 2nd layer to be finished.
         m_second_layer_things_done = true;

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -628,11 +628,14 @@ private:
     std::set<unsigned int>                  m_initial_layer_extruders;
     // BBS
     int get_bed_temperature(const int extruder_id, const bool is_first_layer, const BedType bed_type) const;
+    // BBS: max bed temperature over all used extruders, so that the bed temperature always
+    // accommodates the highest-temperature filament of a compatible mixed print (e.g. PLA + TPU).
+    int get_bed_temperature_max(const Print& print, const bool is_first_layer) const;
 
     std::string _extrude(const ExtrusionPath &path, std::string description = "", double speed = -1);
     bool _needSAFC(const ExtrusionPath &path);
     void print_machine_envelope(GCodeOutputStream &file, Print &print);
-    void _print_first_layer_bed_temperature(GCodeOutputStream &file, Print &print, const std::string &gcode, unsigned int first_printing_extruder_id, bool wait);
+    void _print_first_layer_bed_temperature(GCodeOutputStream &file, Print &print, const std::string &gcode, bool wait);
     void _print_first_layer_extruder_temperatures(GCodeOutputStream &file, Print &print, const std::string &gcode, unsigned int first_printing_extruder_id, bool wait);
     // On the first printing layer. This flag triggers first layer speeds.
     //BBS

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -8677,7 +8677,7 @@ TemperaturesConfigDef::TemperaturesConfigDef()
 
     new_def("bed_temperature", coInts, "Bed temperature", "Vector of bed temperatures for each extruder/filament.")
     new_def("bed_temperature_initial_layer", coInts, "Initial layer bed temperature", "Vector of initial layer bed temperatures for each extruder/filament. Provides the same value as first_layer_bed_temperature.")
-    new_def("bed_temperature_initial_layer_single", coInt, "Initial layer bed temperature (initial extruder)", "Initial layer bed temperature for the initial extruder. Same as bed_temperature_initial_layer[initial_extruder]")
+    new_def("bed_temperature_initial_layer_single", coInt, "Initial layer bed temperature (max of used filaments)", "Initial layer bed temperature for a mixed print. This value is the maximum initial layer bed temperature over all used extruders/filaments.")
     new_def("chamber_temperature", coInts, "Chamber temperature", "Vector of chamber temperatures for each extruder/filament.")
     new_def("overall_chamber_temperature", coInt, "Overall chamber temperature", "Overall chamber temperature. This value is the maximum chamber temperature of any extruder/filament used.")
     new_def("first_layer_bed_temperature", coInts, "First layer bed temperature", "Vector of first layer bed temperatures for each extruder/filament. Provides the same value as bed_temperature_initial_layer.")

--- a/tests/fff_print/CMakeLists.txt
+++ b/tests/fff_print/CMakeLists.txt
@@ -14,9 +14,19 @@ add_executable(${_TEST_NAME}_tests
 	test_printobject.cpp
 	test_skirt_brim.cpp
 	test_support_material.cpp
+	test_bed_temperature.cpp
 	test_trianglemesh.cpp
 	)
-target_link_libraries(${_TEST_NAME}_tests test_common libslic3r OpenSSL::Crypto)
+# libslic3r_cgal links CGAL privately, so the GMP/MPFR libraries are needed at link time.
+# They are not propagated to this test target; find them under the deps prefix or the
+# system paths, and only add them when found to avoid linking a NOTFOUND placeholder.
+find_library(GMP_LIB  NAMES libgmp-10  gmp  PATHS "${CMAKE_PREFIX_PATH}/lib")
+find_library(MPFR_LIB NAMES libmpfr-4 mpfr PATHS "${CMAKE_PREFIX_PATH}/lib")
+if (GMP_LIB AND MPFR_LIB)
+    target_link_libraries(${_TEST_NAME}_tests test_common libslic3r OpenSSL::Crypto ${GMP_LIB} ${MPFR_LIB})
+else()
+    target_link_libraries(${_TEST_NAME}_tests test_common libslic3r OpenSSL::Crypto)
+endif()
 if (WIN32)
     target_link_libraries(${_TEST_NAME}_tests bcrypt.lib)
 endif()

--- a/tests/fff_print/test_bed_temperature.cpp
+++ b/tests/fff_print/test_bed_temperature.cpp
@@ -1,0 +1,114 @@
+#include <catch2/catch.hpp>
+
+#include "libslic3r/Config.hpp"
+#include "libslic3r/Print.hpp"
+
+#include <regex>
+#include <string>
+
+#include "test_data.hpp"
+
+using namespace Slic3r;
+using namespace Slic3r::Test;
+
+namespace {
+// Extract the S value of the first M190 (first-layer bed temperature, emitted after machine_start_gcode).
+int first_layer_bed_temp(const std::string& gcode)
+{
+    std::smatch m;
+    if (std::regex_search(gcode, m, std::regex(R"(M190 S(\d+))")))
+        return std::stoi(m[1]);
+    return -1;
+}
+
+// Extract the S value of the M140 emitted at the first-to-second layer transition.
+int later_layer_bed_temp(const std::string& gcode)
+{
+    std::smatch m;
+    if (std::regex_search(gcode, m, std::regex(R"(M140 S(\d+))")))
+        return std::stoi(m[1]);
+    return -1;
+}
+} // namespace
+
+// Regression: with a single filament the emitted bed temperature is the value of that filament
+// (identical to the pre-change behavior, which always used the first printing extruder).
+TEST_CASE("Single filament bed temperature is unchanged", "[BedTemperature]")
+{
+    DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
+    config.set_deserialize_strict({
+        { "curr_bed_type", "High Temp Plate" }, // btPEI -> hot_plate_temp
+        { "hot_plate_temp", "45" },
+        { "hot_plate_temp_initial_layer", "55" }
+    });
+    std::string gcode = Slic3r::Test::slice({TestMesh::cube_20x20x20}, config);
+    REQUIRE(first_layer_bed_temp(gcode) == 55);
+    REQUIRE(later_layer_bed_temp(gcode) == 45);
+}
+
+// Two compatible filaments (PLA-like 65C + TPU-like 35C). The bed temperature shall always take the
+// higher value, even if the first printing extruder (wall) is the low-temperature one.
+TEST_CASE("Mixed print uses the highest bed temperature", "[BedTemperature]")
+{
+    DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
+    config.set_num_extruders(2);
+    config.set_num_filaments(2);
+    config.set_deserialize_strict({
+        { "curr_bed_type", "High Temp Plate" },
+        { "hot_plate_temp", "30,60" },
+        { "hot_plate_temp_initial_layer", "35,65" },
+        // Wall printed by extruder 1 (0-based 0, low bed temp 35C), infill by extruder 2 (0-based 1, 65C).
+        { "wall_filament", 1 },
+        { "sparse_infill_filament", 2 },
+        { "solid_infill_filament", 2 }
+    });
+    std::string gcode = Slic3r::Test::slice({TestMesh::cube_20x20x20}, config);
+    REQUIRE(first_layer_bed_temp(gcode) == 65);
+    REQUIRE(later_layer_bed_temp(gcode) == 60);
+}
+
+// All paths: with wall_loops = 0 the brim-introduced wall_filament extruder must be included in the
+// max, even though it is not the first printing extruder of the object.
+TEST_CASE("Brim-introduced extruder is covered when wall_loops is zero", "[BedTemperature]")
+{
+    DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
+    config.set_num_extruders(2);
+    config.set_num_filaments(2);
+    config.set_deserialize_strict({
+        { "curr_bed_type", "High Temp Plate" },
+        { "hot_plate_temp", "30,60" },
+        { "hot_plate_temp_initial_layer", "35,65" },
+        // No walls. Infill uses extruder 1 (0-based 0, 35C); the brim follows wall_filament
+        // (extruder 2, 0-based 1, 65C) and must raise the bed temperature.
+        { "wall_loops", 0 },
+        { "brim_width", 5 },
+        { "brim_type", "auto_brim" },
+        { "wall_filament", 2 },
+        { "sparse_infill_filament", 1 },
+        { "solid_infill_filament", 1 }
+    });
+    std::string gcode = Slic3r::Test::slice({TestMesh::cube_20x20x20}, config);
+    REQUIRE(first_layer_bed_temp(gcode) == 65);
+    REQUIRE(later_layer_bed_temp(gcode) == 60);
+}
+
+// Placeholder: the machine_start_gcode single-value placeholder expands to the max bed temperature
+// (this is the path used by the Snapmaker U1 start gcode).
+TEST_CASE("bed_temperature_initial_layer_single expands to the max", "[BedTemperature]")
+{
+    DynamicPrintConfig config = Slic3r::DynamicPrintConfig::full_print_config();
+    config.set_num_extruders(2);
+    config.set_num_filaments(2);
+    config.set_deserialize_strict({
+        { "curr_bed_type", "High Temp Plate" },
+        { "hot_plate_temp", "30,60" },
+        { "hot_plate_temp_initial_layer", "35,65" },
+        { "wall_filament", 1 },
+        { "sparse_infill_filament", 2 },
+        { "solid_infill_filament", 2 },
+        { "machine_start_gcode", "M190 S{bed_temperature_initial_layer_single}" }
+    });
+    std::string gcode = Slic3r::Test::slice({TestMesh::cube_20x20x20}, config);
+    // start gcode already sets the temperature, so no additional M190 is emitted by the slicer.
+    REQUIRE(gcode.find("M190 S65") != std::string::npos);
+}


### PR DESCRIPTION
# Description
For compatible multi-material prints (e.g. PLA 65C + TPU 35C), the bed temperature was taken from the first printing extruder only, ignoring the bed temperature of the other filaments. Now the initial layer and following layers bed temperature is the maximum over all used extruders (object/support/wipe tower, including brim-introduced extruders when wall_loops is 0).

- Add GCode::get_bed_temperature_max() over print.extruders()
- Use the max for the first layer write, the first->second layer transition and the CONFIG_BLOCK header comment
- Inject the bed_temperature_initial_layer_single placeholder as the max over used extruders (affects all profiles referencing it)
- Fall back to PEI bed temps for bed types without dedicated options
- Snapmaker J1/A250/A350/A400 start gcode now reference the max single placeholder; change_filament_gcode keeps the higher temperature (min -> max) instead of cooling the bed on tool change
- Add unit tests for single/mixed/brim/placeholder cases

