### PR TITLE
fix: resolve tree-support slicing stall at 70% when base pattern spacing is 0

### DIFF
--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -1527,9 +1527,28 @@ void TreeSupport::generate_toolpaths()
                         bool need_infill = with_infill;
                         if(m_object_config->support_base_pattern==smpDefault)
                             need_infill &= area_group.need_infill;
-                        std::shared_ptr<Fill> filler_support = std::shared_ptr<Fill>(Fill::new_from_type(layer_id == 0 ? ipConcentric : m_support_params.base_fill_pattern));
+                        // Ported from upstream OrcaSlicer d2ca5d3a1e.
+                        //
+                        // The bed-contacting support base (layer 0, no raft) previously forced
+                        // ipConcentric and computed spacing as
+                        //   support_base_pattern_spacing * support_density.
+                        // When the effective support_base_pattern_spacing is 0 (per-object override
+                        // or global default), spacing becomes 0, which makes FillConcentric's
+                        // while(!last.empty()) convergence loop spin forever: distance=0 means
+                        // offset2_ex(last, -(0+0), +0) is a no-op, so the polygon never shrinks.
+                        //
+                        // Fix: on the bed-contacting base layer, use ipRectilinear (which has no
+                        // offset-convergence loop) and real flow spacing (always > 0).
+                        const bool support_base_on_bed = (layer_id == 0 && m_raft_layers == 0);
+                        const InfillPattern base_fill_pattern = support_base_on_bed
+                            ? ipRectilinear
+                            : m_support_params.base_fill_pattern;
+                        std::shared_ptr<Fill> filler_support =
+                            std::shared_ptr<Fill>(Fill::new_from_type(base_fill_pattern));
                         filler_support->set_bounding_box(bbox_object);
-                        filler_support->spacing = object_config.support_base_pattern_spacing.value * support_density;// constant spacing to align support infill lines
+                        filler_support->spacing = support_base_on_bed
+                            ? flow.spacing()
+                            : (object_config.support_base_pattern_spacing.value * support_density);
                         filler_support->angle = Geometry::deg2rad(object_config.support_angle.value);
 
                         Polygons loops = to_polygons(poly);


### PR DESCRIPTION
# Description

- Fixes a slicing stall at 70% that occurred when hybrid tree support was enabled together with an effective `support_base_pattern_spacing` of 0 (per-object override or global default).
- Root cause: the bed-contacting support base (layer 0, no raft) forced the `ipConcentric` fill pattern and computed `spacing = support_base_pattern_spacing * support_density`. With pattern spacing 0 this yields spacing 0, which drives `FillConcentric`'s `while(!last.empty())` convergence loop into an infinite spin: distance 0 makes `offset2_ex(last, -(0+0), +0)` a no-op, so the polygon never shrinks. One worker burned 100% CPU while its peers blocked at the `tbb::parallel_for` barrier, stalling slicing at 70%.
- Fix: on the bed-contacting base layer, use `ipRectilinear` (which has no offset-convergence loop) instead of `ipConcentric`, and real flow spacing (always > 0) instead of the density-scaled pattern spacing.
- Ports upstream OrcaSlicer d2ca5d3a1e (SoftFever/OrcaSlicer#13454).

# Screenshots/Recordings/Graphs

Not applicable — slicing-engine fix only, no UI change.

## Tests

- Reproduction: enable hybrid tree support with `support_base_pattern_spacing` = 0 → slicing stalls at 70% with one worker thread pinned at 100% CPU. After the fix, the same model and configuration slices to completion.
- Instrumented `FillConcentric` with a per-iteration probe log: on the failing call, `area_ratio` stayed at 1.0 from i=1000 to i=1999 (loop never converging); all other calls (distance != 0) converged normally.
- Verified that normal tree-support configurations (non-zero pattern spacing) still produce the same toolpaths as before, since only the bed-contacting base layer (layer 0, no raft) changed pattern and spacing.