### PR TITLE
Replace splash screen Beta label with localized Release tag

### DIFF
--- a/localization/i18n/Snapmaker_Orca.pot
+++ b/localization/i18n/Snapmaker_Orca.pot
@@ -8646,6 +8646,9 @@ msgstr ""
 msgid "Beta version"
 msgstr ""
 
+msgid "Release"
+msgstr ""
+
 msgid "Updating"
 msgstr ""
 

--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -8469,6 +8469,9 @@ msgstr "更新固件"
 msgid "Beta version"
 msgstr "Beta 版"
 
+msgid "Release"
+msgstr "版本"
+
 msgid "Updating"
 msgstr "更新中"
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -495,15 +495,6 @@ public:
                        startX + brandExt.GetWidth() + gap,
                        tagY);
 
-        // Beta text below brand, centered
-        int betaY = scaleY(279);
-        memDc.SetFont(m_constant_text.versionFont);
-        memDc.SetTextForeground(wxColour(143, 143, 143));
-        wxSize betaExt = memDc.GetTextExtent(m_constant_text.betaText);
-        wxRect betaRect(wxPoint(0, betaY),
-                        wxPoint(width, betaY + betaExt.GetHeight()));
-        memDc.DrawLabel(m_constant_text.betaText, betaRect, wxALIGN_CENTER);
-
         // Dynamic text y position (for SetText)
         m_action_line_y_position = scaleY(384);
     }
@@ -580,7 +571,6 @@ private:
     {
         wxString title;
         wxString version;
-        wxString betaText;
 
         wxFont   titleFont;
         wxFont   versionFont;
@@ -589,8 +579,7 @@ private:
         void init()
         {
             title    = "Snapmaker Orca";
-            version  = std::string("V") + Snapmaker_VERSION;
-            betaText = _L("Beta version");
+            version  = wxString::Format("V%s %s", Snapmaker_VERSION, _L("Release"));
 
             titleFont   = Label::sysFont(20, false);
             versionFont = Label::Body_13;


### PR DESCRIPTION
- Remove the "Beta version" line drawn under the brand name
- Append a localized "Release" tag to the version string on the splash screen (zh_CN: 版本), rendered as "V2.3.6 版本"
- Add the "Release" msgid to the zh_CN catalog and the pot template; other languages fall back to English until translated
