### PR TITLE
fix(gui): dark-mode icons, layout shift and DPI rescale in mixed-filament batch dialog

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -15306,7 +15306,7 @@ msgid ""
 "The mix ratios for %s in the Color Mapping list are outside the recommended %d"
 "%%–%d%% range. Adjust the mix ratios manually for better results."
 msgstr ""
-"Color Mapping 列表中 %s 的混色比例超出推荐范围 %d%%–%d%%。请手动调整混色比例以获得更好效果。"
+"颜色映射列表中 %s 混色比例超出推荐范围 %d%%–%d%%。建议手动调整混色比例，以获得更好的颜色效果。"
 
 msgid "Cannot enable both Variable Layer Height and Subdivide Mix Layer."
 msgstr "可变层高与混色细分层高功能互斥，请勿同时开启。"

--- a/resources/images/filament_picker_left_arrow_light.svg
+++ b/resources/images/filament_picker_left_arrow_light.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="9.083" stroke="#CCCCCC" stroke-width="1.5"/>
+<path d="M11.5 6.5L8 10L11.5 13.5" stroke="#CCCCCC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/resources/images/filament_picker_right_arrow_light.svg
+++ b/resources/images/filament_picker_right_arrow_light.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="9.083" stroke="#CCCCCC" stroke-width="1.5"/>
+<path d="M8.5 6.5L12 10L8.5 13.5" stroke="#CCCCCC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/resources/images/icon_minus_light.svg
+++ b/resources/images/icon_minus_light.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.33203 8H12.6654" stroke="#CCCCCC" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/resources/images/icon_plus_light.svg
+++ b/resources/images/icon_plus_light.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.33203 8.00391H12.6654" stroke="#CCCCCC" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.99609 3.33203V12.6654" stroke="#CCCCCC" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -234,8 +234,16 @@ private:
         const wxBitmap& draw_bmp = m_bmp.IsOk() ? m_bmp :
             (m_placeholder_loaded ? m_placeholder.bmp() : wxNullBitmap);
         if (draw_bmp.IsOk()) {
-            const int bw = draw_bmp.GetWidth();
-            const int bh = draw_bmp.GetHeight();
+            // Center by LOGICAL size. On macOS a ScalableBitmap raster carries a Retina
+            // scale factor (physical = logical x2) and DrawBitmap renders it at its
+            // logical size in this point-based DC, so centering on GetWidth()/
+            // GetHeight() (physical) shifted the placeholder left/up by
+            // (physical - logical)/2. GetScaledSize() divides out the bitmap's own
+            // scale factor; it is an identity op for scale-1.0 bitmaps (Windows/Linux
+            // rasters and the GL-rendered thumbnails), so those paths are unchanged.
+            const wxSize logical_sz = draw_bmp.GetScaledSize();
+            const int bw = logical_sz.x;
+            const int bh = logical_sz.y;
             if (bw > 0 && bh > 0)
                 dc.DrawBitmap(draw_bmp, (sz.x - bw) / 2, (sz.y - bh) / 2, false);
         }
@@ -1351,11 +1359,19 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
         // overridden by the GTK theme — set fg+bg explicitly via darkModeColorFor.
         lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        // Pin the title row height to match the recommended card's (avoids a content shift on mode switch).
+        lbl->SetMinSize(wxSize(-1, FromDIP(20)));
         title_row->Add(lbl, 0, wxALIGN_CENTER_VERTICAL);
         title_row->AddStretchSpacer();
 
-        m_btn_remove_filament = new ScalableButton(card, wxID_ANY, "icon_minus");
+        // Palette swap: base icon (#8F8F8F) and its _light variant (#CCCCCC) exchange
+        // enabled/disabled roles between themes — two assets cover all four states.
+        const bool dark = wxGetApp().dark_mode();
+        m_btn_remove_filament = new ScalableButton(card, wxID_ANY, dark ? "icon_minus_light" : "icon_minus");
+        m_btn_remove_filament->SetBitmapDisabled_(ScalableBitmap(card, dark ? "icon_minus" : "icon_minus_light", 16));
         m_btn_remove_filament->SetToolTip(_L("Remove filament"));
+        m_btn_remove_filament->SetMinSize(wxSize(FromDIP(16), FromDIP(16)));
+        m_btn_remove_filament->SetMaxSize(wxSize(FromDIP(16), FromDIP(16)));
         m_btn_remove_filament->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
             if (m_manual_filament_count > 2) {
                 --m_manual_filament_count;
@@ -1367,8 +1383,11 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
         });
         title_row->Add(m_btn_remove_filament, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
 
-        m_btn_add_filament = new ScalableButton(card, wxID_ANY, "icon_plus");
+        m_btn_add_filament = new ScalableButton(card, wxID_ANY, dark ? "icon_plus_light" : "icon_plus");
+        m_btn_add_filament->SetBitmapDisabled_(ScalableBitmap(card, dark ? "icon_plus" : "icon_plus_light", 16));
         m_btn_add_filament->SetToolTip(_L("Add filament"));
+        m_btn_add_filament->SetMinSize(wxSize(FromDIP(16), FromDIP(16)));
+        m_btn_add_filament->SetMaxSize(wxSize(FromDIP(16), FromDIP(16)));
         m_btn_add_filament->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
             // Cap at the number of physical filaments — you can't pick more rows than the
             // spools the printer actually has — and never exceed the 4-row UI bound.
@@ -1407,8 +1426,10 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
         // selected filament's name is. wxFlexGridSizer sizes columns by content (best size)
         // first, then distributes leftover via AddGrowableCol(0/1, 1) — without a pinned
         // base width, slots 1/2 and 3/4 drift apart when names differ in length.
-        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
-        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
+        // Height pinned to 30 like the recommended card's rows, so mode switching doesn't
+        // shift the cards below.
+        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), FromDIP(30)));
+        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), FromDIP(30)));
         auto* r = new wxBoxSizer(wxHORIZONTAL);
 
         // §68: read-only selection would normally call for wxChoice, but this
@@ -1484,6 +1505,8 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
         // resists GTK theme override.
         lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        // Pin the title row height to match the manual card's (avoids a content shift on mode switch).
+        lbl->SetMinSize(wxSize(-1, FromDIP(20)));
         s->Add(lbl, 0, wxLEFT | wxRIGHT | wxTOP, FromDIP(16));
     }
     // No divider between title and grid — matches build_manual_card (Figma spec relies on
@@ -1642,7 +1665,9 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
     // Centered controls: Plate (prev arrow + label + combo + next arrow) | View (label + combo)
     {
         auto* crow = new wxBoxSizer(wxHORIZONTAL);
-        m_btn_tray_prev = new ScalableButton(m_preview_card, wxID_ANY, "filament_picker_left_arrow");
+        const bool dark = wxGetApp().dark_mode();
+        m_btn_tray_prev = new ScalableButton(m_preview_card, wxID_ANY, dark ? "filament_picker_left_arrow_light" : "filament_picker_left_arrow");
+        m_btn_tray_prev->SetBitmapDisabled_(ScalableBitmap(m_preview_card, dark ? "filament_picker_left_arrow" : "filament_picker_left_arrow_light", 16));
         m_btn_tray_prev->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { on_tray_nav(-1); });
         crow->Add(m_btn_tray_prev, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(10));
 
@@ -1671,7 +1696,8 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
         });
         crow->Add(m_tray_combo, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(10));
 
-        m_btn_tray_next = new ScalableButton(m_preview_card, wxID_ANY, "filament_picker_right_arrow");
+        m_btn_tray_next = new ScalableButton(m_preview_card, wxID_ANY, dark ? "filament_picker_right_arrow_light" : "filament_picker_right_arrow");
+        m_btn_tray_next->SetBitmapDisabled_(ScalableBitmap(m_preview_card, dark ? "filament_picker_right_arrow" : "filament_picker_right_arrow_light", 16));
         m_btn_tray_next->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { on_tray_nav(1); });
         crow->Add(m_btn_tray_next, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(48));
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3902,6 +3902,11 @@ void Sidebar::msw_rescale()
     p->m_bpButton_ams_filament->msw_rescale();
     p->m_bpButton_set_filament->msw_rescale();
     p->m_flushing_volume_btn->Rescale();
+    // Batch-match button caches its text extent (messureSize) at creation DPI; without
+    // Rescale() the cached size goes stale after a per-monitor DPI change (e.g. moving
+    // the window to a 150% 4K screen), so render() centers the auto-rescaled font with
+    // the old-DPI metrics and the label drifts/clips.
+    p->m_btn_batch_match->Rescale();
     //BBS
     m_bed_type_list->Rescale();
     m_bed_type_list->SetMinSize({-1, 3 * wxGetApp().em_unit()});
@@ -3975,6 +3980,8 @@ void Sidebar::sys_color_changed()
     p->m_bpButton_ams_filament->msw_rescale();
     p->m_bpButton_set_filament->msw_rescale();
     p->m_flushing_volume_btn->Rescale();
+    // Keep the cached text extent in sync with the new DPI, same as above.
+    p->m_btn_batch_match->Rescale();
 
     // BBS
 #if 0


### PR DESCRIPTION
# Description

Follow-up UI fixes for the mixed-filament batch color-match dialog introduced in #702, plus the related sidebar button:

- **Dark-mode icons**: added `_light` variants for the add/remove and tray-nav buttons and set explicit
  disabled-state bitmaps (muted opposite-palette asset), so enabled/disabled states are distinguishable
  in both light and dark themes.
- **macOS placeholder centering**: center the preview placeholder by logical size (`GetScaledSize`) so
  Retina-rasterized bitmaps are no longer shifted toward the top-left; identity for scale-1.0 bitmaps,
  so Windows/Linux rendering is unchanged.
- **Layout stability**: pinned title rows to 20 DIP, manual-card rows to 30 DIP (matching the recommended
  card), and add/remove buttons to 16x16 DIP, so cards no longer shift when switching between
  recommended and manual modes.
- **DPI rescale**: the sidebar "Color Mixing Match" button now gets `Rescale()` in `msw_rescale()` and
  `sys_color_changed()`. Its cached text extent (`messureSize`) otherwise goes stale after a per-monitor
  DPI change or theme switch, making the label drift or clip.
- **zh_CN**: refined the mix-ratio range warning translation.

No breaking changes, no new dependencies.

## Tests

Manual verification (Windows 11):
- Toggled light/dark theme — add/remove and tray-nav buttons show distinct enabled/disabled states in both themes
- Switched Recommended ↔ Manual repeatedly — no card shift, title rows stay aligned
- Moved the window between 100% and 150% monitors — sidebar button label and dialog placeholder stay centered, no clipping