### PR TITLE
Fix Flatpak build with SLIC3R_PCH=OFF (mixed-filament missing includes)

### DIFF
--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -28,6 +28,7 @@
 
 #include <wx/scrolwin.h>
 #include <wx/dcbuffer.h>
+#include <wx/wupdlock.h>
 #include <boost/log/trivial.hpp>
 
 namespace Slic3r { namespace GUI {

--- a/src/slic3r/GUI/MixedFilamentColorMapPanel.hpp
+++ b/src/slic3r/GUI/MixedFilamentColorMapPanel.hpp
@@ -7,6 +7,7 @@
 #include <wx/timer.h>
 
 #include <algorithm>
+#include <array>
 #include <vector>
 
 namespace Slic3r { namespace GUI {


### PR DESCRIPTION
## Description

The Flatpak CI build fails because the mixed-filament code relies on the precompiled header to pull in two headers:

- `src/slic3r/GUI/MixedFilamentBatchDialog.cpp` uses `wxWindowUpdateLocker` but never includes `<wx/wupdlock.h>`. The Flatpak build sets `-DSLIC3R_PCH=OFF`, so the TU fails with `'wxWindowUpdateLocker' was not declared in this scope` (run 31679936598, aarch64 Flatpak job).
- `src/slic3r/GUI/MixedFilamentColorMapPanel.hpp` uses `std::array` without including `<array>` — the same latent PCH dependency. The failed CI run aborted at 74% before compiling this TU, so it would have failed on the next run.

Both are one-line include additions, matching sibling files (e.g. `BitmapComboBox.cpp`, `EditGCodeDialog.cpp`) that already include these headers directly.

## Screenshots/Recordings/Graphs

N/A — build-only fix.

## Tests

- Reproduced the failure locally with `-DSLIC3R_PCH=OFF` (MSVC, fresh Ninja build reusing the prebuilt deps): `MixedFilamentBatchDialog.cpp` failed with C2065 `'wxWindowUpdateLocker': undeclared identifier`; after the fix, all 14 TUs touched by the mixed-filament commit (9e42e789b3) compile cleanly.
- A/B CI comparison: the previous scheduled "Build all" run (31626722495, commit `b63ab9afb9`) had both Flatpak jobs green; the failing dispatch run (31679936598, commit `df205a640d`) differs by 6 commits, of which only the mixed-filament commit (#702) touches C++ that reaches the Flatpak build.
- A fresh Flatpak CI run on this branch is the final confirmation.