### PR TITLE
fix: use literal format string for visibility icon in GCodeViewer legend

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -4486,7 +4486,7 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
                 ImGui::SameLine(checkbox_pos);
                 ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0.0, 0.0)); // ensure no padding active
                 ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0, 0.0)); // ensure no item spacing active
-                ImGui::Text(into_u8(visible ? ImGui::VisibleIcon : ImGui::HiddenIcon).c_str(), ImVec2(16 * m_scale, 16 * m_scale));
+                ImGui::Text("%s", into_u8(visible ? ImGui::VisibleIcon : ImGui::HiddenIcon).c_str());
                 ImGui::PopStyleVar(2);
             }
         }


### PR DESCRIPTION
fix: use literal format string for visibility icon in GCodeViewer legend

ImGui::Text() is a printf-style API. Passing the icon glyph string directly as the format argument is a format-string misuse (-Wformat-security) and would misrender if the string ever contained '%'. The extra ImVec2 argument matched no Text() overload and was silently ignored by vsnprintf, so drop it. No visual change.
