### PR TITLE
fix: disable macOS memory guard detection

### DIFF
--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -1531,15 +1531,13 @@ size_t get_available_physical_memory()
 	long page_size   = sysconf(_SC_PAGE_SIZE);
 	return (avail_pages > 0 && page_size > 0) ? static_cast<size_t>(avail_pages) * static_cast<size_t>(page_size) : 0;
 #elif defined(__APPLE__)
-	vm_size_t page_size = 0;
-	mach_port_t host_port = mach_host_self();
-	if (host_page_size(host_port, &page_size) != KERN_SUCCESS)
-		return 0;
-	vm_statistics64_data_t vm_stats;
-	mach_msg_type_number_t count = sizeof(vm_stats) / sizeof(natural_t);
-	if (host_statistics64(host_port, HOST_VM_INFO64, reinterpret_cast<host_info64_t>(&vm_stats), &count) != KERN_SUCCESS)
-		return 0;
-	return static_cast<size_t>(vm_stats.free_count) * static_cast<size_t>(page_size);
+	// Memory guard detection on macOS is intentionally disabled by product
+	// decision: the vm_statistics64-based "available" estimate counts free
+	// pages only and ignores reclaimable cache (inactive/purgeable), so it
+	// sits far below the guard threshold on any normally-used system and
+	// raised false low-memory warnings even for small models. Returning 0
+	// makes check_memory_guard() skip the sample entirely (avail == 0).
+	return 0;
 #else
 	return 0;
 #endif


### PR DESCRIPTION
# Description

Disables the runtime slicing memory guard (introduced in #642) on macOS. Windows and Linux behavior is untouched.

The macOS query in `get_available_physical_memory()` returned `free_count * page_size` from `host_statistics64`. On a normally-used macOS system the kernel fills idle RAM with reclaimable file cache (inactive/purgeable pages), so `free_count` sits far below the 512MB guard threshold regardless of model size — the guard raised false low-memory warnings even for very small models.

Per product decision, macOS detection is dropped instead of shipping a corrected metric: the `__APPLE__` branch now returns 0, and the existing `avail == 0` short-circuit in `check_memory_guard()` (PrintBase.hpp) skips the sample entirely — no dialog and no guard actions on macOS.

# Screenshots/Recordings/Graphs

No UI changes. Single-file diff: `src/libslic3r/utils.cpp` (+7/-9).

## Tests

- Full `libslic3r_tests` suite on Windows/Release: failure set identical to the `release_2_3_6` baseline (3 pre-existing failures unrelated to this change; the edited code only compiles into the `__APPLE__` branch)
- `Snapmaker_Orca_app_gui` (full app) builds and links on Windows/VS2022 Release
- The macOS path is compile-guarded; a macOS build is recommended before merge to confirm
