### PR TITLE
fix(mixed-filament): keep slot-overflow banner over ratio advisory on manual edit

### DIFF
--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -2077,6 +2077,14 @@ void MixedFilamentBatchDialog::check_manual_recipe_ratio()
     if (m_matching_method != MANUAL) return;
     if (!m_match_completed || m_result.mappings.empty()) return;
 
+    // Overflow outranks the ratio hint (the two banners are mutually exclusive — see
+    // handle_batch_match_result). This path is also reached from on_manual_selection_changed
+    // after a match that already surfaced the overflow error: without this guard the
+    // display_warning call below would hide that error and replace it with the ratio hint.
+    // m_result is unchanged by a combo edit (no re-match), so an overflow predicted at match
+    // time still holds here — re-show the advisory and skip the ratio evaluation entirely.
+    if (try_show_slot_overflow_advisory()) return;
+
     // NOTE: size by m_physical_colors.size(). In manual mode, launch_background_match's
     // manual-remap branch rewrites recipe component ids to project-wide 1-based indices, so
     // expand_color_match_recipe_weights must be sized against the FULL physical palette.
@@ -2236,6 +2244,18 @@ bool MixedFilamentBatchDialog::predict_slot_overflow() const
     const size_t enabled_mixed = pb->mixed_filaments.enabled_count();
     const size_t post_apply_total = n + enabled_mixed + new_mixed_rows;
     return post_apply_total > MAXIMUM_FILAMENT_NUMBER;
+}
+
+bool MixedFilamentBatchDialog::try_show_slot_overflow_advisory()
+{
+    // Single source of truth for the overflow banner + the "overflow wins over ratio"
+    // priority. Returns true (and shows the red advisory) when applying m_result would
+    // exceed the 64-slot cap; otherwise returns false and leaves the banners as they are
+    // so the caller is free to surface the lower-priority ratio hint.
+    if (!predict_slot_overflow()) return false;
+    display_error_advisory(
+        _L("Color mapping list limit reached (max 64 colors). Excess colors will be removed."));
+    return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -2655,14 +2675,11 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
     //     match completion (not at confirm time) so the user sees the risk before deciding
     //     to Confirm. Confirm stays enabled; overflow is dropped silently at apply time.
     //   • Ratio hint ("single component > 70%", gap doc case 13): warning banner.
-    // The two banners are mutually exclusive (display_error_advisory / display_warning hide
-    // each other); overflow is the more serious condition, so check it first.
-    if (predict_slot_overflow()) {
-        display_error_advisory(
-            _L("Color mapping list limit reached (max 64 colors). Excess colors will be removed."));
-    } else {
+    // The two banners are mutually exclusive and overflow is the more serious condition, so
+    // it wins — try_show_slot_overflow_advisory centralizes that priority (also honoured by
+    // check_manual_recipe_ratio on the re-evaluation paths).
+    if (!try_show_slot_overflow_advisory())
         check_manual_recipe_ratio();
-    }
     // Defer the button-state flip until AFTER refresh_previews() has rendered and
     // pushed the After-Match bitmap, so Confirm/Re-match light up in lockstep with
     // the preview — not a frame earlier. m_match_completed stays true throughout so

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
@@ -101,6 +101,16 @@ private:
     // commitment, not as a banner at match-completion time. See the .cpp impl for
     // the precise n / enabled_mixed / new_mixed_rows derivations.
     bool predict_slot_overflow() const;
+    // Post-match advisory priority: slot overflow (data-loss) outranks the ratio hint —
+    // the red error banner and the orange ratio banner are mutually exclusive. Shows the
+    // overflow advisory via display_error_advisory and returns true when predict_slot_overflow
+    // holds; otherwise leaves banners untouched and returns false. Centralizes both the
+    // overflow message and the "overflow wins over ratio" invariant so every caller of
+    // check_manual_recipe_ratio (on_manual_selection_changed, on_method_changed,
+    // handle_batch_match_result) honours the same priority — without it, a post-match combo
+    // edit re-enters check_manual_recipe_ratio and its display_warning call hides the
+    // already-shown overflow error, replacing a serious data-loss warning with the ratio hint.
+    bool try_show_slot_overflow_advisory();
     // Re-layout the scrolled region after its content height changes (add/remove filament row,
     // mode switch, legend rebuild). Layout() alone re-arranges within the existing virtual size;
     // FitInside() also re-computes the virtual (scrollable) extent from the children's best size,


### PR DESCRIPTION
## Problem
In manual mode, after a match predicted a 64-slot overflow (red banner), editing a filament combo turned the red overflow error into the orange ratio warning.

## Root cause
The "slot-overflow outranks ratio-hint" invariant (the two banners are mutually exclusive) was only enforced in `handle_batch_match_result` via an `if/else`. The re-evaluation path `on_manual_selection_changed -> check_manual_recipe_ratio` did **not** re-check `predict_slot_overflow()`, so its `display_warning()` call (which does `m_error_panel->Hide()`) clobbered the more serious overflow error with the ratio hint.

`m_result` is unchanged by a combo edit (no re-match happens), so an overflow predicted at match time still holds at edit time — the red banner should have persisted.

## Fix
- New `try_show_slot_overflow_advisory()` helper centralizes the overflow check + red banner text + the "overflow wins" priority (single source of truth, removes a duplicated translatable string).
- `check_manual_recipe_ratio()` calls it at the top, so all three entry points (`on_manual_selection_changed`, `on_method_changed`, `handle_batch_match_result`) honour the same priority.
- `handle_batch_match_result` simplified to `if (!try_show_slot_overflow_advisory()) check_manual_recipe_ratio();` (logically equivalent, less duplication).

## Behavior change
Toggling Manual -> Recommended -> Manual with an overflow result on screen now **re-shows** the red overflow advisory when returning to manual (previously the banner was lost on the round-trip). This is more consistent; flagged for product/QA in case the old "clear on toggle away" behavior was intentional.

## Verification
- Builds clean (macOS arm64 Release).
- Banner mutual-exclusion logic has no unit test coverage (GUI path); smoke-tested manually:
  - Manual match with overflow -> edit combo -> red overflow banner stays (no longer replaced by ratio warning).
  - Manual match without overflow + a >70% component -> orange ratio warning still shows.

## Risk
Low. `predict_slot_overflow()` is a cheap `const` read with no side effects, now called once more per post-match combo edit. No new translation strings; no thread-safety changes.