### PR TITLE
fix: first layer height should not override variable layer height profile

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -3927,7 +3927,11 @@ bool PrintObject::update_layer_height_profile(const ModelObject          &model_
             std::abs(layer_height_profile[layer_height_profile.size() - 2] - slicing_parameters.object_print_z_uncompensated_max + slicing_parameters.object_print_z_min) > 1e-3))
         layer_height_profile.clear();
 
-    if (layer_height_profile.empty() || layer_height_profile[1] != slicing_parameters.first_object_layer_height || has_dithering_ranges) {
+    // A differing first layer height must NOT force regeneration: doing so discards a valid
+    // variable layer height profile (e.g. loaded from a 3MF) and replaces it with a fixed-height
+    // profile. The first layer height is applied separately in generate_object_layers(), which
+    // hard-codes the first layer, so the profile's first segment does not need to match it here.
+    if (layer_height_profile.empty() || has_dithering_ranges) {
         //layer_height_profile = layer_height_profile_adaptive(slicing_parameters, model_object.layer_config_ranges, model_object.volumes);
         layer_height_profile = layer_height_profile_from_ranges(slicing_parameters, *ranges_to_use);
         // The layer height profile is already compressed.


### PR DESCRIPTION
# Description

Fix an issue where setting the first layer height to `0.2` caused the model's existing variable layer height profile to become ineffective.

Previously, `PrintObject::update_layer_height_profile()` compared the saved layer height profile with `first_object_layer_height`. When they differed, the existing profile was discarded and regenerated, which replaced a valid variable layer height profile, such as one loaded from a 3MF, with a fixed-height profile.

This PR removes `layer_height_profile[1] != slicing_parameters.first_object_layer_height` from the regeneration condition. The first layer height is already handled separately in `generate_object_layers()`, so it should not force regeneration of the whole layer height profile.

No breaking changes or new dependencies.

# Screenshots/Recordings/Graphs

Before: variable layer height became ineffective after setting first layer height to `0.2`.

<img width="3044" height="1814" alt="image" src="https://github.com/user-attachments/assets/a5ded00a-27f5-4196-b97a-559fd67ea0c6" />


After: variable layer height remains effective while the first layer height is still `0.2`.

<img width="2518" height="1346" alt="image" src="https://github.com/user-attachments/assets/2b224072-982e-45ac-a8b4-fa186fa39f18" />

## Tests

Manually verified with a 3MF containing a variable layer height profile:

1. Open the 3MF file.
2. Set first layer height to `0.2`.
3. Slice the model.
4. Confirm the first layer uses `0.2`.
5. Confirm the remaining layers still follow the original variable layer height profile.

Also verified that the Windows test package starts successfully.