### PR TITLE
Fix Flatpak build: add missing <wx/wupdlock.h> includes

### DIFF
--- a/src/slic3r/GUI/ParamsPanel.cpp
+++ b/src/slic3r/GUI/ParamsPanel.cpp
@@ -18,6 +18,8 @@
 #include "Widgets/Button.hpp"
 #include "GUI_Factories.hpp"
 
+#include <wx/wupdlock.h>
+
 
 namespace Slic3r {
 namespace GUI {

--- a/src/slic3r/GUI/Timelapse/TimelapseDownloadPopup.cpp
+++ b/src/slic3r/GUI/Timelapse/TimelapseDownloadPopup.cpp
@@ -7,6 +7,7 @@
 #include <wx/gdicmn.h>
 #include <wx/statbmp.h>
 #include <wx/dcclient.h>
+#include <wx/wupdlock.h>
 
 #include "slic3r/GUI/I18N.hpp"
 #include "slic3r/GUI/GUI_App.hpp"


### PR DESCRIPTION
## Problem

The Flatpak jobs (x86_64 and aarch64) of the `release_2_3_6 Build all` run (32143560654) failed with:

```
src/slic3r/GUI/Timelapse/TimelapseDownloadPopup.cpp:492:5: error: 'wxWindowUpdateLocker' was not declared in this scope
  492 |     wxWindowUpdateLocker lock(this);
```

## Root cause

`TimelapseDownloadPopup.cpp` (introduced in #733) uses `wxWindowUpdateLocker` without including `<wx/wupdlock.h>`. It only compiled on other platforms because the PCH (`pchheader.hpp`) pulls the header in. The Flatpak build sets `-DSLIC3R_PCH=OFF`, exposing the missing include.

`ParamsPanel.cpp` has the same latent dependency (CI stopped at the first error, so it hasn't fired yet) and is fixed preemptively.

## Fix

Add `#include <wx/wupdlock.h>` to both files — same pattern as 46e6284f91 (`MixedFilamentBatchDialog.cpp`).

Verified on `release_2_3_6` (c6e16f7da5) that these are the only remaining files using `wxWindowUpdateLocker` without the direct include.