### PR TITLE
Fix Snapmaker account login not persisting across restarts

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2234,6 +2234,18 @@ void GUI_App::init_app_config()
         }
         // Save orig_version here, so its empty if no app_config existed before this run.
         m_last_config_version = app_config->orig_version();//parse_semver_from_ini(app_config->config_path());
+
+        // SM: restore persisted Snapmaker account login (if any) before the webview's
+        // first sw_GetUserLoginState call, so the session survives app restarts.
+        std::string sm_saved_token = app_config->get("sm_user", "token");
+        if (!sm_saved_token.empty()) {
+            m_login_userinfo.set_user_id(app_config->get("sm_user", "id"));
+            m_login_userinfo.set_user_name(app_config->get("sm_user", "nickname"));
+            m_login_userinfo.set_user_icon_url(app_config->get("sm_user", "icon"));
+            m_login_userinfo.set_user_account(app_config->get("sm_user", "account"));
+            m_login_userinfo.set_user_token(sm_saved_token);
+            m_login_userinfo.set_user_login(true);
+        }
     }
     else {
 #ifdef _WIN32
@@ -4285,6 +4297,9 @@ void GUI_App::sm_request_user_logout()
     if (m_login_userinfo.is_user_login()) {
         m_login_userinfo.set_user_login(false);
     }
+    // SM: drop the persisted session so a stale token isn't restored on next launch.
+    app_config->set("sm_user", "token", "");
+    app_config->save();
     try {
         wxString region = wxString::FromUTF8(app_config->get_country_code());
         std::string url    = "";

--- a/src/slic3r/GUI/WebSMUserLoginDialog.cpp
+++ b/src/slic3r/GUI/WebSMUserLoginDialog.cpp
@@ -221,6 +221,14 @@ void SMUserLogin::OnNavigationRequest(wxWebViewEvent &evt)
                         sentryReportLog(SENTRY_LOG_TRACE, userInfo, BP_LOGIN);
                         wxGetApp().sm_get_userinfo()->set_user_token(token);
                         wxGetApp().sm_get_userinfo()->set_user_login(true);
+
+                        // SM: persist the session so it survives app restarts.
+                        wxGetApp().app_config->set("sm_user", "token", token);
+                        wxGetApp().app_config->set("sm_user", "id", wxGetApp().sm_get_userinfo()->get_user_id());
+                        wxGetApp().app_config->set("sm_user", "nickname", wxGetApp().sm_get_userinfo()->get_user_name());
+                        wxGetApp().app_config->set("sm_user", "icon", wxGetApp().sm_get_userinfo()->get_user_icon_url());
+                        wxGetApp().app_config->set("sm_user", "account", wxGetApp().sm_get_userinfo()->get_user_account());
+                        wxGetApp().app_config->save();
                     }
                 })
                 .on_error([&](std::string body, std::string error, unsigned status) {


### PR DESCRIPTION
## Summary

Fixes #669 (and the same underlying cause behind the related reports in #226, #116, and #716).

The native `SMUserInfo` struct (`m_login_userinfo`), which backs `sw_GetUserLoginState` for the embedded Flutter login webview, was only ever populated in-memory during an active login flow (`WebSMUserLoginDialog::OnNavigationRequest`) and was never written to or restored from `AppConfig`. Every app restart therefore started with an empty, logged-out struct — regardless of whether the embedded webview's own `localStorage` still had a cached token — so the login screen reappeared on every launch even though the account token itself was still valid.

This was reproducible outside the Flatpak sandbox too (confirmed on a from-source Linux build), which rules out sandbox/permission causes such as keyring access or the webview's local-server port.

## Platform scope

All existing reports of this symptom are Linux-only, but the affected code (`WebSMUserLoginDialog::OnNavigationRequest`, `GUI_App::sm_get_login_info`, the `SMUserInfo` struct) has no `#ifdef _WIN32` / `__APPLE__` guards anywhere — it's plain cross-platform C++ shared by every build. The native "am I logged in" check always reads from `m_login_userinfo`, which resets to its default (logged-out) state on every process launch regardless of OS or webview backend (WebKitGTK/WebView2/WKWebView). I don't have a Windows or macOS machine to confirm directly, but nothing in the code path is platform-specific, so this likely affects those builds too, just underreported so far.

## Fix

- On successful login (`WebSMUserLoginDialog.cpp`), persist token/account/nickname/icon/id to a new `sm_user` `AppConfig` section and save immediately.
- On startup (`GUI_App.cpp`), right after `AppConfig::load()` and before the webview's first `sw_GetUserLoginState` call, restore the saved session into `m_login_userinfo` if a token is present.
- On logout (`sm_request_user_logout`), clear the persisted `sm_user.token` so a revoked session isn't restored on next launch.

## Test plan

- [x] Built from source on Linux (Ubuntu 24.04), logged in via Login/Register
- [x] Confirmed `sm_user` section written to `AppConfig` (`~/.config/Snapmaker_Orca/Snapmaker_Orca.conf`) with token/account/nickname/icon/id
- [x] Fully quit the app, relaunched — session restored, sidebar shows the logged-in account instead of Login/Register
- [x] Repeated across multiple restarts, consistent
- [ ] Not yet verified on Windows/macOS — the fix touches shared, platform-agnostic code, so it should apply, but a maintainer/tester with those platforms should confirm