### PR TITLE
Fix syntax errors introduced by crash hardening (#735)

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -1795,7 +1795,7 @@ void SSWCP_MachineFind_Instance::sw_WakeupFind()
         }
 
         // the target service queries once every 2 seconds
-        {
+        try {
             auto kick = Bonjour("snapmaker")
                             .set_retries(1)
                             .set_timeout(2)

--- a/src/slic3r/Utils/MoonRaker.cpp
+++ b/src/slic3r/Utils/MoonRaker.cpp
@@ -864,9 +864,8 @@ std::unordered_map<std::string, std::function<void(const nlohmann::json&)>> Moon
 Moonraker_Mqtt::Moonraker_Mqtt(DynamicPrintConfig* config, bool change_engine) : Moonraker(config) {
     std::string host_info = config->option<ConfigOptionString>("print_host")->value;
     auto& wcp_loger = GUI::WCP_Logger::getInstance();
-    if (change_engine) {        
+    if (change_engine) {
         std::string local_ip = "";
-        {
         try {
             #ifdef _WIN32
                 SOCKET sock = socket(AF_INET, SOCK_DGRAM, 0);


### PR DESCRIPTION
# Description

The crash-hardening changes in #735 introduced two syntax errors that make the current tip of `release_2_3_6` fail to compile on any platform:

- `SSWCP.cpp` `sw_WakeupFind()`: the Bonjour kick block was left as a bare `{ ... } catch (...) {}` — the `try` keyword is missing, producing an orphan catch handler (MSVC C2318)
- `MoonRaker.cpp` `Moonraker_Mqtt` constructor: a stray `{` remained when the socket probe was wrapped in try/catch; the unbalanced brace keeps the constructor scope open and cascades C2601 / C2065 / C1075 errors for every definition after it (the `METHOD_START_LOCAL_PRINT` "undeclared" error is part of this cascade — the definition at line 2427 is fine)

Both fixes are single-line keyword/brace restorations matching the evident intent of #735; no logic changes.

# Screenshots/Recordings/Graphs

Not a UI change — compiler output only.

## Tests

- Full Release build of `Snapmaker_Orca` with VS2022/MSVC after the fix: **0 errors** (both translation units compile cleanly)
- Before the fix the same build fails with C2318 in SSWCP.cpp and the C2601/C1075 cascade in MoonRaker.cpp