### PR TITLE
fix: crash hardening (MQTT/SSWCP/GCodeViewer), mixed-filament dialog UI, preset and logging fixes

### DIFF
--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -15306,7 +15306,7 @@ msgid ""
 "The mix ratios for %s in the Color Mapping list are outside the recommended %d"
 "%%–%d%% range. Adjust the mix ratios manually for better results."
 msgstr ""
-"Color Mapping 列表中 %s 的混色比例超出推荐范围 %d%%–%d%%。请手动调整混色比例以获得更好效果。"
+"颜色映射列表中 %s 混色比例超出推荐范围 %d%%–%d%%。建议手动调整混色比例，以获得更好的颜色效果。"
 
 msgid "Cannot enable both Variable Layer Height and Subdivide Mix Layer."
 msgstr "可变层高与混色细分层高功能互斥，请勿同时开启。"

--- a/resources/images/filament_picker_left_arrow_light.svg
+++ b/resources/images/filament_picker_left_arrow_light.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="9.083" stroke="#CCCCCC" stroke-width="1.5"/>
+<path d="M11.5 6.5L8 10L11.5 13.5" stroke="#CCCCCC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/resources/images/filament_picker_right_arrow_light.svg
+++ b/resources/images/filament_picker_right_arrow_light.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="9.083" stroke="#CCCCCC" stroke-width="1.5"/>
+<path d="M8.5 6.5L12 10L8.5 13.5" stroke="#CCCCCC" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/resources/images/icon_minus_light.svg
+++ b/resources/images/icon_minus_light.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.33203 8H12.6654" stroke="#CCCCCC" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/resources/images/icon_plus_light.svg
+++ b/resources/images/icon_plus_light.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.33203 8.00391H12.6654" stroke="#CCCCCC" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.99609 3.33203V12.6654" stroke="#CCCCCC" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/resources/profiles/Snapmaker/filament/Snapmaker PETG-CF @U1 0.4 nozzle.json
+++ b/resources/profiles/Snapmaker/filament/Snapmaker PETG-CF @U1 0.4 nozzle.json
@@ -40,7 +40,7 @@
   "temperature_vitrification": ["70"],
   "textured_plate_temp": ["80"],
   "textured_plate_temp_initial_layer": ["80"],
-  "supertack_plate_temp": ["60"],
-  "supertack_plate_temp_initial_layer": ["60"],
+  "supertack_plate_temp": ["0"],
+  "supertack_plate_temp_initial_layer": ["0"],
   "filament_type": ["PETG-CF"]
 }

--- a/src/libslic3r/utils.cpp
+++ b/src/libslic3r/utils.cpp
@@ -1531,15 +1531,13 @@ size_t get_available_physical_memory()
 	long page_size   = sysconf(_SC_PAGE_SIZE);
 	return (avail_pages > 0 && page_size > 0) ? static_cast<size_t>(avail_pages) * static_cast<size_t>(page_size) : 0;
 #elif defined(__APPLE__)
-	vm_size_t page_size = 0;
-	mach_port_t host_port = mach_host_self();
-	if (host_page_size(host_port, &page_size) != KERN_SUCCESS)
-		return 0;
-	vm_statistics64_data_t vm_stats;
-	mach_msg_type_number_t count = sizeof(vm_stats) / sizeof(natural_t);
-	if (host_statistics64(host_port, HOST_VM_INFO64, reinterpret_cast<host_info64_t>(&vm_stats), &count) != KERN_SUCCESS)
-		return 0;
-	return static_cast<size_t>(vm_stats.free_count) * static_cast<size_t>(page_size);
+	// Memory guard detection on macOS is intentionally disabled by product
+	// decision: the vm_statistics64-based "available" estimate counts free
+	// pages only and ignores reclaimable cache (inactive/purgeable), so it
+	// sits far below the guard threshold on any normally-used system and
+	// raised false low-memory warnings even for small models. Returning 0
+	// makes check_memory_guard() skip the sample entirely (avail == 0).
+	return 0;
 #else
 	return 0;
 #endif

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -1001,16 +1001,27 @@ void GCodeViewer::load(const GCodeProcessorResult& gcode_result, const Print& pr
    //BBS: add logs
   BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": gcode result %1%, new id %2%, gcode file %3% ") % (&gcode_result) % m_last_result_id % gcode_result.filename;
 
-   // release gpu memory, if used
-   reset();
+    // release gpu memory, if used.
+    // NOTE: this MUST run before m_loading is armed below. reset() early-returns
+    // when m_loading is set, so arming first would silently skip this cleanup and
+    // the previous gcode's buffers would leak / be appended to by load_toolpaths().
+    reset();
 
-   //BBS: add mutex for protection of gcode result
-   gcode_result.lock();
+    // load_toolpaths() below pumps the event loop through its modal progress
+    // dialog; a dispatched event can re-enter reset() (via reset_gcode_toolpaths)
+    // and zero m_moves_count mid-flight -> unsigned underflow in reserve().
+    // Arm the guard so any re-entrant reset() is ignored. ScopeGuard clears the
+    // flag on every exit, including exceptions thrown from load_toolpaths().
+    m_loading = true;
+    ScopeGuard loading_guard([this]() { m_loading = false; });
+
+    //BBS: add mutex for protection of gcode result
+    gcode_result.lock();
+    ScopeGuard unlock_guard([&gcode_result]() { gcode_result.unlock(); });
     //BBS: add safe check
     if (gcode_result.moves.size() == 0) {
         //result cleaned before slicing ,should return here
         BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(": gcode result reset before, return directly!");
-        gcode_result.unlock();
         return;
     }
 
@@ -1081,7 +1092,6 @@ void GCodeViewer::load(const GCodeProcessorResult& gcode_result, const Print& pr
 
     //BBS: add mutex for protection of gcode result
     if (m_layers.empty()) {
-        gcode_result.unlock();
         return;
     }
 
@@ -1179,10 +1189,9 @@ void GCodeViewer::load(const GCodeProcessorResult& gcode_result, const Print& pr
     m_conflict_result = gcode_result.conflict_result;
     if (m_conflict_result) { m_conflict_result.value().layer = m_layers.get_l_at(m_conflict_result.value()._height); }
 
-    //BBS: add mutex for protection of gcode result
-    gcode_result.unlock();
     //BBS: add logs
-   BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": finished, m_buffers size %1%!")%m_buffers.size();
+    // gcode_result.unlock() and m_loading = false run here via the ScopeGuards above.
+    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": finished, m_buffers size %1%!")%m_buffers.size();
 }
 
 void GCodeViewer::refresh(const GCodeProcessorResult& gcode_result, const std::vector<std::string>& str_tool_colors)
@@ -1193,19 +1202,18 @@ void GCodeViewer::refresh(const GCodeProcessorResult& gcode_result, const std::v
 
     //BBS: add mutex for protection of gcode result
     gcode_result.lock();
+    ScopeGuard unlock_guard([&gcode_result]() { gcode_result.unlock(); });
 
     //BBS: add safe check
     if (gcode_result.moves.size() == 0) {
         //result cleaned before slicing ,should return here
         BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(": gcode result reset before, return directly!");
-        gcode_result.unlock();
         return;
     }
 
     //BBS: add mutex for protection of gcode result
     if (m_moves_count == 0) {
         BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(": gcode result m_moves_count is 0, return directly!");
-        gcode_result.unlock();
         return;
     }
 
@@ -1213,7 +1221,7 @@ void GCodeViewer::refresh(const GCodeProcessorResult& gcode_result, const std::v
     // Skip all GPU rendering work here to avoid OOM.
     if (m_no_render_path) {
         BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << ": m_no_render_path is set, skipping toolpath rendering (no GPU buffers were built)";
-        gcode_result.unlock();
+        // gcode_result.unlock() runs here via the ScopeGuard above.
         return;
     }
 
@@ -1286,8 +1294,6 @@ m_extrusions.ranges.layer_duration_log.update_from(curr.layer_duration);
     m_statistics.refresh_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start_time).count();
 #endif // ENABLE_GCODE_VIEWER_STATISTICS
 
-    //BBS: add mutex for protection of gcode result
-    gcode_result.unlock();
 
     // update buffers' render paths
     refresh_render_paths();
@@ -1317,6 +1323,8 @@ void GCodeViewer::reset_shell()
 
 void GCodeViewer::reset()
 {
+    if (m_loading)
+        return;
     //BBS: should also reset the result id
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": current result id %1% ")%m_last_result_id;
     m_last_result_id = -1;
@@ -2663,8 +2671,18 @@ void GCodeViewer::load_toolpaths(const GCodeProcessorResult& gcode_result, const
     };
     //BBS: generate map from ssid to move id in advance to reduce computation
     m_ssid_to_moveid_map.clear();
-    m_ssid_to_moveid_map.reserve( m_moves_count - biased_seams_ids.size());
-    for (size_t i = 0; i < m_moves_count - biased_seams_ids.size(); i++)
+    // Defensive clamp: if m_moves_count were ever smaller than the seam count
+    // (e.g. zeroed by a re-entrant reset()), this unsigned subtraction would wrap
+    // to ~SIZE_MAX and reserve() would throw std::length_error. The m_loading
+    // guard prevents that today; this keeps it safe regardless.
+    const size_t ssid_count = (m_moves_count > biased_seams_ids.size()) ? (m_moves_count - biased_seams_ids.size()) : 0;
+   m_ssid_to_moveid_map.reserve(ssid_count);
+   if (ssid_count == 0 && m_moves_count > 0) {
+        BOOST_LOG_TRIVIAL(warning) << __FUNCTION__
+            << boost::format(": reentrancy detected -- m_moves_count=%1% biased_seams=%2% moves.size=%3%")
+                   % m_moves_count % biased_seams_ids.size() % gcode_result.moves.size();
+   }
+   for (size_t i = 0; i < ssid_count; i++)
         m_ssid_to_moveid_map.push_back(extract_move_id(i));
 
     //BBS: smooth toolpaths corners for the given TBuffer using triangles

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -737,6 +737,7 @@ private:
     const GCodeProcessorResult* m_gcode_result;
     //BBS: add only gcode mode
     bool m_only_gcode_in_preview {false};
+    bool m_loading{ false };
     std::vector<size_t> m_ssid_to_moveid_map;
 
     std::vector<TBuffer> m_buffers{ static_cast<size_t>(EMoveType::Extrude) };

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -234,8 +234,16 @@ private:
         const wxBitmap& draw_bmp = m_bmp.IsOk() ? m_bmp :
             (m_placeholder_loaded ? m_placeholder.bmp() : wxNullBitmap);
         if (draw_bmp.IsOk()) {
-            const int bw = draw_bmp.GetWidth();
-            const int bh = draw_bmp.GetHeight();
+            // Center by LOGICAL size. On macOS a ScalableBitmap raster carries a Retina
+            // scale factor (physical = logical x2) and DrawBitmap renders it at its
+            // logical size in this point-based DC, so centering on GetWidth()/
+            // GetHeight() (physical) shifted the placeholder left/up by
+            // (physical - logical)/2. GetScaledSize() divides out the bitmap's own
+            // scale factor; it is an identity op for scale-1.0 bitmaps (Windows/Linux
+            // rasters and the GL-rendered thumbnails), so those paths are unchanged.
+            const wxSize logical_sz = draw_bmp.GetScaledSize();
+            const int bw = logical_sz.x;
+            const int bh = logical_sz.y;
             if (bw > 0 && bh > 0)
                 dc.DrawBitmap(draw_bmp, (sz.x - bw) / 2, (sz.y - bh) / 2, false);
         }
@@ -1351,11 +1359,19 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
         // overridden by the GTK theme — set fg+bg explicitly via darkModeColorFor.
         lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        // Pin the title row height to match the recommended card's (avoids a content shift on mode switch).
+        lbl->SetMinSize(wxSize(-1, FromDIP(20)));
         title_row->Add(lbl, 0, wxALIGN_CENTER_VERTICAL);
         title_row->AddStretchSpacer();
 
-        m_btn_remove_filament = new ScalableButton(card, wxID_ANY, "icon_minus");
+        // Palette swap: base icon (#8F8F8F) and its _light variant (#CCCCCC) exchange
+        // enabled/disabled roles between themes — two assets cover all four states.
+        const bool dark = wxGetApp().dark_mode();
+        m_btn_remove_filament = new ScalableButton(card, wxID_ANY, dark ? "icon_minus_light" : "icon_minus");
+        m_btn_remove_filament->SetBitmapDisabled_(ScalableBitmap(card, dark ? "icon_minus" : "icon_minus_light", 16));
         m_btn_remove_filament->SetToolTip(_L("Remove filament"));
+        m_btn_remove_filament->SetMinSize(wxSize(FromDIP(16), FromDIP(16)));
+        m_btn_remove_filament->SetMaxSize(wxSize(FromDIP(16), FromDIP(16)));
         m_btn_remove_filament->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
             if (m_manual_filament_count > 2) {
                 --m_manual_filament_count;
@@ -1367,8 +1383,11 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
         });
         title_row->Add(m_btn_remove_filament, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(4));
 
-        m_btn_add_filament = new ScalableButton(card, wxID_ANY, "icon_plus");
+        m_btn_add_filament = new ScalableButton(card, wxID_ANY, dark ? "icon_plus_light" : "icon_plus");
+        m_btn_add_filament->SetBitmapDisabled_(ScalableBitmap(card, dark ? "icon_plus" : "icon_plus_light", 16));
         m_btn_add_filament->SetToolTip(_L("Add filament"));
+        m_btn_add_filament->SetMinSize(wxSize(FromDIP(16), FromDIP(16)));
+        m_btn_add_filament->SetMaxSize(wxSize(FromDIP(16), FromDIP(16)));
         m_btn_add_filament->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
             // Cap at the number of physical filaments — you can't pick more rows than the
             // spools the printer actually has — and never exceed the 4-row UI bound.
@@ -1407,8 +1426,10 @@ void MixedFilamentBatchDialog::build_manual_card(wxBoxSizer& parent)
         // selected filament's name is. wxFlexGridSizer sizes columns by content (best size)
         // first, then distributes leftover via AddGrowableCol(0/1, 1) — without a pinned
         // base width, slots 1/2 and 3/4 drift apart when names differ in length.
-        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
-        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), -1));
+        // Height pinned to 30 like the recommended card's rows, so mode switching doesn't
+        // shift the cards below.
+        panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), FromDIP(30)));
+        panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), FromDIP(30)));
         auto* r = new wxBoxSizer(wxHORIZONTAL);
 
         // §68: read-only selection would normally call for wxChoice, but this
@@ -1484,6 +1505,8 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
         // resists GTK theme override.
         lbl->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
         lbl->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        // Pin the title row height to match the manual card's (avoids a content shift on mode switch).
+        lbl->SetMinSize(wxSize(-1, FromDIP(20)));
         s->Add(lbl, 0, wxLEFT | wxRIGHT | wxTOP, FromDIP(16));
     }
     // No divider between title and grid — matches build_manual_card (Figma spec relies on
@@ -1642,7 +1665,9 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
     // Centered controls: Plate (prev arrow + label + combo + next arrow) | View (label + combo)
     {
         auto* crow = new wxBoxSizer(wxHORIZONTAL);
-        m_btn_tray_prev = new ScalableButton(m_preview_card, wxID_ANY, "filament_picker_left_arrow");
+        const bool dark = wxGetApp().dark_mode();
+        m_btn_tray_prev = new ScalableButton(m_preview_card, wxID_ANY, dark ? "filament_picker_left_arrow_light" : "filament_picker_left_arrow");
+        m_btn_tray_prev->SetBitmapDisabled_(ScalableBitmap(m_preview_card, dark ? "filament_picker_left_arrow" : "filament_picker_left_arrow_light", 16));
         m_btn_tray_prev->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { on_tray_nav(-1); });
         crow->Add(m_btn_tray_prev, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(10));
 
@@ -1671,7 +1696,8 @@ void MixedFilamentBatchDialog::build_preview_card(wxBoxSizer& parent)
         });
         crow->Add(m_tray_combo, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(10));
 
-        m_btn_tray_next = new ScalableButton(m_preview_card, wxID_ANY, "filament_picker_right_arrow");
+        m_btn_tray_next = new ScalableButton(m_preview_card, wxID_ANY, dark ? "filament_picker_right_arrow_light" : "filament_picker_right_arrow");
+        m_btn_tray_next->SetBitmapDisabled_(ScalableBitmap(m_preview_card, dark ? "filament_picker_right_arrow" : "filament_picker_right_arrow_light", 16));
         m_btn_tray_next->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { on_tray_nav(1); });
         crow->Add(m_btn_tray_next, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(48));
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12950,6 +12950,7 @@ void Plater::priv::reset(bool apply_presets_change)
     Plater::TakeSnapshot snapshot(q, "Reset Project", UndoRedo::SnapshotType::ProjectSeparator);
 
     clear_warnings();
+    first_enter_assemble = true;
 
     set_project_filename("");
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << __LINE__ << " call set_project_filename: empty";

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3902,6 +3902,11 @@ void Sidebar::msw_rescale()
     p->m_bpButton_ams_filament->msw_rescale();
     p->m_bpButton_set_filament->msw_rescale();
     p->m_flushing_volume_btn->Rescale();
+    // Batch-match button caches its text extent (messureSize) at creation DPI; without
+    // Rescale() the cached size goes stale after a per-monitor DPI change (e.g. moving
+    // the window to a 150% 4K screen), so render() centers the auto-rescaled font with
+    // the old-DPI metrics and the label drifts/clips.
+    p->m_btn_batch_match->Rescale();
     //BBS
     m_bed_type_list->Rescale();
     m_bed_type_list->SetMinSize({-1, 3 * wxGetApp().em_unit()});
@@ -3975,6 +3980,8 @@ void Sidebar::sys_color_changed()
     p->m_bpButton_ams_filament->msw_rescale();
     p->m_bpButton_set_filament->msw_rescale();
     p->m_flushing_volume_btn->Rescale();
+    // Keep the cached text extent in sync with the new DPI, same as above.
+    p->m_btn_batch_match->Rescale();
 
     // BBS
 #if 0

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -510,7 +510,7 @@ void SSWCP_Instance::process() {
 }
 
 void SSWCP_Instance::sw_UploadEvent() {
-    {
+    try {
         if(!m_param_data.count("traceId")){
             handle_general_fail(-1, "param [traceId] required!");
             return;
@@ -541,6 +541,9 @@ void SSWCP_Instance::sw_UploadEvent() {
         finish_job();
 
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_Instance::sw_GetSoftwareInfo()
@@ -554,7 +557,7 @@ void SSWCP_Instance::sw_GetSoftwareInfo()
 }
 
 void SSWCP_Instance::sw_OpenNetworkDialog() {
-    {
+    try {
         send_to_js();
         finish_job();
 
@@ -583,11 +586,14 @@ void SSWCP_Instance::sw_OpenNetworkDialog() {
             new DelayedReleaseTimer(dlg);
         });
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 
 void SSWCP_Instance::sw_OpenBrowser() {
-    {
+    try {
         std::string url = m_param_data.count("url") ? m_param_data["url"].get<std::string>() : "";
         wxString wx_url  = wxString::FromUTF8(url);
 
@@ -606,10 +612,13 @@ void SSWCP_Instance::sw_OpenBrowser() {
             }
         });
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_Instance::sw_OpenOrcaWebview() {
-    {
+    try {
         std::string url = m_param_data.count("url") ? m_param_data["url"].get<std::string>() : "";
         wxString wx_url = wxString::FromUTF8(url);
 
@@ -626,10 +635,13 @@ void SSWCP_Instance::sw_OpenOrcaWebview() {
             dialog->Show();
         });
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_Instance::sw_FileLog() {
-    {
+    try {
         std::string level = m_param_data.count("level") ? m_param_data["level"].get<std::string>() : "debug";
         std::string content = m_param_data.count("content") ? m_param_data["content"].get<std::string>() : "";
 
@@ -647,6 +659,9 @@ void SSWCP_Instance::sw_FileLog() {
 
         send_to_js();
         finish_job();
+    }
+    catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -742,7 +757,7 @@ void SSWCP_Instance::sw_GetActiveFile()
 }
 
 void SSWCP_Instance::sw_LaunchConsole() {
-    {
+    try {
         bool res = WCP_Logger::getInstance().run();
         if (res) {
             m_msg = "Orca Console has been launched";
@@ -752,10 +767,14 @@ void SSWCP_Instance::sw_LaunchConsole() {
             handle_general_fail(-1, "Orca Console launched failed");
         }
     }
+    catch (std::exception& e) {
+        wxString reason = e.what();
+        handle_general_fail(-1, "Exception caught: " + reason);
+    }
 }
 
 void SSWCP_Instance::sw_SetLogLevel() {
-    {
+    try {
         if (m_param_data.count("level")) {
             wxString level = m_param_data["level"].get<std::string>();
             bool res = WCP_Logger::getInstance().set_level(level);
@@ -770,11 +789,15 @@ void SSWCP_Instance::sw_SetLogLevel() {
             handle_general_fail(-1, "param [level] required!");
         }
     }
+    catch (std::exception& e) {
+        wxString reason = e.what();
+        handle_general_fail(-1, "Exception caught: " + reason);
+    }
 }
 
 void SSWCP_Instance::sw_Log()
 {
-    {
+    try {
         wxString time = m_param_data.count("time") ? m_param_data["time"].get<wxString>() : "";
         wxString level = m_param_data.count("level") ? m_param_data["level"].get<wxString>() : "";
         wxString module = m_param_data.count("module") ? m_param_data["module"].get<wxString>() : "";
@@ -793,10 +816,13 @@ void SSWCP_Instance::sw_Log()
         finish_job();
 
     }
+    catch (std::exception& e) {
+        finish_job();
+    }
 }
 
 void SSWCP_Instance::sw_GetFileStream() {
-    {
+    try {
         std::string file_path = SSWCP::get_active_filename();
         std::string file_name = SSWCP::get_display_filename();
         if (file_path == "" || file_name == "") {
@@ -891,6 +917,9 @@ void SSWCP_Instance::sw_GetFileStream() {
                 });
             });
         }
+    }
+    catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -1004,7 +1033,7 @@ void SSWCP_Instance::sync_test() {
 }
 
 void SSWCP_Instance::test_mqtt_request() {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -1021,11 +1050,14 @@ void SSWCP_Instance::test_mqtt_request() {
             }
         });
         // host->async_get_printer_info([self](const json& response) { SSWCP_Instance::on_mqtt_msg_arrived(self, response); });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_Instance::sw_SwitchTab() {
-    {        
+    try {
+
         if (m_param_data.count("target")) {
             std::string target_tab = m_param_data["target"].get<std::string>();
             if (SSWCP::m_tab_map.count(target_tab)) {
@@ -1037,11 +1069,13 @@ void SSWCP_Instance::sw_SwitchTab() {
         }        
         handle_general_fail();
     }
-
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_Instance::sw_SetCache() {
-    {
+    try {
         if (m_param_data.count("objects") && m_param_data["objects"].is_array() &&
             m_param_data["objects"].size() > 0) {
             json objects = m_param_data["objects"];
@@ -1056,12 +1090,15 @@ void SSWCP_Instance::sw_SetCache() {
             handle_general_fail();
         }
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 
 }
 
 void SSWCP_Instance::sw_GetCache()
 {
-    {
+    try {
         if (m_param_data.count("keys") && m_param_data["keys"].is_array() && m_param_data["keys"].size() > 0) {
             json res_data;
             json keys = m_param_data["keys"];
@@ -1079,13 +1116,15 @@ void SSWCP_Instance::sw_GetCache()
         } else {
             handle_general_fail();
         }
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 
 void SSWCP_Instance::sw_RemoveCache()
 {
-    {
+    try {
         if (m_param_data.count("keys") && m_param_data["keys"].is_array()) {
             json keys = m_param_data["keys"];
             if (keys.size() == 0) {
@@ -1108,12 +1147,14 @@ void SSWCP_Instance::sw_RemoveCache()
         } else {
             handle_general_fail();
         }
-    } 
+    } catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_Instance::sw_SubscribeCacheKey()
 {
-    {
+    try {
         if (!m_param_data.count("key") || !m_param_data["key"].is_string()) {
             handle_general_fail(-1, "param [keys] required or wrong type");
             return;
@@ -1134,11 +1175,14 @@ void SSWCP_Instance::sw_SubscribeCacheKey()
         std::weak_ptr<SSWCP_Instance> weak_self = shared_from_this();
         cache_map[{m_webview, weak_self}]       = key;
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_Instance::sw_UnsubscribeCacheKeys()
 {
-    {
+    try {
         if (!m_param_data.count("keys") || !m_param_data["keys"].is_array()) {
             handle_general_fail(-1, "param [keys] required or wrong type!");
             return;
@@ -1166,6 +1210,9 @@ void SSWCP_Instance::sw_UnsubscribeCacheKeys()
                 }
             }
         }
+    }
+    catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -1275,7 +1322,7 @@ void SSWCP_Instance::sw_Webview_Unsubscribe() {
 }
 
 void SSWCP_Instance::sw_Unsubscribe_Filter() {
-    {
+    try {
         std::string cmd = m_param_data.count("cmd") ? m_param_data["cmd"].get<std::string>() : "";
         std::string event_id = m_param_data.count("event_id") ? m_param_data["event_id"].get<std::string>() : "";
         if (cmd == "" || event_id == "") {
@@ -1471,6 +1518,9 @@ void SSWCP_Instance::sw_Unsubscribe_Filter() {
         send_to_js();
         finish_job();
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 
@@ -1519,9 +1569,13 @@ void SSWCP_Instance::update_filament_info(const json& objects, bool send_message
             return;
         } else {
             json j_value;
-           
-            j_value = json::parse(value);
-           
+            try {
+                j_value = json::parse(value);
+            } catch (std::exception& e) {
+                if (send_message)
+                    handle_general_fail(-1, "value parse failed");
+                return;
+            }
 
             if (!j_value.count("nozzle_diameters") ||!j_value.count("filament_vendor") || !j_value["filament_vendor"].is_array() ||
                 !j_value.count("filament_type") ||
@@ -1723,10 +1777,10 @@ void SSWCP_MachineFind_Instance::sw_GetMachineFindSupportInfo()
 
 void SSWCP_MachineFind_Instance::sw_WakeupFind()
 {
-    {
+    try {
         // 1) Wide Area Service Browsing: _services._dns-sd._udp.local will work for ~8s
         //    this query causes the AP/switch to build 224.0.0.251:5353 multicast forwarding, prompting the device to issue a notification
-        {
+        try {
             Bonjour::TxtKeys warmup_txt_keys = {};
             auto warmup = Bonjour("services._dns-sd")
                               .set_protocol("udp")
@@ -1737,6 +1791,7 @@ void SSWCP_MachineFind_Instance::sw_WakeupFind()
                               .on_complete([](){})
                               .lookup();
             (void)warmup;
+        } catch (...) {
         }
 
         // the target service queries once every 2 seconds
@@ -1748,6 +1803,7 @@ void SSWCP_MachineFind_Instance::sw_WakeupFind()
                             .on_complete([](){})
                             .lookup();
             (void)kick;
+        } catch (...) {
         }
 
         // query in thread
@@ -1757,12 +1813,15 @@ void SSWCP_MachineFind_Instance::sw_WakeupFind()
         send_to_js();
         finish_job();
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 // Start machine discovery
 void SSWCP_MachineFind_Instance::sw_StartMachineFind()
 {
-    {
+    try {
 
         std::vector<string> protocols;
 
@@ -1931,15 +1990,20 @@ void SSWCP_MachineFind_Instance::sw_StartMachineFind()
             }
         }
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineFind_Instance::sw_StopMachineFind()
 {
-    {
+    try {
         SSWCP::stop_machine_find();
         send_to_js();
         finish_job();
+    }
+    catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -1947,7 +2011,7 @@ void SSWCP_MachineFind_Instance::sw_StopMachineFind()
 
 void SSWCP_MachineFind_Instance::add_machine_to_list(const json& machine_info)
 {
-    {
+    try {
         BOOST_LOG_TRIVIAL(info) << "check the machine list on json: " << machine_info.dump();
         for (const auto& [key, value] : machine_info.items()) {
             std::string sn        = value["sn"].get<std::string>();
@@ -1999,6 +2063,9 @@ void SSWCP_MachineFind_Instance::add_machine_to_list(const json& machine_info)
                 send_to_js();
             }
         }
+    }
+    catch (std::exception& e) {
+
     }
 }
 
@@ -2139,7 +2206,7 @@ void SSWCP_MachineOption_Instance::process()
 }
 
 void SSWCP_MachineOption_Instance::sw_UnSubscribeMachineState() {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2162,11 +2229,13 @@ void SSWCP_MachineOption_Instance::sw_UnSubscribeMachineState() {
         SSWCP::stop_subscribe_machine();
 
 
-    } 
+    } catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_SubscribeMachineState() {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2187,11 +2256,13 @@ void SSWCP_MachineOption_Instance::sw_SubscribeMachineState() {
             }
         });
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_GetPrintInfo() {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2208,10 +2279,13 @@ void SSWCP_MachineOption_Instance::sw_GetPrintInfo() {
             }
         });
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_GetMachineState() {
-    {
+    try {
         if (m_param_data.count("objects")) {
             std::shared_ptr<PrintHost> host = nullptr;
             wxGetApp().get_connect_host(host);
@@ -2249,11 +2323,14 @@ void SSWCP_MachineOption_Instance::sw_GetMachineState() {
         } else {
             handle_general_fail();
         }
+
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_SystemGetDeviceInfo() {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
         if (!host) {
@@ -2269,12 +2346,14 @@ void SSWCP_MachineOption_Instance::sw_SystemGetDeviceInfo() {
             }
         });
 
+    } catch (const std::exception&) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_FileGetStatus()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2291,10 +2370,13 @@ void SSWCP_MachineOption_Instance::sw_FileGetStatus()
             }
         });
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_SendGCodes() {
-    {
+    try {
         if (m_param_data.count("script")) {
             std::shared_ptr<PrintHost> host = nullptr;
             wxGetApp().get_connect_host(host);
@@ -2324,11 +2406,13 @@ void SSWCP_MachineOption_Instance::sw_SendGCodes() {
             });
         }
 
+    } catch (const std::exception&) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_MachinePrintStart() {
-    {
+    try {
         if (m_param_data.count("filename")) {
             std::shared_ptr<PrintHost> host = nullptr;
             wxGetApp().get_connect_host(host);
@@ -2349,11 +2433,14 @@ void SSWCP_MachineOption_Instance::sw_MachinePrintStart() {
             });
         }
     }
+    catch(std::exception& e){
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_MachinePrintPause()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2369,12 +2456,14 @@ void SSWCP_MachineOption_Instance::sw_MachinePrintPause()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_MachinePrintResume()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2390,12 +2479,14 @@ void SSWCP_MachineOption_Instance::sw_MachinePrintResume()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_MachinePrintCancel()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2411,12 +2502,14 @@ void SSWCP_MachineOption_Instance::sw_MachinePrintCancel()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_GetSystemInfo()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2433,11 +2526,14 @@ void SSWCP_MachineOption_Instance::sw_GetSystemInfo()
             }
         });
     }
+    catch(std::exception& e){
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_SetMachineSubscribeFilter()
 {
-    {
+    try {
         if (m_param_data.count("objects")) {
             std::shared_ptr<PrintHost> host = nullptr;
             wxGetApp().get_connect_host(host);
@@ -2475,11 +2571,13 @@ void SSWCP_MachineOption_Instance::sw_SetMachineSubscribeFilter()
             handle_general_fail();
         }
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 void SSWCP_MachineOption_Instance::sw_GetMachineObjects()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2496,12 +2594,14 @@ void SSWCP_MachineOption_Instance::sw_GetMachineObjects()
             }
         });
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_PullCloudFile()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2519,12 +2619,14 @@ void SSWCP_MachineOption_Instance::sw_PullCloudFile()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_UpdateMachineFilamentInfo()
 {
-    {
+    try {
         if (!m_param_data.count("objects") || !m_param_data["objects"].is_array()) {
             handle_general_fail(-1, "param [objects] required or wrong type!");
             return;
@@ -2533,11 +2635,14 @@ void SSWCP_MachineOption_Instance::sw_UpdateMachineFilamentInfo()
         update_filament_info(m_param_data["objects"], true);
 
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_CancelPullCloudFile()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2553,12 +2658,14 @@ void SSWCP_MachineOption_Instance::sw_CancelPullCloudFile()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_StartCloudPrint()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2576,6 +2683,9 @@ void SSWCP_MachineOption_Instance::sw_StartCloudPrint()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    }
+    catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -2629,7 +2739,7 @@ void SSWCP_MachineOption_Instance::sw_MachineHeartbeat()
 
 void SSWCP_MachineOption_Instance::sw_MachineFilesRoots()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -2645,11 +2755,13 @@ void SSWCP_MachineOption_Instance::sw_MachineFilesRoots()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_MachineFilesMetadata() {
-    {
+    try {
         if (m_param_data.count("filename")) {
             std::shared_ptr<PrintHost> host = nullptr;
             wxGetApp().get_connect_host(host);
@@ -2670,13 +2782,16 @@ void SSWCP_MachineOption_Instance::sw_MachineFilesMetadata() {
             });
         } else {
             handle_general_fail();
-        }        
+        }
+
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_MachineFilesThumbnails()
 {
-    {
+    try {
         if (m_param_data.count("filename")) {
             std::shared_ptr<PrintHost> host = nullptr;
             wxGetApp().get_connect_host(host);
@@ -2699,12 +2814,15 @@ void SSWCP_MachineOption_Instance::sw_MachineFilesThumbnails()
         } else {
             handle_general_fail();
         }
+
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_MachineFilesGetDirectory()
 {
-    {
+    try {
         if (m_param_data.count("path") && m_param_data.count("extended")) {
             std::shared_ptr<PrintHost> host = nullptr;
             wxGetApp().get_connect_host(host);
@@ -2728,12 +2846,14 @@ void SSWCP_MachineOption_Instance::sw_MachineFilesGetDirectory()
             handle_general_fail();
         }
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_ServerClientManagerSetUserinfo()
 {
-    {
+    try {
         if (!m_param_data.count("auther")) {
             handle_general_fail(-1, "param [auther] is required");
             return;
@@ -2764,11 +2884,14 @@ void SSWCP_MachineOption_Instance::sw_ServerClientManagerSetUserinfo()
         });
 
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_FinishPreprint()
 {
-    {
+    try {
         if (m_param_data.count("status")) {
             std::string status = m_param_data["status"].get<std::string>();
 
@@ -2786,11 +2909,14 @@ void SSWCP_MachineOption_Instance::sw_FinishPreprint()
 
         handle_general_fail();
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_GetPrintZip()
 {
-    {
+    try {
         auto oriname = SSWCP::get_active_filename();
         auto targetname = SSWCP::get_display_filename();
 
@@ -2818,11 +2944,14 @@ void SSWCP_MachineOption_Instance::sw_GetPrintZip()
         });
 
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_GetPrintLegal()
 {
-    {
+    try {
         if (m_param_data.count("connected_model")) {
             std::string connected_model = m_param_data["connected_model"].get<std::string>();
             const auto& edit_preset     = wxGetApp().preset_bundle->printers.get_edited_preset();
@@ -2847,10 +2976,13 @@ void SSWCP_MachineOption_Instance::sw_GetPrintLegal()
 
         handle_general_fail();
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_UploadFiletoMachine() {
-    {
+    try {
         if (!m_param_data.count("url")) {
             handle_general_fail();
             return;
@@ -2893,7 +3025,7 @@ void SSWCP_MachineOption_Instance::sw_UploadFiletoMachine() {
                     });
                 })
                 .on_complete([=](std::string body, unsigned) {
-                    {
+                    try {
                         wxGetApp().CallAfter([=]() {
                             json response;
                             response["filename"] = std::string(filename.ToUTF8());
@@ -2906,6 +3038,8 @@ void SSWCP_MachineOption_Instance::sw_UploadFiletoMachine() {
                             msg_window.ShowModal();
                             finish_job();
                         });
+                    } catch (std::exception& e) {
+                        handle_general_fail();
                     }
                 })
                 .on_progress([&](Http::Progress progress, bool& cancel) {
@@ -2914,10 +3048,13 @@ void SSWCP_MachineOption_Instance::sw_UploadFiletoMachine() {
                 .perform();
         });
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_DownloadMachineFile() {
-    {
+    try {
         if (!m_param_data.count("url")) {
             handle_general_fail();
             return;
@@ -2982,7 +3119,7 @@ void SSWCP_MachineOption_Instance::sw_DownloadMachineFile() {
                     });
                 })
                 .on_complete([=](std::string body, unsigned) {
-                    {
+                    try {
                         boost::nowide::ofstream file(path.ToStdString(wxConvUTF8), std::ios::binary);
                         if (!file.is_open()) {
                             BOOST_LOG_TRIVIAL(error) << "Failed to open file for writing: " << path;
@@ -2997,6 +3134,8 @@ void SSWCP_MachineOption_Instance::sw_DownloadMachineFile() {
                                                      _L("DownLoad Successfully"), wxICON_QUESTION | wxOK);
                             msg_window.ShowModal();
                         });
+                    } catch (std::exception& e) {
+                        handle_general_fail();
                     }
                 })
                 .on_progress([&](Http::Progress progress, bool& cancel) {
@@ -3004,12 +3143,14 @@ void SSWCP_MachineOption_Instance::sw_DownloadMachineFile() {
                 })
                 .perform();
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_FinishFilamentMapping()
 {
-    {
+    try {
         if (wxGetApp().get_web_preprint_dialog()) {
             WebPreprintDialog* dialog = dynamic_cast<WebPreprintDialog*>(wxGetApp().get_web_preprint_dialog());
             if (dialog) {
@@ -3021,11 +3162,13 @@ void SSWCP_MachineOption_Instance::sw_FinishFilamentMapping()
                 }
             }
         }
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 void SSWCP_MachineOption_Instance::sw_GetFileFilamentMapping()
 {
-    {
+    try {
         std::string filename = m_param_data.count("filename") ? m_param_data["filename"].get<std::string>() : "";
 
         if (filename == "") {
@@ -3281,12 +3424,14 @@ void SSWCP_MachineOption_Instance::sw_GetFileFilamentMapping()
         send_to_js();
         finish_job();
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_SetFilamentMappingComplete()
 {
-    {
+    try {
         if (!m_param_data.count("status")) {
             handle_general_fail();
         }
@@ -3316,10 +3461,13 @@ void SSWCP_MachineOption_Instance::sw_SetFilamentMappingComplete()
         send_to_js();
         finish_job();
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineOption_Instance::sw_CameraStartMonitor() {
-    {
+    try {
         if (m_param_data.count("domain")) {
             std::shared_ptr<PrintHost> host = nullptr;
             wxGetApp().get_connect_host(host);
@@ -3346,11 +3494,13 @@ void SSWCP_MachineOption_Instance::sw_CameraStartMonitor() {
             handle_general_fail();
         }
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_DeleteMachineFile() {
-    {
+    try {
         if(!m_param_data.count("path")){
             handle_general_fail(-1, "param [path] required!");
             return;
@@ -3374,11 +3524,13 @@ void SSWCP_MachineOption_Instance::sw_DeleteMachineFile() {
             }
         });
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_CameraStopMonitor() {
-    {
+    try {
         if (m_param_data.count("domain")) {
             std::shared_ptr<PrintHost> host = nullptr;
             wxGetApp().get_connect_host(host);
@@ -3401,12 +3553,14 @@ void SSWCP_MachineOption_Instance::sw_CameraStopMonitor() {
             handle_general_fail();
         }
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_SetDeviceName()
 {
-    {
+    try {
         if (m_param_data.count("name")) {
             std::string name = m_param_data["name"].get<std::string>();
 
@@ -3428,12 +3582,14 @@ void SSWCP_MachineOption_Instance::sw_SetDeviceName()
         } else {
             handle_general_fail(-1, "param [name] required!");
         }
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_ControlLed()
 {
-    {
+    try {
         if (!m_param_data.count("name")) {
             handle_general_fail(-1, "param [name] required!");
             return;
@@ -3462,12 +3618,14 @@ void SSWCP_MachineOption_Instance::sw_ControlLed()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_ControlPrintSpeed()
 {
-    {
+    try {
         if (!m_param_data.count("percentage")) {
             handle_general_fail(-1, "param [percentage] required!");
             return;
@@ -3490,12 +3648,14 @@ void SSWCP_MachineOption_Instance::sw_ControlPrintSpeed()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_BedMesh_AbortProbeMesh()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -3511,6 +3671,8 @@ void SSWCP_MachineOption_Instance::sw_BedMesh_AbortProbeMesh()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -3536,7 +3698,7 @@ void SSWCP_MachineOption_Instance::sw_ControlPurifier()
 
 void SSWCP_MachineOption_Instance::sw_ControlMainFan()
 {
-    {
+    try {
         if (!m_param_data.count("speed")) {
             handle_general_fail(-1, "param [speed] required!");
             return;
@@ -3559,12 +3721,14 @@ void SSWCP_MachineOption_Instance::sw_ControlMainFan()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_ControlGenericFan()
 {
-    {
+    try {
         if (!m_param_data.count("name")) {
             handle_general_fail(-1, "param [fan_id] required!");
             return;
@@ -3593,13 +3757,15 @@ void SSWCP_MachineOption_Instance::sw_ControlGenericFan()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 
 void SSWCP_MachineOption_Instance::sw_ControlBedTemp()
 {
-    {
+    try {
         if (!m_param_data.count("temp")) {
             handle_general_fail(-1, "param [temp] required!");
             return;
@@ -3622,12 +3788,14 @@ void SSWCP_MachineOption_Instance::sw_ControlBedTemp()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_ControlExtruderTemp()
 {
-    {
+    try {
         if (!m_param_data.count("temp")) {
             handle_general_fail(-1, "param [temp] required!");
             return;
@@ -3653,12 +3821,14 @@ void SSWCP_MachineOption_Instance::sw_ControlExtruderTemp()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_FilesThumbnailsBase64()
 {
-    {
+    try {
         if (!m_param_data.count("path")) {
             handle_general_fail(-1, "param [path] required");
             return;
@@ -3682,12 +3852,14 @@ void SSWCP_MachineOption_Instance::sw_FilesThumbnailsBase64()
             }
         });
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_UploadCameraTimelapse()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -3703,6 +3875,9 @@ void SSWCP_MachineOption_Instance::sw_UploadCameraTimelapse()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    }
+    catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 void SSWCP_MachineOption_Instance::sw_UploadAsyncTimelapseInstance()
@@ -3725,7 +3900,7 @@ void SSWCP_MachineOption_Instance::sw_UploadAsyncTimelapseInstance()
 }
 void SSWCP_MachineOption_Instance::CmdForwarding()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -3741,12 +3916,14 @@ void SSWCP_MachineOption_Instance::CmdForwarding()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_GetCameraTimelapseInstance()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -3763,10 +3940,14 @@ void SSWCP_MachineOption_Instance::sw_GetCameraTimelapseInstance()
             }
         });
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 void SSWCP_MachineOption_Instance::sw_GetDeviceDataStorageSpace()
 {
-    {
+
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -3782,6 +3963,8 @@ void SSWCP_MachineOption_Instance::sw_GetDeviceDataStorageSpace()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -3791,7 +3974,7 @@ namespace { void cancel_active_timelapse_by_date_index(const std::string& date_i
 
 void SSWCP_MachineOption_Instance::sw_DeleteCameraTimelapse()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -3814,12 +3997,14 @@ void SSWCP_MachineOption_Instance::sw_DeleteCameraTimelapse()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineOption_Instance::sw_DefectDetactionConfig()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -3835,6 +4020,8 @@ void SSWCP_MachineOption_Instance::sw_DefectDetactionConfig()
                 SSWCP_Instance::on_mqtt_msg_arrived(self, response);
             }
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -3860,7 +4047,7 @@ void SSWCP_MachineOption_Instance::sw_PrinterDefectDetection()
 
 void SSWCP_MachineOption_Instance::sw_GetFileListPage()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -3896,13 +4083,15 @@ void SSWCP_MachineOption_Instance::sw_GetFileListPage()
             }
         });
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 
 void SSWCP_MachineOption_Instance::sw_exception_query()
 {
-    {
+    try {
         std::shared_ptr<PrintHost> host = nullptr;
         wxGetApp().get_connect_host(host);
 
@@ -3919,6 +4108,8 @@ void SSWCP_MachineOption_Instance::sw_exception_query()
             }
         });
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -3952,7 +4143,7 @@ void SSWCP_MachineConnect_Instance::process() {
 
 void SSWCP_MachineConnect_Instance::sw_get_pin_code()
 {
-    {
+    try {
         if (m_param_data.count("ip") && m_param_data.count("userid") && m_param_data.count("nickname")) {
             std::string ip = m_param_data["ip"].get<std::string>();
             std::string userid    = m_param_data["userid"].get<std::string>();
@@ -4010,12 +4201,14 @@ void SSWCP_MachineConnect_Instance::sw_get_pin_code()
         } else {
             handle_general_fail();
         }
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 
 void SSWCP_MachineConnect_Instance::sw_connect_other_device() {
-    {
+    try {
         auto weak_self = std::weak_ptr<SSWCP_Instance>(shared_from_this());
         wxGetApp().CallAfter([weak_self](){
 
@@ -4043,10 +4236,13 @@ void SSWCP_MachineConnect_Instance::sw_connect_other_device() {
 
         });
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineConnect_Instance::sw_test_connect() {
-    {
+    try {
         if (m_param_data.count("ip")) {
             std::string protocol = "moonraker";
 
@@ -4092,6 +4288,8 @@ void SSWCP_MachineConnect_Instance::sw_test_connect() {
             
             finish_job();
         }
+    } catch (const std::exception&) {
+        handle_general_fail();
     }
 }
 
@@ -4100,7 +4298,7 @@ void SSWCP_MachineConnect_Instance::sw_connect() {
 }
 
 void SSWCP_MachineConnect_Instance::sw_get_connect_machine() {
-    {
+    try {
         auto devices = wxGetApp().app_config->get_devices();
         for (const auto& device : devices) {
             if (device.connected) {
@@ -4111,6 +4309,9 @@ void SSWCP_MachineConnect_Instance::sw_get_connect_machine() {
 
         send_to_js();
         finish_job();
+    }
+    catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -4201,13 +4402,13 @@ void SSWCP_SliceProject_Instance::process()
 
 void SSWCP_SliceProject_Instance::sw_NewProject()
 {
-    { 
+    try {
         if (!m_param_data.count("preset_name") || m_param_data["preset_name"].get<std::string>() == "")
             wxGetApp().request_open_project("<new>");
         else {
             std::string preset_name = m_param_data["preset_name"].get<std::string>();
             wxGetApp().CallAfter([this, preset_name]() {
-                {
+                try {
                     if (wxGetApp().get_tab(Preset::TYPE_PRINTER)->select_preset(preset_name)) {
                         wxGetApp().plater()->new_project();
                     } else {
@@ -4216,26 +4417,33 @@ void SSWCP_SliceProject_Instance::sw_NewProject()
                         msg_window.ShowModal();
                     }
 
+                } catch (std::exception& e) {
                 }
             });
         }
         send_to_js();
         finish_job();
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_SliceProject_Instance::sw_OpenProject()
 {
-    {
+    try {
         wxGetApp().request_open_project({});
         send_to_js();
         finish_job();
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_SliceProject_Instance::sw_GetRecentProjects()
 {
-    {        
+    try {
+
         json data;
         wxGetApp().mainframe->get_recent_projects(data, INT_MAX);
 
@@ -4243,12 +4451,14 @@ void SSWCP_SliceProject_Instance::sw_GetRecentProjects()
 
         send_to_js();
         finish_job();
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_SliceProject_Instance::sw_OpenRecentFile()
 {
-    {
+    try {
         if (m_param_data.count("path")) {
             std::string path = m_param_data["path"].get<std::string>();
             if (path != "") {
@@ -4263,12 +4473,14 @@ void SSWCP_SliceProject_Instance::sw_OpenRecentFile()
         }
         send_to_js();
         finish_job();
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_SliceProject_Instance::sw_DeleteRecentFiles()
 {
-    {
+    try {
         if (m_param_data.count("paths") && m_param_data["paths"].is_array()) {
             auto paths = m_param_data["paths"];
             send_to_js();
@@ -4286,13 +4498,19 @@ void SSWCP_SliceProject_Instance::sw_DeleteRecentFiles()
         }
 
         finish_job();
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_SliceProject_Instance::sw_SubscribeRecentFiles()
 {
-    auto weak_self = std::weak_ptr<SSWCP_Instance>(shared_from_this());
-    wxGetApp().m_recent_file_subscribers[m_webview] = weak_self;
+    try {
+        auto weak_self = std::weak_ptr<SSWCP_Instance>(shared_from_this());
+        wxGetApp().m_recent_file_subscribers[m_webview] = weak_self;
+    } catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 // SSWCP_UserLogin_Instance
@@ -4343,7 +4561,7 @@ void SSWCP_UserLogin_Instance::process()
 }
 void SSWCP_UserLogin_Instance::sw_UserLogin()
 {
-    {
+    try {
         send_to_js();
         finish_job();
         bool show = m_param_data.count("show") ? m_param_data["show"].get<bool>() : true;
@@ -4352,20 +4570,25 @@ void SSWCP_UserLogin_Instance::sw_UserLogin()
             wxGetApp().sm_request_login(show);
         });               
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_UserLogin_Instance::sw_UserLogout()
 {
-    {
+    try {
         send_to_js();
         wxGetApp().sm_request_user_logout();
         finish_job();
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_UserLogin_Instance::sw_GetUserLoginState()
 {
-    {
+    try {
         json data;
         auto pInfo = wxGetApp().sm_get_userinfo();
         if (pInfo) {
@@ -4388,6 +4611,9 @@ void SSWCP_UserLogin_Instance::sw_GetUserLoginState()
             handle_general_fail();
         }
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 void SSWCP_UserLogin_Instance::sw_GetUserUpdatePrivacy()
 {
@@ -4408,7 +4634,7 @@ void SSWCP_UserLogin_Instance::sw_GetUserUpdatePrivacy()
 
 void SSWCP_UserLogin_Instance::sw_DownloadFileAndOpen()
 {
-    {
+    try {
         std::string fileName = m_param_data.count("file_name") ? m_param_data["file_name"].get<std::string>() : "";
         std::string fileUrl  = m_param_data.count("file_url") ? m_param_data["file_url"].get<std::string>() : "";
 
@@ -4434,20 +4660,24 @@ void SSWCP_UserLogin_Instance::sw_DownloadFileAndOpen()
                 self->handle_general_fail(-1, wxString::FromUTF8("Main window not available"));
                 return;
             }
-            {
+            try {
                 wxGetApp().mainframe->downloadOpenProject(fileUrl, fileName, "");
                 self->m_status = 0;
                 self->m_msg    = "success";
                 self->send_to_js();
                 self->finish_job();
+            } catch (const std::exception& e) {
+                self->handle_general_fail(-1, wxString::FromUTF8(e.what()));
             }
         });
 
+    } catch (const std::exception& e) {
+        handle_general_fail(-1, wxString::FromUTF8(e.what()));
     }
 }
 
 void SSWCP_UserLogin_Instance::sw_DownloadFileEx() {
-    {
+    try {
         std::string fileName = m_param_data.count("file_name") ? m_param_data["file_name"].get<std::string>() : "";
         std::string fileUrl  = m_param_data.count("file_url") ? m_param_data["file_url"].get<std::string>() : "";
 
@@ -4476,6 +4706,8 @@ void SSWCP_UserLogin_Instance::sw_DownloadFileEx() {
         m_msg = "success";
         send_to_js();
 
+    } catch (std::exception& e) {
+        handle_general_fail(-1, e.what());
     }
 }
 
@@ -5629,7 +5861,7 @@ void SSWCP_UserLogin_Instance::sw_CancelDownload() {
 }
 
 void SSWCP_UserLogin_Instance::sw_FileView() {
-    {
+    try {
         std::string file_path = m_param_data.count("file_path") ? m_param_data["file_path"].get<std::string>() : "";
         wxFileName  file(wxString::FromUTF8(file_path));
 
@@ -5654,6 +5886,8 @@ void SSWCP_UserLogin_Instance::sw_FileView() {
             self->finish_job();
 
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -5752,14 +5986,24 @@ void SSWCP_UserLogin_Instance::sw_GetFilesFromDir()
 
 void SSWCP_UserLogin_Instance::sw_SubUserUpdatePrivacy()
 {
-    std::weak_ptr<SSWCP_Instance> weak_ptr         = shared_from_this();
-    wxGetApp().m_user_update_privacy_subscribers[m_webview] = weak_ptr;
+    try {
+        std::weak_ptr<SSWCP_Instance> weak_ptr         = shared_from_this();
+        wxGetApp().m_user_update_privacy_subscribers[m_webview] = weak_ptr;
+    } catch (std::exception& e) {
+        handle_general_fail();
+    }
+
 }
 
 void SSWCP_UserLogin_Instance::sw_SubscribeUserLoginState()
 {
-    std::weak_ptr<SSWCP_Instance> weak_ptr = shared_from_this();
-    wxGetApp().m_user_login_subscribers[m_webview]  = weak_ptr;
+    try {
+        std::weak_ptr<SSWCP_Instance> weak_ptr = shared_from_this();
+        wxGetApp().m_user_login_subscribers[m_webview]  = weak_ptr;
+    }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 // SSWCP_MachineManage_Instance
@@ -5792,19 +6036,27 @@ void SSWCP_MachineManage_Instance::process()
 
 void SSWCP_MachineManage_Instance::sw_GetLocalDevices()
 {
-    {
+    try {
         auto devices = wxGetApp().app_config->get_devices();
         m_res_data = devices;
 
         send_to_js();
         finish_job();
     }
+    catch (std::exception& e)
+    {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MachineManage_Instance::sw_SubscribeLocalDevices()
-{    
-    auto self = shared_from_this();
-    wxGetApp().m_device_card_subscribers[m_webview] = self;
+{
+    try {
+        auto self = shared_from_this();
+        wxGetApp().m_device_card_subscribers[m_webview] = self;
+    } catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 // SSWCP_PageStateChange_Instance
@@ -5829,13 +6081,17 @@ void SSWCP_PageStateChange_Instance::process()
 
 void SSWCP_PageStateChange_Instance::sw_SubscribePageStateChange()
 {
-    auto self = shared_from_this();
-    wxGetApp().m_page_state_subscribers[m_webview] = self;
+    try {
+        auto self = shared_from_this();
+        wxGetApp().m_page_state_subscribers[m_webview] = self;
+    } catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_PageStateChange_Instance::sw_UnsubscribePageStateChange()
 {
-    {
+    try {
         auto& page_state_map = wxGetApp().m_page_state_subscribers;
         std::string event_id = m_param_data.count("event_id") ? m_param_data["event_id"].get<std::string>() : "";
 
@@ -5858,12 +6114,14 @@ void SSWCP_PageStateChange_Instance::sw_UnsubscribePageStateChange()
 
         send_to_js();
         finish_job();
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineManage_Instance::sw_AddDevice()
 {
-    {
+    try {
         wxGetApp().CallAfter([] {
             if (wxGetApp().web_device_dialog)
                 delete wxGetApp().web_device_dialog;
@@ -5874,12 +6132,14 @@ void SSWCP_MachineManage_Instance::sw_AddDevice()
         send_to_js();
 
         finish_job();
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineManage_Instance::sw_RenameDevice()
 {
-    {
+    try {
         if (m_param_data.count("dev_id") && m_param_data.count("dev_name")) {
             std::string dev_id = m_param_data["dev_id"].get<std::string>();
             std::string dev_name = m_param_data["dev_name"].get<std::string>();
@@ -5901,12 +6161,14 @@ void SSWCP_MachineManage_Instance::sw_RenameDevice()
         } else {
             handle_general_fail();
         }
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineManage_Instance::sw_DeleteDevices()
 {
-    {
+    try {
         if (m_param_data.count("dev_ids") && m_param_data["dev_ids"].is_array()) {
             auto ids = m_param_data["dev_ids"];
             if (ids.size() == 0) {
@@ -5953,12 +6215,14 @@ void SSWCP_MachineManage_Instance::sw_DeleteDevices()
         } else {
             handle_general_fail();
         }
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MachineManage_Instance::sw_SwitchModel()
 {
-    {
+    try {
         if (m_param_data.count("dev_id")) {
             std::string dev_id = m_param_data["dev_id"].get<std::string>();
             send_to_js();
@@ -5972,6 +6236,8 @@ void SSWCP_MachineManage_Instance::sw_SwitchModel()
         } else {
             handle_general_fail();
         }
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -6095,7 +6361,7 @@ void SSWCP_MqttAgent_Instance::mqtt_msg_cb(const std::string& topic, const std::
 
 void SSWCP_MqttAgent_Instance::sw_create_mqtt_client()
 {
-    {
+    try {
         std::string server_address = "";
         std::string clientId       = "";
         std::string ca             = "";
@@ -6174,13 +6440,15 @@ void SSWCP_MqttAgent_Instance::sw_create_mqtt_client()
         send_to_js();
         finish_job();
 
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 // mqtt connect
 void SSWCP_MqttAgent_Instance::sw_mqtt_connect()
 {
-    {
+    try {
         if (!m_param_data.count("id") || !m_param_data["id"].is_string()) {
             handle_general_fail(-1, "param [id] is required or wrong type");
 
@@ -6230,13 +6498,16 @@ void SSWCP_MqttAgent_Instance::sw_mqtt_connect()
             });
         });
 
+
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 
 void SSWCP_MqttAgent_Instance::sw_mqtt_disconnect()
 {
-    {
+    try {
         if (!m_param_data.count("id") || !m_param_data["id"].is_string()) {
             handle_general_fail(-1, "param [id] is required or wrong type");
             return;
@@ -6277,12 +6548,15 @@ void SSWCP_MqttAgent_Instance::sw_mqtt_disconnect()
                 }
             });
         });
-    }    
+    }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MqttAgent_Instance::sw_mqtt_subscribe()
 {
-    {
+    try {
         if (!m_param_data.count("id") || !m_param_data["id"].is_string()) {
             handle_general_fail(-1, "param [id] is required or wrong type");
             Slic3r::sentryReportLog(Slic3r::SENTRY_LOG_ERROR, std::string("device_subscribe param [id] is required or wrong type"), DEVICE_SUBSCRIBE_ERR);
@@ -6361,10 +6635,13 @@ void SSWCP_MqttAgent_Instance::sw_mqtt_subscribe()
             });
         });
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MqttAgent_Instance::sw_mqtt_unsubscribe() {
-    {
+    try {
         if (!m_param_data.count("id") || !m_param_data["id"].is_string()) {
             handle_general_fail(-1, "param [id] is required or wrong type");
             return;
@@ -6423,12 +6700,14 @@ void SSWCP_MqttAgent_Instance::sw_mqtt_unsubscribe() {
                 }
             });
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
 void SSWCP_MqttAgent_Instance::sw_mqtt_set_engine()
 {
-    {
+    try {
         if (!m_param_data.count("engine_id") || !m_param_data["engine_id"].is_string()) {
             handle_general_fail(-1, "param [engine_id] is required or wrong type");
             Slic3r::sentryReportLog(Slic3r::SENTRY_LOG_ERROR, std::string("device_set_engine param [engine_id] is required or wrong type"),DEVICE_SET_ENGINE_ERR);
@@ -7001,11 +7280,14 @@ void SSWCP_MqttAgent_Instance::sw_mqtt_set_engine()
         }
 
     }
+    catch (std::exception& e) {
+        handle_general_fail();
+    }
 }
 
 void SSWCP_MqttAgent_Instance::sw_mqtt_publish()
 {
-    {
+    try {
         if (!m_param_data.count("id") || !m_param_data["id"].is_string()) {
             handle_general_fail(-1, "param [id] is required or wrong type");
             Slic3r::sentryReportLog(Slic3r::SENTRY_LOG_ERROR, std::string("device_publish host created failed"), DEVICE_PBLISH_ERR);
@@ -7070,6 +7352,8 @@ void SSWCP_MqttAgent_Instance::sw_mqtt_publish()
                 }
             });
         });
+    } catch (std::exception& e) {
+        handle_general_fail();
     }
 }
 
@@ -7229,7 +7513,7 @@ std::shared_ptr<SSWCP_Instance> SSWCP::create_sswcp_instance(std::string cmd, co
 
 // Handle incoming web messages
 void SSWCP::handle_web_message(std::string message, wxWebView* webview) {
-    {
+    try {        
 
         if (!webview) {
             return;
@@ -7269,6 +7553,8 @@ void SSWCP::handle_web_message(std::string message, wxWebView* webview) {
             instance->process();
         }
 
+    }
+    catch (std::exception& e) {
     }
 }
 
@@ -7533,7 +7819,7 @@ bool SSWCP::query_machine_info(std::shared_ptr<PrintHost>& host, std::string& ou
 
                 // get diameter
                 if(product_info.contains("nozzle_diameter")){
-                    {
+                    try {
                         if (product_info["nozzle_diameter"].is_array()) {
                             for (const auto& nozzle : product_info["nozzle_diameter"]) {
                                 // todo not sure is string
@@ -7577,6 +7863,9 @@ bool SSWCP::query_machine_info(std::shared_ptr<PrintHost>& host, std::string& ou
                                 }
                             }
                         }
+                    }
+                    catch (std::exception& e) {
+                        return false;
                     }
                 }
                 if (product_info.contains("device_name")) {

--- a/src/slic3r/GUI/WebGuideDialog.cpp
+++ b/src/slic3r/GUI/WebGuideDialog.cpp
@@ -1411,7 +1411,7 @@ int GuideFrame::LoadProfileFamily(std::string strVendor, std::string strFilePath
 
                 int nRet = GetFilamentInfo(vendor_dir.string(), tFilaList_ro, sub_file, sV, sT);
                 if (nRet != 0) {
-                    BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << "Load Filament:" << s1 << ",GetFilamentInfo Failed, Vendor:" << sV << ",Type:"<< sT;
+                    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << "Load Filament:" << s1 << ",GetFilamentInfo Failed, Vendor:" << sV << ",Type:"<< sT;
                     return;
                 }
 

--- a/src/slic3r/GUI/WebPresetDialog.cpp
+++ b/src/slic3r/GUI/WebPresetDialog.cpp
@@ -1529,7 +1529,7 @@ int WebPresetDialog::LoadProfileFamily(std::string strVendor, std::string strFil
 
                 int nRet = GetFilamentInfo(vendor_dir.string(), tFilaList_ro, sub_file, sV, sT);
                 if (nRet != 0) {
-                    BOOST_LOG_TRIVIAL(error)
+                    BOOST_LOG_TRIVIAL(info)
                         << __FUNCTION__ << "Load Filament:" << s1 << ",GetFilamentInfo Failed, Vendor:" << sV << ",Type:" << sT;
                     return;
                 }

--- a/src/slic3r/Utils/MQTT.cpp
+++ b/src/slic3r/Utils/MQTT.cpp
@@ -25,7 +25,7 @@ bool is_soft_disconnect_error(const mqtt::exception& e)
 MqttClient::MqttClient(const std::string& server_address, const std::string& client_id, const std::string& username, const std::string& password,  bool clean_session)
     : server_address_(server_address)
     , client_id_(client_id)
-    , client_(std::make_unique<mqtt::async_client>(server_address_, client_id_))
+    , client_(nullptr)
     , connOpts_()
     , subListener_("Subscription")
     , connected_(false)            
@@ -36,20 +36,27 @@ MqttClient::MqttClient(const std::string& server_address, const std::string& cli
 {
     BOOST_LOG_TRIVIAL(info) << "[MQTT_INFO] initializing MQTT connection, server_address: " << server_address << ", client_id: " << client_id;
 
-    // Configure connection options    
-    connOpts_.set_clean_session(false);
-    connOpts_.set_keep_alive_interval(30);
-    connOpts_.set_connect_timeout(10);
-    // auto-reconnect enabled only after first successful connection
-    connOpts_.set_automatic_reconnect(std::chrono::seconds(0), std::chrono::seconds(0));
-    client_->set_callback(*this);
+    try {
+        client_ = std::make_unique<mqtt::async_client>(server_address_, client_id_);
 
-    // set authentication info
-    if (!username.empty()) {
-        connOpts_.set_user_name(username);
-        if (!password.empty()) {
-            connOpts_.set_password(password);
+        // Configure connection options    
+        connOpts_.set_clean_session(false);
+        connOpts_.set_keep_alive_interval(30);
+        connOpts_.set_connect_timeout(10);
+        // auto-reconnect enabled only after first successful connection
+        connOpts_.set_automatic_reconnect(std::chrono::seconds(0), std::chrono::seconds(0));
+        client_->set_callback(*this);
+
+        // set authentication info
+        if (!username.empty()) {
+            connOpts_.set_user_name(username);
+            if (!password.empty()) {
+                connOpts_.set_password(password);
+            }
         }
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] MQTT client construction failed: " << e.what();
+        client_.reset();
     }
 }
 
@@ -67,6 +74,11 @@ MqttClient::MqttClient(const std::string& server_address,
     BOOST_LOG_TRIVIAL(info) << "[MQTT_INFO] initializing MQTT SSL connection, server_address: " << server_address << ", client_id: " << client_id
                             << ", ca_content: " << ca_content << ", cert_content: " << cert_content << ", username: " << username
                             << ", password: " << password;
+
+    if (!client_) {
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] skip SSL initialization because MQTT client was not created";
+        return;
+    }
     
     try {
         boost::filesystem::path temp_dir = boost::filesystem::temp_directory_path();
@@ -127,7 +139,7 @@ MqttClient::MqttClient(const std::string& server_address,
     } catch (const std::exception& e) {
         cleanup_temp_files();
         BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] MQTT SSL initialization failed: " << e.what();
-        throw;
+        client_.reset();
     }
 }
 
@@ -142,7 +154,14 @@ bool MqttClient::Connect(std::string& msg)
         return true;
     }
 
-    {                        
+    if (!client_) {
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] Cannot connect: MQTT client pointer is null";
+        msg = "MQTT client is null";
+        connected_.store(false, std::memory_order_release);
+        return false;
+    }
+
+    try {
          {
             auto ssl_opts = connOpts_.get_ssl_options();
             BOOST_LOG_TRIVIAL(debug) << "[MQTT_INFO] SSL config info:"
@@ -194,6 +213,18 @@ bool MqttClient::Connect(std::string& msg)
         BOOST_LOG_TRIVIAL(info) << "[MQTT_INFO] Successfully connected to MQTT server";
         msg = "success";
         return true;
+    } catch (const mqtt::exception& exc) {
+        connected_.store(false, std::memory_order_release);
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] MQTT exception during connect: " << exc.what()
+                                << ", Return code: " << exc.get_return_code()
+                                << ", Message: " << exc.get_message();
+        msg = std::string(exc.what()) + ";" + exc.get_reason_code_str() + ";" + exc.get_message();
+        return false;
+    } catch (const std::exception& e) {
+        connected_.store(false, std::memory_order_release);
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] General exception during connect: " << e.what();
+        msg = std::string(e.what());
+        return false;
     }
 }
 
@@ -227,6 +258,10 @@ bool MqttClient::Disconnect(std::string& msg)
                                  << ", rc=" << e.get_return_code();
         msg = e.what();
         return false;
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] General exception during disconnect: " << e.what();
+        msg = e.what();
+        return false;
     }
 
     BOOST_LOG_TRIVIAL(info) << "[MQTT_INFO] Disconnect completed";
@@ -247,7 +282,7 @@ bool MqttClient::Subscribe(const std::string& topic, int qos, std::string& msg)
         return false;
     }
 
-    {
+    try {
         BOOST_LOG_TRIVIAL(info) << "[MQTT_INFO] Subscribing to MQTT topic '" << topic << "' with QoS " << qos;
         mqtt::token_ptr subtok = client_->subscribe(topic, qos, nullptr, subListener_);
         if (!subtok->wait_for(std::chrono::seconds(5))) {
@@ -258,6 +293,14 @@ bool MqttClient::Subscribe(const std::string& topic, int qos, std::string& msg)
         add_topic_to_resubscribe(topic, qos);
         msg = "success";
         return true;
+    } catch (const mqtt::exception& exc) {
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] Error subscribing to topic '" << topic << "': " << exc.what();
+        msg = "Error: " + std::string(exc.what());
+        return false;
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] General exception subscribing to topic '" << topic << "': " << e.what();
+        msg = "Error: " + std::string(e.what());
+        return false;
     }
 }
 
@@ -272,7 +315,7 @@ bool MqttClient::Unsubscribe(const std::string& topic, std::string& msg)
         return false;
     }
 
-    {
+    try {
         BOOST_LOG_TRIVIAL(info) << "[MQTT_INFO] Unsubscribing from MQTT topic '" << topic << "'";
         mqtt::token_ptr unsubtok = client_->unsubscribe(topic);
         if (!unsubtok->wait_for(std::chrono::seconds(5))) {
@@ -283,6 +326,14 @@ bool MqttClient::Unsubscribe(const std::string& topic, std::string& msg)
         remove_topic_from_resubscribe(topic);
         msg = "success";
         return true;
+    } catch (const mqtt::exception& exc) {
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] Error unsubscribing from topic '" << topic << "': " << exc.what();
+        msg = "Error unsubscribing from topic: " + std::string(exc.what());
+        return false;
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] General exception unsubscribing from topic '" << topic << "': " << e.what();
+        msg = "Error unsubscribing from topic: " + std::string(e.what());
+        return false;
     }
 }
 
@@ -298,10 +349,10 @@ bool MqttClient::Publish(const std::string& topic, const std::string& payload, i
         return false;
     }
 
-    mqtt::message_ptr pubmsg = mqtt::make_message(topic, payload);
-    pubmsg->set_qos(qos);
+    try {
+        mqtt::message_ptr pubmsg = mqtt::make_message(topic, payload);
+        pubmsg->set_qos(qos);
 
-    {
         BOOST_LOG_TRIVIAL(debug) << "[MQTT_INFO] Publishing message to topic '" << topic << "' with QoS " << qos;
         mqtt::token_ptr pubtok = client_->publish(pubmsg);
         /*if (!pubtok->wait_for(std::chrono::seconds(5))) {
@@ -310,7 +361,15 @@ bool MqttClient::Publish(const std::string& topic, const std::string& payload, i
         }*/
         msg = "success";
         return true;
-    } 
+    } catch (const mqtt::exception& exc) {
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] Error publishing to topic '" << topic << "': " << exc.what();
+        msg = "error: " + std::string(exc.what());
+        return false;
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] General exception publishing to topic '" << topic << "': " << e.what();
+        msg = "error: " + std::string(e.what());
+        return false;
+    }
 }
 
 // Set callback function for handling incoming messages
@@ -331,35 +390,39 @@ void MqttClient::SetMessageCallback(std::function<void(const std::string& topic,
 // @return: true if connected, false otherwise
 bool MqttClient::CheckConnected()
 {
-    if (!connected_.load(std::memory_order_acquire)) {
-        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] MQTT client is not connected to server";
-        return false;
-    }
+    try {
+        if (!connected_.load(std::memory_order_acquire)) {
+            BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] MQTT client is not connected to server";
+            return false;
+        }
 
-    
-    if (!client_) {
-        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] MQTT client pointer is null";
-        connected_.store(false, std::memory_order_release);
-        return false;
-    }
-    
-    auto check_future = std::async(std::launch::async, [this]() {
-        
-        return client_->is_connected();      
-    });
-    
-    if (check_future.wait_for(std::chrono::seconds(3)) == std::future_status::timeout) {
-        BOOST_LOG_TRIVIAL(info) << "[MQTT_INFO] Connection status check timeout";
-        connected_.store(false, std::memory_order_release);
-        return false;
-    }
-    
-    if (!check_future.get()) {
-        connected_.store(false, std::memory_order_release);
-        return false;
-    }
+        if (!client_) {
+            BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] MQTT client pointer is null";
+            connected_.store(false, std::memory_order_release);
+            return false;
+        }
 
-    return true;
+        auto check_future = std::async(std::launch::async, [this]() {
+            return client_->is_connected();
+        });
+
+        if (check_future.wait_for(std::chrono::seconds(3)) == std::future_status::timeout) {
+            BOOST_LOG_TRIVIAL(info) << "[MQTT_INFO] Connection status check timeout";
+            connected_.store(false, std::memory_order_release);
+            return false;
+        }
+
+        if (!check_future.get()) {
+            connected_.store(false, std::memory_order_release);
+            return false;
+        }
+
+        return true;
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] Exception checking connection: " << e.what();
+        connected_.store(false, std::memory_order_release);
+        return false;
+    }
 }
 
 // Callback when connection is lost
@@ -494,12 +557,12 @@ void MqttClient::connected(const std::string& cause)
 }
 
 void MqttClient::resubscribe_topics() {
-    if (topics_to_resubscribe_.empty()) {
+    if (topics_to_resubscribe_.empty() || !client_) {
         return;
-    }    
-    
+    }
+
     for (const auto& topic_pair : topics_to_resubscribe_) {
-        {
+        try {
             auto tok = client_->subscribe(topic_pair.first, topic_pair.second, nullptr,  subListener_);
             if (!tok->wait_for(std::chrono::seconds(5))) {
                 BOOST_LOG_TRIVIAL(info) << "[MQTT_INFO] Subscribe timeout for topic: " << topic_pair.first;
@@ -508,6 +571,8 @@ void MqttClient::resubscribe_topics() {
             if (!tok->is_complete() || tok->get_return_code() != 0) {
                 BOOST_LOG_TRIVIAL(info) << "[MQTT_INFO] Failed to resubscribe to topic: " << topic_pair.first;
             }
+        } catch (const std::exception& e) {
+            BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] Error resubscribing to topic '" << topic_pair.first << "': " << e.what();
         }
     }
 }

--- a/src/slic3r/Utils/MoonRaker.cpp
+++ b/src/slic3r/Utils/MoonRaker.cpp
@@ -335,14 +335,20 @@ bool Moonraker::get_machine_info(const std::vector<std::pair<std::string, std::v
             BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] failed to get machine info, error: " << error << ", HTTP status: " << status;
             wcp_loger.add_log("failed to get machine info, error: " + error + ", HTTP status: " + std::to_string(status), false, "", "Moonraker_Mqtt", "error");
             res = false;
-            response = json::parse(body);
-
+            try{
+                response = json::parse(body);
+            } catch (std::exception& e) {
+                BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] analysis error: " << e.what();
+            }
         })
         .on_complete([&](std::string body, unsigned) {
         
             wcp_loger.add_log("got machine info successfully", false, "", "Moonraker_Mqtt", "info");
-            response = json::parse(body);
-
+            try {
+                response = json::parse(body);
+            } catch (std::exception& e) {
+                BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] analysis machine response: " << e.what();
+            }
         })
         .perform_sync();
 
@@ -861,6 +867,7 @@ Moonraker_Mqtt::Moonraker_Mqtt(DynamicPrintConfig* config, bool change_engine) :
     if (change_engine) {        
         std::string local_ip = "";
         {
+        try {
             #ifdef _WIN32
                 SOCKET sock = socket(AF_INET, SOCK_DGRAM, 0);
                 if (sock == INVALID_SOCKET) {
@@ -911,8 +918,16 @@ Moonraker_Mqtt::Moonraker_Mqtt(DynamicPrintConfig* config, bool change_engine) :
                 close(sock);
             #endif
 
+        } catch (const std::exception& e) {
+            BOOST_LOG_TRIVIAL(error) << "Error getting local IP: " << e.what();
+            local_ip = "0.0.0.0"; 
         }
-        m_mqtt_client.reset(new MqttClient("mqtt://" + host_info, local_ip, "", "", true));
+        try {
+            m_mqtt_client.reset(new MqttClient("mqtt://" + host_info, local_ip, "", "", true));
+        } catch (const std::exception& e) {
+            BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] failed to create MQTT client: " << e.what();
+            m_mqtt_client.reset();
+        }
         m_mqtt_client_tls.reset();
         BOOST_LOG_TRIVIAL(error) << "local ip" << local_ip;
         wcp_loger.add_log("local IP: " + local_ip, false, "", "Moonraker_Mqtt", "error");
@@ -1230,7 +1245,14 @@ bool Moonraker_Mqtt::connect(wxString& msg, const nlohmann::json& params) {
     std::string mqtts_url = "mqtts://" + host_ip + ":" + std::to_string(m_port);
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] creating MQTTS client, URL: " << mqtts_url << ", client ID: " << m_client_id;
     wcp_loger.add_log("creating MQTTS client, URL: " + mqtts_url + ", client ID: " + m_client_id, false, "", "Moonraker_Mqtt", "info");
-    m_mqtt_client_tls.reset(new MqttClient(mqtts_url, m_client_id, m_ca, m_cert, m_key));
+    try {
+        m_mqtt_client_tls.reset(new MqttClient(mqtts_url, m_client_id, m_ca, m_cert, m_key));
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] failed to create MQTTS client: " << e.what();
+        wcp_loger.add_log("failed to create MQTTS client: " + std::string(e.what()), false, "", "Moonraker_Mqtt", "error");
+        m_mqtt_client_tls.reset();
+        return false;
+    }
 
     if (!m_mqtt_client_tls) {
         BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] failed to create MQTT client";


### PR DESCRIPTION
# Description

Batch of bugfixes for the 2.3.6 release branch, cherry-picked/merged from #723, #724, #726, #727, #730 and #611.

**Stability / crash fixes**
- **MQTT hardening** (`MQTT.cpp`): construct the `mqtt::async_client` inside try/catch; null-safe guards in SSL init, `Connect()`, `Disconnect()` and `Subscribe()`. Exceptions are now logged and reported via the out-param instead of propagating and crashing the caller.
- **SW web-channel hardening** (`SSWCP.cpp`): wrap all `sw_*` event handlers in try/catch with `handle_general_fail()` so exceptions thrown while handling JS events fail the job gracefully instead of terminating the app.
- **GCodeViewer re-entrancy crash** (`GCodeViewer.cpp`, cherry-picked from #611): the modal progress dialog in `load_toolpaths()` pumps the event loop, allowing dispatched events to re-enter `reset()` and zero `m_moves_count`, causing unsigned underflow in `reserve()` → `std::length_error`. Guarded `reset()` with an `m_loading` flag armed by an RAII ScopeGuard, replaced manual `gcode_result.unlock()` with a ScopeGuard, and added a defensive clamp on `ssid_count`.
- **Disable macOS memory guard detection** (`utils.cpp`, #724): `get_available_physical_memory()` returns 0 on macOS so `check_memory_guard()` skips sampling. The old vm_statistics64-based estimate counted free pages only (ignoring reclaimable cache) and raised false low-memory warnings even for small models. Windows/Linux behavior unchanged.

**UI fixes — mixed filament batch dialog** (#726)
- Add `_light` icon variants for add/remove and tray-nav buttons plus explicit disabled-state bitmaps, so all four states are distinguishable in dark mode.
- Center the preview placeholder by logical size (`GetScaledSize`) to fix the Retina-rasterized bitmap drifting to top-left on macOS.
- Pin row heights (title 20 DIP, manual-card 30 DIP) and add/remove buttons to 16x16 DIP so cards no longer shift when switching between recommended and manual modes.
- Call `m_btn_batch_match->Rescale()` in `Sidebar::msw_rescale()` and `sys_color_changed()` so the cached text extent stays correct after DPI/theme changes.
- Refine zh_CN translation of the mix-ratio range warning.

**Other fixes**
- Reset assembly view camera fit state (`first_enter_assemble = true`) when opening/resetting a project (#730).
- Preset: set supertack (cold) plate temperature to 0 for `Snapmaker PETG-CF @U1 0.4 nozzle`.
- Downgrade `GetFilamentInfo` failure log from error to info (#727).

No breaking changes; no profile migration required (single filament preset value update).