### PR TITLE
Safeguard EdgeGrid.hpp

### DIFF
--- a/src/libslic3r/EdgeGrid.hpp
+++ b/src/libslic3r/EdgeGrid.hpp
@@ -224,6 +224,8 @@ public:
 						iy += 1;
 						assert(iy <= iyb);
 					}
+					if (ix < 0 || iy < 0 || ix >= (int64_t)m_cols || iy >= (int64_t)m_rows)
+						return; 
 					if (! visitor(iy, ix))
 						return;
 				} while (ix != ixb || iy != iyb);
@@ -245,6 +247,8 @@ public:
 						iy -= 1;
 						assert(iy >= iyb);
 					}
+					if (ix < 0 || iy < 0 || ix >= (int64_t)m_cols || iy >= (int64_t)m_rows)
+						return; 
 					if (! visitor(iy, ix))
 						return;
 				} while (ix != ixb || iy != iyb);
@@ -270,6 +274,8 @@ public:
 						iy += 1;
 						assert(iy <= iyb);
 					}
+					if (ix < 0 || iy < 0 || ix >= (int64_t)m_cols || iy >= (int64_t)m_rows)
+						return; 
 					if (! visitor(iy, ix))
 						return;
 				} while (ix != ixb || iy != iyb);
@@ -307,6 +313,8 @@ public:
 						iy -= 1;
 						assert(iy >= iyb);
 					}
+					if (ix < 0 || iy < 0 || ix >= (int64_t)m_cols || iy >= (int64_t)m_rows)
+						return; 
 					if (! visitor(iy, ix))
 						return;
 				} while (ix != ixb || iy != iyb);


### PR DESCRIPTION
## Problem

Multi-color models (repro: `方章圆章生成器 印章盒3.1.3mf`) crash during slicing when imported **with painting kept**; slicing works fine once the painting is removed.

Crash stack (bottom-up):
Snapmaker_Orca.dll!Slic3r::EdgeGrid::Grid::line(...) EdgeGrid.hpp:354 ← crash frame: OOB access into m_contours Snapmaker_Orca.dll!Slic3r::PaintedLineVisitor::operator()(iy, ix) MMS.cpp:540 EdgeGrid::Grid::visit_cells_intersecting_line EdgeGrid.hpp:310 ← out-of-range (iy, ix) reported here segmentation_by_painting painted-triangle projection (tbb::parallel_for)


## Root cause

`visit_cells_intersecting_line()` advances `(ix, iy)` cell-by-cell using Bresenham-style error terms. Index validity is guarded **only by `assert()`**, which is stripped in Release builds — there is no runtime fallback. The indices go out of range when the painted line meets either of the following geometric conditions:

1. **Endpoint on the grid's max boundary**: the caller clips painted lines to `edge_grid_bbox = m_bbox + 10·EPSILON`, and `BoundingBox::contains` is closed on `max`, so a clipped endpoint cell can reach `m_cols`;
2. **Line crossing a cell corner exactly (`ex == ey`)**: the 4th quadrant branch does `ix -= 1; iy -= 1;` and lacks an `assert(ix >= ixb)`, so the walk can run past the target cell.

The out-of-range index is reported to `PaintedLineVisitor::operator()`, which makes `cell_data_range()` read past the end of `m_cells[iy*m_cols+ix]` → garbage `begin/end` → `Grid::line()` accesses `m_contours` with a garbage index → crash.

**Why it only triggers with painting**: only the multi-color painting projection queries the EdgeGrid with externally computed line segments; the grid's own rasterization uses contour points strictly inside the bbox and never goes out of range. The repro model is regular parametric geometry (axis-aligned / 45° features, endpoints exactly on the max boundary), which hits both conditions reliably, hence the 100% reproduction.

## Fix

Backport of the upstream, already-verified OrcaSlicer fix (PR [#12806](https://github.com/OrcaSlicer/OrcaSlicer/pull/12806), commit `9478af93e`, fixes [#13083](https://github.com/OrcaSlicer/OrcaSlicer/issues/13083)): add a bounds check before each `visitor(iy, ix)` call in **all 4 do-while quadrants** of `visit_cells_intersecting_line` (`src/libslic3r/EdgeGrid.hpp`, +8 / −0):





