### PR TITLE
fix: set Supertack plate temperature to 0 for Snapmaker PETG-CF @ U1 0.4 nozzle

### DIFF
--- a/resources/profiles/Snapmaker/filament/Snapmaker PETG-CF @U1 0.4 nozzle.json
+++ b/resources/profiles/Snapmaker/filament/Snapmaker PETG-CF @U1 0.4 nozzle.json
@@ -40,7 +40,7 @@
   "temperature_vitrification": ["70"],
   "textured_plate_temp": ["80"],
   "textured_plate_temp_initial_layer": ["80"],
-  "supertack_plate_temp": ["60"],
-  "supertack_plate_temp_initial_layer": ["60"],
+  "supertack_plate_temp": ["0"],
+  "supertack_plate_temp_initial_layer": ["0"],
   "filament_type": ["PETG-CF"]
 }


### PR DESCRIPTION
# Description

Update the default bed temperature preset for the **Snapmaker PETG-CF @ U1 (0.4 nozzle)** filament profile when printing on the **Supertack (cold) plate**:

- `supertack_plate_temp`: 60 → 0
- `supertack_plate_temp_initial_layer`: 60 → 0

The Supertack plate is designed to be used without heating. Setting the preset temperature to `0` disables bed heating for PETG-CF on this plate type, which improves first-layer adhesion behavior and avoids unnecessary heating that could cause the part to stick too aggressively or warp on release.

## Tests

- [x] Verified the profile JSON loads correctly in the slicer.
- [x] Confirmed the Supertack plate temperature fields show `0` for PETG-CF @ U1 0.4 nozzle after the change.
