### PR TITLE
fix: crash in solve_extruder_order due to out-of-bounds access (Sentry #7256025247)

### DIFF
--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -19,6 +19,8 @@
 #include <algorithm>
 #include <cmath>
 
+#include <boost/log/trivial.hpp>
+
 #include <libslic3r.h>
 
 namespace Slic3r {

--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -152,6 +152,11 @@ void remove_duplicates_preserve_order(std::vector<unsigned int> &values)
 // Shortest hamilton path problem
 static std::vector<unsigned int> solve_extruder_order(const std::vector<std::vector<float>>& wipe_volumes, std::vector<unsigned int> all_extruders, std::optional<unsigned int> start_extruder_id) 
 {
+	for (auto id : all_extruders) {
+    if (id >= wipe_volumes.size())
+        return all_extruders;
+	}
+	
     bool add_start_extruder_flag = false;
 
     if (start_extruder_id) {


### PR DESCRIPTION
## Problem

Sentry Issue [#7256025247](https://snapmaker-hc.sentry.io/issues/7256025247/) (SNAPMAKER_ORCA-7VR):
multi-color / mixed-filament models crash when computing the extruder order.
Exception: `EXC_BAD_ACCESS / KERN_INVALID_ADDRESS / 0x4` (fatal), crashing in `Slic3r::solve_extruder_order`
at `ToolOrdering.cpp:177`, on macOS ARM64, version 2.3.4.

Address `0x4` = `nullptr + 4`, i.e. a near-null pointer dereference.

## Root cause

**Direct cause**: an extruder ID in `all_extruders` falls outside the valid index range of the
`wipe_volumes` matrix, causing an out-of-bounds access.
