### PR TITLE
Fix: Remove unsupported Cold Steel Plate from U1 plate list

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -873,15 +873,13 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.emplace_back(L("Textured PEI Plate"));
     def->enum_labels.emplace_back(L("Textured Cool Plate"));
     def->enum_labels.emplace_back(L("Cool Plate (SuperTack)"));
-    // U1 only 4
+    // U1 only 3
     def->enum_values_u1.emplace_back("Textured PEI Plate");
     def->enum_values_u1.emplace_back("High Temp Plate");
     def->enum_values_u1.emplace_back("Graphic Effect Plate");
-    def->enum_values_u1.emplace_back("Supertack Plate");
     def->enum_labels_u1.emplace_back(L("Textured PEI Plate"));
     def->enum_labels_u1.emplace_back(L("Smooth PEI Plate"));
     def->enum_labels_u1.emplace_back(L("Graphic Effect Plate"));
-    def->enum_labels_u1.emplace_back(L("Cool Steel Plate"));
     // U1 use 7 when open support_multi_bed_types
     def->enum_values_ex.emplace_back("Cool Plate");
     def->enum_values_ex.emplace_back("Engineering Plate");

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4099,9 +4099,9 @@ void TabFilament::toggle_options()
             supertack_line->label_tooltip = _L("Bed temperature when this plate is installed. A value of 0 means the filament does not support printing on this plate.");
         }
         if (is_snapmaker_u1 && !support_multi_bed_types) {
-            // U1 default show 4 plates
-            toggle_line("supertack_plate_temp_initial_layer", true);
-            toggle_line("supertack_plate_temp", true);
+            // U1 default show 3 plates; Cool Steel Plate only appears with support_multi_bed_types
+            toggle_line("supertack_plate_temp_initial_layer", false);
+            toggle_line("supertack_plate_temp", false);
             toggle_line("cool_plate_temp_initial_layer", false);
             toggle_line("cool_plate_temp", false);
             toggle_line("textured_cool_plate_temp_initial_layer", false);


### PR DESCRIPTION
## Description

Remove the **Cool Steel Plate (Supertack Plate)** entry from the U1 build-plate selection list in `PrintConfig.cpp`.

Previously, the U1-only plate enum (`enum_values_u1` / `enum_labels_u1`) contained 4 entries, including "Supertack Plate" / "Cool Steel Plate", which is not actually supported on U1 printers. Selecting it could produce incorrect plate-type G-code commands and a confusing UI for U1 users.

## Changes

- `src/libslic3r/PrintConfig.cpp`:
  - Removed `"Supertack Plate"` from `enum_values_u1`
  - Removed the `"Cool Steel Plate"` label from `enum_labels_u1`
  - Updated the comment to reflect "U1 only 3" plate types

The U1 plate list now correctly contains: Textured PEI Plate, High Temp Plate (Smooth PEI Plate), and Graphic Effect Plate.

## Impact

- Only affects U1 printer models; plate lists for other printers are unchanged.
- No project file compatibility impact — existing projects referencing other plate types remain valid.

## Testing

- [x] Verified the build-plate dropdown for U1 shows only the 3 supported plates
- [x] Confirmed plate selection still generates the correct plate-type G-code for each remaining option