### PR TITLE
fix: stay on Preview when re-dropping the same G-code file

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9647,9 +9647,17 @@ bool PlaterDropTarget::OnDropFiles(wxCoord x, wxCoord y, const wxArrayString &fi
 #endif // WIN32
 
     m_mainframe.Raise();
-    m_mainframe.select_tab(size_t(MainFrame::tp3DEditor));
-    if (wxGetApp().is_editor())
-        m_plater.select_view_3D("3D");
+    // Do not force the 3D editor before we even know what was dropped. When a
+    // G-code is already loaded (only-gcode mode) and the same file is dropped
+    // again, load_gcode() early-returns on its same-file guard and never
+    // switches back to Preview, so forcing the 3D editor here would strand the
+    // UI there and make the already-loaded G-code preview look like it
+    // "disappeared". Let the user stay on the Preview tab in that case.
+    if (!m_plater.only_gcode_mode()) {
+        m_mainframe.select_tab(size_t(MainFrame::tp3DEditor));
+        if (wxGetApp().is_editor())
+            m_plater.select_view_3D("3D");
+    }
 
     // When only one .svg file is dropped on scene
     if (filenames.size() == 1) {
@@ -9667,6 +9675,13 @@ bool PlaterDropTarget::OnDropFiles(wxCoord x, wxCoord y, const wxArrayString &fi
     }
     bool res = m_plater.load_files(filenames);
     m_mainframe.update_title();
+    // After dropping a G-code file, make sure we land on the Preview tab. On a
+    // fresh load load_gcode() switches to Preview itself, but when the *same*
+    // G-code is dropped again load_gcode() early-returns via its same-file
+    // guard, so without this the UI stays on the (empty) 3D editor and the
+    // already-loaded G-code preview looks like it "disappeared".
+    if (m_plater.only_gcode_mode())
+        m_plater.select_view_3D("Preview");
     return res;
 }
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9648,11 +9648,10 @@ bool PlaterDropTarget::OnDropFiles(wxCoord x, wxCoord y, const wxArrayString &fi
 
     m_mainframe.Raise();
     // Do not force the 3D editor before we even know what was dropped. When a
-    // G-code is already loaded (only-gcode mode) and the same file is dropped
-    // again, load_gcode() early-returns on its same-file guard and never
-    // switches back to Preview, so forcing the 3D editor here would strand the
-    // UI there and make the already-loaded G-code preview look like it
-    // "disappeared". Let the user stay on the Preview tab in that case.
+    // G-code is already loaded (only-gcode mode) the user is on the Preview
+    // tab: load_gcode()'s same-file guard switches straight back to Preview
+    // on a repeat drop, and the other load paths select their own final view,
+    // so switching here would only flash the (empty) 3D editor.
     if (!m_plater.only_gcode_mode()) {
         m_mainframe.select_tab(size_t(MainFrame::tp3DEditor));
         if (wxGetApp().is_editor())
@@ -9675,13 +9674,6 @@ bool PlaterDropTarget::OnDropFiles(wxCoord x, wxCoord y, const wxArrayString &fi
     }
     bool res = m_plater.load_files(filenames);
     m_mainframe.update_title();
-    // After dropping a G-code file, make sure we land on the Preview tab. On a
-    // fresh load load_gcode() switches to Preview itself, but when the *same*
-    // G-code is dropped again load_gcode() early-returns via its same-file
-    // guard, so without this the UI stays on the (empty) 3D editor and the
-    // already-loaded G-code preview looks like it "disappeared".
-    if (m_plater.only_gcode_mode())
-        m_plater.select_view_3D("Preview");
     return res;
 }
 
@@ -17977,10 +17969,21 @@ void Plater::load_gcode(const wxString& filename)
 {
     BOOST_LOG_TRIVIAL(trace) << __FUNCTION__ << __LINE__ << " entry and filename: " << filename;
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__;
-    if (! is_gcode_file(into_u8(filename))
-        || (m_last_loaded_gcode == filename && m_only_gcode)
-        )
+    if (! is_gcode_file(into_u8(filename)))
         return;
+
+    if (m_last_loaded_gcode == filename && m_only_gcode) {
+        // The same G-code is already loaded: reloading would be a no-op, so
+        // just make sure the user is looking at its preview — callers may
+        // have left the UI on another view (e.g. the 3D editor after a
+        // drag & drop).
+        wxGetApp().mainframe->select_tab(MainFrame::tpPreview);
+        p->set_current_panel(p->preview, true);
+        GLCanvas3D* canvas = p->get_current_canvas3D();
+        if (canvas)
+            canvas->render();
+        return;
+    }
 
     // Reject a missing / inaccessible file up front. Without this check the
     // code below would walk through process_file -> parse_file_raw_internal,


### PR DESCRIPTION
# Description

Re-dropping the same G-code file onto the window stranded the UI on the
(empty) 3D editor, so the already-loaded G-code preview looked like it had
disappeared. Root cause: `PlaterDropTarget::OnDropFiles` unconditionally
switched to the 3D editor before calling `load_files`, while
`Plater::load_gcode` early-returns on its same-file guard
(`m_last_loaded_gcode == filename && m_only_gcode`) and never reaches its
`select_tab(tpPreview)`.

Fixed in two commits:

1. **21a68ae945** — gate the pre-load 3D-editor switch on
   `!only_gcode_mode()` so a repeat G-code drop does not yank the user off
   the Preview tab.
2. **c5ed6c10** — move the view restore into `load_gcode`'s same-file
   guard itself: when the guard hits, it now selects the Preview tab and
   panel (mirroring the normal load path) before returning, and the
   caller-side post-load check is removed. This makes "re-opening the
   already-loaded G-code leaves you looking at it" an invariant of
   `load_gcode`, benefiting every caller (drag & drop, File > Open
   G-code, file association).

The second commit also fixes a regression introduced by the first draft of
this fix: the post-load check keyed off `only_gcode_mode()` after
`load_files()` returned, but that flag stays stale-true on the 3MF "Load
Geometry Only" path (nothing there resets `m_only_gcode`). Dropping a 3MF
in only-gcode mode would load the model, switch to the 3D editor, then
bounce the user back to the empty Preview tab, making the model invisible
(and clicking Prepare would offer to discard it via `new_project`). With
the restore living inside `load_gcode`'s guard, each load path owns its
final view and the stale flag can no longer misfire.

Only `src/slic3r/GUI/Plater.cpp` is touched.

# Screenshots/Recordings/Graphs

Not applicable — behavior-only change (tab/panel selection), verified by
the manual matrix below.

## Tests

Manual matrix (Windows, Release build):

| # | Scenario | Result |
|---|----------|--------|
| 1 | Editor mode, drop model files | lands on 3D editor (unchanged) |
| 2 | First G-code drop | lands on Preview (unchanged) |
| 3 | Repeat drop of the same G-code | stays on Preview, no flash (bug fixed) |
| 4 | Drop a different G-code in only-gcode mode | loads, stays on Preview |
| 5 | Only-gcode + drop STL | "Cannot add models when in preview mode!" message, stays on Preview |
| 6 | Only-gcode + drop multiple G-codes | "Only one G-code file" message, stays on Preview |
| 7 | Only-gcode + drop 3MF (Load Geometry Only) | lands on 3D editor with the model visible (regression fixed) |
| 8 | Only-gcode + drop 3MF (Open Project) | lands on 3D editor (unchanged) |
| 9 | File > Open G-code with the already-loaded file | switches to Preview |

Known pre-existing issues intentionally left out of scope (flagged for
follow-up): `m_only_gcode` is not reset on the 3MF LoadGeometry/LoadConfig
paths; `m_last_loaded_gcode` is assigned before the cancellable
`new_project` call in `load_gcode`.