### PR TITLE
Fix blank Flatpak canvas on NVIDIA Wayland

### DIFF
--- a/scripts/flatpak/entrypoint
+++ b/scripts/flatpak/entrypoint
@@ -1,7 +1,28 @@
 #!/usr/bin/env sh
 
-# Work-around https://gitlab.gnome.org/GNOME/gnome-build-meta/-/issues/754
-grep -q org.freedesktop.Platform.GL.nvidia /.flatpak-info && export WEBKIT_DISABLE_DMABUF_RENDERER=1
+# Work around NVIDIA rendering issues under Wayland. The AppImage launcher uses
+# Zink for NVIDIA drivers newer than 555, but glxinfo and nvidia-smi are not
+# available in the Flatpak runtime. Derive the driver version from the mounted
+# org.freedesktop.Platform.GL.nvidia-* extension instead.
+if grep -q 'org.freedesktop.Platform.GL.nvidia-' /.flatpak-info; then
+    export WEBKIT_DISABLE_DMABUF_RENDERER=1
+
+    nvidia_driver_major=$(sed -n 's/.*org\.freedesktop\.Platform\.GL\.nvidia-\([0-9][0-9]*\)-.*/\1/p' /.flatpak-info | head -n 1)
+    if [ "$XDG_SESSION_TYPE" = "wayland" ] && [ "${ZINK_DISABLE_OVERRIDE:-0}" != "1" ] && \
+       { [ "${ZINK_FORCE_OVERRIDE:-0}" = "1" ] || { [ -n "$nvidia_driver_major" ] && [ "$nvidia_driver_major" -gt 555 ]; }; }; then
+        for mesa_egl_vendor in \
+            /usr/lib/*-linux-gnu/GL/default/share/glvnd/egl_vendor.d/50_mesa.json \
+            /usr/share/glvnd/egl_vendor.d/50_mesa.json; do
+            if [ -f "$mesa_egl_vendor" ]; then
+                export __GLX_VENDOR_LIBRARY_NAME=mesa
+                export __EGL_VENDOR_LIBRARY_FILENAMES="$mesa_egl_vendor"
+                export MESA_LOADER_DRIVER_OVERRIDE=zink
+                export GALLIUM_DRIVER=zink
+                break
+            fi
+        done
+    fi
+fi
 
 # Work-around https://github.com/bambulab/BambuStudio/issues/3440
 export LC_ALL=C.UTF-8


### PR DESCRIPTION
## Summary

Fix the blank Prepare and Preview 3D canvases in the Flatpak build on recent NVIDIA drivers under Wayland.

This is a counterpart to what was fixed in OrcaSlicer PR https://github.com/OrcaSlicer/OrcaSlicer/pull/8373. That PR was [successfully pulled](https://github.com/Snapmaker/OrcaSlicer/blob/main/src/dev-utils/platform/unix/build_linux_image.sh.in#L356-L385) into Snapmaker Orca [Feb 2025](https://github.com/Snapmaker/OrcaSlicer/commit/fd8792f3428bbcd93634b897c2a04c75d8470ebf) but only into the AppImage build. 

With Snapmaker Orca moving to Flatpak distribution, this was missing. This is why I was able to use the application [when I built it myself as an AppImage](https://github.com/Snapmaker/OrcaSlicer/issues/404#issuecomment-4804298147), but why myself and others [were only seeing a blank](https://github.com/Snapmaker/OrcaSlicer/issues/404) Prepare and Preview window when using the official Flatpak.

## Root cause

The AppImage launcher already routes OpenGL through Mesa Zink for affected NVIDIA drivers, but this workaround was missing from the Flatpak entrypoint.

The native NVIDIA GLX path with drivers newer than 555 through XWayland can leave the wxGTK OpenGL canvases blank.

## Fix

- Detect the mounted NVIDIA Flatpak driver and its version.
- Use Mesa GLX/EGL with Zink on Wayland for NVIDIA drivers newer than 555.
- Preserve `ZINK_FORCE_OVERRIDE` and `ZINK_DISABLE_OVERRIDE` controls.
- Retain the existing WebKit DMA-BUF workaround.

## Verification

Tested on CachyOS with KDE Wayland, an NVIDIA RTX 3090, and driver 610.57.04. Prepare and Preview now render correctly.

POSIX shell syntax, ShellCheck, whitespace, and activation-condition tests pass.

## Impact

The change is limited to affected NVIDIA Wayland Flatpak sessions. Non-NVIDIA and X11 sessions remain unchanged. Rendering remains hardware accelerated through the NVIDIA Vulkan driver.