### PR TITLE
Fix crashes reported by Sentry during GUI shutdown/recreation

### DIFF
--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -356,7 +356,21 @@ BoundingBoxf3 GLVolume::transformed_convex_hull_bounding_box(const Transform3d& 
 
 BoundingBoxf3 GLVolume::transformed_non_sinking_bounding_box(const Transform3d& trafo) const
 {
-    return GUI::wxGetApp().plater()->model().objects[object_idx()]->volumes[volume_idx()]->mesh().transformed_bounding_box(trafo, 0.0);
+    auto* plater = GUI::wxGetApp().plater();
+    if (!plater)
+        return bounding_box().transformed(trafo);
+
+    const auto& objects = plater->model().objects;
+    int         obj_idx = object_idx();
+    if (obj_idx < 0 || obj_idx >= (int) objects.size() || !objects[obj_idx])
+        return bounding_box().transformed(trafo);
+
+    const auto& volumes = objects[obj_idx]->volumes;
+    int         vol_idx = volume_idx();
+    if (vol_idx < 0 || vol_idx >= (int) volumes.size())
+        return bounding_box().transformed(trafo);
+
+    return volumes[vol_idx]->mesh().transformed_bounding_box(trafo, 0.0);
 }
 
 const BoundingBoxf3& GLVolume::transformed_non_sinking_bounding_box() const
@@ -1037,7 +1051,7 @@ void GLVolumeCollection::render(GLVolumeCollection::ERenderType      type,
 
 bool GLVolumeCollection::check_outside_state(const BuildVolume& build_volume, ModelInstanceEPrintVolumeState* out_state) const
 {
-    if (GUI::wxGetApp().plater() == NULL) {
+    if (GUI::wxGetApp().plater() == NULL || GUI::wxGetApp().is_recreating_gui()) {
         if (out_state != nullptr)
             *out_state = ModelInstancePVS_Inside;
         return false;

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -2572,7 +2572,7 @@ void GCodeViewer::load_toolpaths(const GCodeProcessorResult& gcode_result, const
 
         // update progress dialog
         ++progress_count;
-        if (progress_dialog != nullptr && progress_count % progress_threshold == 0) {
+        if (progress_dialog != nullptr && progress_count % progress_threshold == 0 && wxGetApp().mainframe != nullptr) {
             progress_dialog->Update(int(100.0f * float(i) / (2.0f * float(m_moves_count))),
                 _L("Generating geometry vertex data") + ": " + wxNumberFormatter::ToString(100.0 * double(i) / double(m_moves_count), 0, wxNumberFormatter::Style_None) + "%");
             progress_dialog->Fit();
@@ -3079,7 +3079,7 @@ void GCodeViewer::load_toolpaths(const GCodeProcessorResult& gcode_result, const
         }
     }
 
-    if (progress_dialog != nullptr) {
+    if (progress_dialog != nullptr && wxGetApp().mainframe != nullptr) {
         progress_dialog->Update(100, "");
         progress_dialog->Fit();
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -14145,6 +14145,10 @@ void Plater::priv::on_slicing_update(SlicingStatusEvent &evt)
 void Plater::priv::on_slicing_completed(wxCommandEvent & evt)
 {
     BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << boost::format(": event_type %1%, string %2%") % evt.GetEventType() % evt.GetString();
+
+    if (GUI::wxGetApp().is_recreating_gui())
+        return;
+
     //BBS: add slice project logic
     if (m_slice_all && (m_cur_slice_plate < (partplate_list.get_plate_count() - 1))) {
         BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << boost::format("slicing all, finished plate %1%, will continue next.")%m_cur_slice_plate;

--- a/src/slic3r/GUI/wxExtensions.cpp
+++ b/src/slic3r/GUI/wxExtensions.cpp
@@ -440,6 +440,8 @@ wxBitmap create_scaled_bitmap(  const std::string& bmp_name_in,
                                 const vector<std::string>& array_new_color/* = vector<std::string>*/)//used for semi transparent material)
 {
     static Slic3r::GUI::BitmapCache cache;
+    if (win == nullptr)
+        win = (wxWindow*)Slic3r::GUI::wxGetApp().mainframe;
     if (bitmap2) {
         return create_scaled_bitmap2(bmp_name_in, cache, win, px_cnt, grayscale, resize, array_new_color);
     }


### PR DESCRIPTION
## Description

This PR fixes several crashes reported by Sentry. All of them occur while the GUI is being torn down or recreated (e.g. during language/theme change or application shutdown), when background tasks (slicing, G-code viewer loading, rendering) still hold references to objects that have already been destroyed.

## Changes

### 1. `GLVolume::transformed_non_sinking_bounding_box()` — `src/slic3r/GUI/3DScene.cpp`
The method unconditionally dereferenced `plater()->model().objects[object_idx()]->volumes[volume_idx()]`. If the plater is gone, the model object was removed, or the indices are stale/out of range, this crashes with an out-of-bounds access or null dereference.
- Added null checks for the plater, the model object, and range checks for `object_idx()` / `volume_idx()`.
- On failure it now safely falls back to `bounding_box().transformed(trafo)`.

### 2. `GLVolumeCollection::check_outside_state()` — `src/slic3r/GUI/3DScene.cpp`
This can be invoked from a render/refresh path while the GUI is being recreated, after the plater has been rebuilt.
- Also bail out early (treat objects as inside the build volume) when `wxGetApp().is_recreating_gui()` is true.

### 3. G-code viewer progress dialog — `src/slic3r/GUI/GCodeViewer.cpp`
`load_toolpaths()` updates its progress dialog from a worker context; if the main frame has been destroyed in the meantime, calling `progress_dialog->Update()` / `Fit()` crashes.
- Guard the two `progress_dialog->Update()` call sites with `wxGetApp().mainframe != nullptr`.

### 4. `Plater::priv::on_slicing_completed()` — `src/slic3r/GUI/Plater.cpp`
A slicing-completed event may be delivered after GUI recreation has started; continuing to process it (and chaining to the next plate in "slice all") touches stale GUI state.
- Return early when `wxGetApp().is_recreating_gui()` is true.

### 5. `create_scaled_bitmap()` — `src/slic3r/GUI/wxExtensions.cpp`
A null `win` pointer was passed through and eventually dereferenced when scaling bitmaps (the bitmap cache is static, so it can outlive specific windows).
- Fall back to `wxGetApp().mainframe` when `win == nullptr`.

## How This Was Tested

- Reproduced the crash scenarios (slicing / preview loading while quitting the app or triggering GUI recreation, e.g. language switch) — no crashes after the fix.
- Verified normal slicing and G-code preview workflows are unaffected.

## Screenshots / Recordings

N/A (crash fixes only, no UI change)