### PR TITLE
fix: add wasm and otf MIME types to HttpServer

### DIFF
--- a/src/slic3r/GUI/HttpServer.cpp
+++ b/src/slic3r/GUI/HttpServer.cpp
@@ -855,6 +855,8 @@ void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
         content_type = "text/css";
     else if (ends_with(file_path, ".js"))
         content_type = "text/javascript";
+    else if (ends_with(file_path, ".wasm"))
+        content_type = "application/wasm";
     else if (ends_with(file_path, ".png"))
         content_type = "image/png";
     else if (ends_with(file_path, ".jpg"))
@@ -865,6 +867,8 @@ void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
         content_type = "image/svg+xml";
     else if (ends_with(file_path, ".ttf"))
         content_type = "application/x-font-ttf";
+    else if (ends_with(file_path, ".otf"))
+        content_type = "font/otf";
     else if (ends_with(file_path, ".json"))
         content_type = "application/json";
     else if (ends_with(file_path, ".webp"))


### PR DESCRIPTION
## Summary
- Add missing MIME type mappings for `.wasm` and `.otf` files in `HttpServer::ResponseFile::write_response`.
- `.wasm` files are now served with `application/wasm` (required by browsers to compile WebAssembly via `WebAssembly.instantiateStreaming`), and `.otf` files with `font/otf`.

## Problem
Previously, `.wasm` and `.otf` files served by the built-in HTTP server fell through to the default content type. This causes browsers to reject WebAssembly modules ("expected application/wasm MIME type") and may prevent OTF fonts from loading correctly via `@font-face`.

## Changes
- `src/slic3r/GUI/HttpServer.cpp`: added two `else if` branches for the new extensions, following the existing pattern.

