### PR TITLE
ci: sign macOS builds for release_* branches

### DIFF
--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -122,7 +122,7 @@ jobs:
 
  # Thanks to RaySajuuk, it's working now
       - name: Sign app and notary
-        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || github.ref == 'refs/heads/2.3.0-final') && inputs.os == 'macos-14'
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_') || github.ref == 'refs/heads/2.3.0-final') && inputs.os == 'macos-14'
         working-directory: ${{ github.workspace }}
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -175,7 +175,7 @@ jobs:
           fi
 
       - name: Create DMG without notary
-        if: github.ref != 'refs/heads/main' && inputs.os == 'macos-14' && github.ref != 'refs/heads/2.3.0-final'
+        if: github.ref != 'refs/heads/main' && inputs.os == 'macos-14' && github.ref != 'refs/heads/2.3.0-final' && !startsWith(github.ref, 'refs/heads/release_')
         working-directory: ${{ github.workspace }}
         run: |
           mkdir -p ${{ github.workspace }}/build/universal/Snapmaker_Orca_dmg


### PR DESCRIPTION
# Description

Build workflow currently only produces signed + notarized macOS DMGs for `main`
and `2.3.0-final`. Builds dispatched on release branches (`release_2_3_6`,
`release_2_3_7`) come out unsigned, for two reasons:

1. The "Sign app and notary" step matched `refs/heads/release/` (slash), but
   release branches follow the `release_*` (underscore) naming convention, so
   the condition never matched.
2. Even for a matching ref, "Create DMG without notary" had no exclusion, so it
   re-created the DMG after signing and overwrote the notarized artifact.

This PR changes 2 lines in `.github/workflows/build_orca.yml` (macOS job):

- "Sign app and notary" now also runs for `refs/heads/release_*`.
- "Create DMG without notary" now skips `refs/heads/release_*` so the signed
  DMG survives.

Notes:
- Deploy steps are intentionally untouched: release-branch builds remain
  workflow artifacts only; nightly release assets still come from
  `main` / `2.3.0-final` exclusively.
- `release_*` branches are already covered by the `main-protect` ruleset
  (PR + 1 approval, no force push/delete), so signing stays behind review.
- Signed builds hard-depend on the signing secrets; if they are unavailable
  the macOS job fails instead of falling back to an unsigned DMG.

# Screenshots/Recordings/Graphs

N/A (CI-only change)

## Tests

- YAML syntax validated locally.
- Confirmed upstream branches `release_2_3_6` / `release_2_3_7` match the new
  `refs/heads/release_*` condition.
- Post-merge manual verification (requires repo secrets): Actions → "Build all"
  → Run workflow on `release_2_3_7`; expected: "Sign app and notary" runs,
  "Create DMG without notary" is skipped, and the DMG passes
  `spctl -a -v -t open`.
- Regression check: dispatch "Build all" on a non-release branch — unsigned
  path unchanged; nightly schedule on `main` unaffected.