### PR TITLE
feat: extract foreground change subscription to fix MQTT disconnect on screen off

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -7123,6 +7123,20 @@ void GUI_App::page_state_notify_webview(wxWebView* webview, const std::string& s
     }
 }
 
+void GUI_App::notify_foreground_change(const bool active)
+{
+    json data;
+    data["state"] = active;
+
+    for (const auto& instance : m_foreground_change_subscribers) {
+        auto ptr = instance.second.lock();
+        if (ptr) {
+            ptr->m_res_data = data;
+            ptr->send_to_js();
+        }
+    }
+}
+
 void GUI_App::cache_notify(const std::string& key, const json& res)
 {
     for (const auto& instance : m_cache_subscribers) {

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -872,6 +872,7 @@ public:
     std::unordered_map<void*, std::weak_ptr<SSWCP_Instance>> m_user_login_subscribers;
     std::unordered_map<void*, std::weak_ptr<SSWCP_Instance>> m_device_card_subscribers;
     std::unordered_map<void*, std::weak_ptr<SSWCP_Instance>> m_page_state_subscribers;
+    std::unordered_map<void*, std::weak_ptr<SSWCP_Instance>> m_foreground_change_subscribers;
     std::unordered_map<void*, std::weak_ptr<SSWCP_Instance>> m_user_update_privacy_subscribers;
     struct CachePairCompare
     {
@@ -887,6 +888,8 @@ public:
     void user_login_notify(const json& res);
     void device_card_notify(const json& res);
     void page_state_notify_webview(wxWebView* webview, const std::string& state);
+    // Push foreground/background state change to all subscribed webview instances
+    void notify_foreground_change(const bool active);
     void cache_notify(const std::string& key, const json& res);
     void user_update_privacy_notify(const bool& res);
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -73,6 +73,9 @@
 #include <dbt.h>
 #include <shlobj.h>
 #include <shellapi.h>
+#include <wtsapi32.h>
+#include <powersetting.h>
+#pragma comment(lib, "Wtsapi32.lib")
 #endif // _WIN32
 #include <slic3r/GUI/CreatePresetsDialog.hpp>
 #include "sentry_wrapper/SentryWrapper.hpp"
@@ -550,6 +553,7 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
     Bind(wxEVT_ACTIVATE, [this](wxActivateEvent& event) {
         if (m_plater != nullptr && event.GetActive())
             m_plater->on_activate();
+        NotifyActivateChange(event.GetActive());
         event.Skip();
     });
 
@@ -834,6 +838,33 @@ WXLRESULT MainFrame::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam
         HandleGetMinMaxInfo(mmi);
         AdjustWorkingAreaForAutoHide(hWnd, mmi);
         return 0;
+    }
+    case WM_WTSSESSION_CHANGE: {
+        switch (wParam) {
+        case WTS_SESSION_LOCK:
+            BOOST_LOG_TRIVIAL(warning) << "[ACTIVATE_EVT] Windows session locked";
+            wxGetApp().notify_foreground_change(false);
+            break;
+        case WTS_SESSION_UNLOCK:
+            BOOST_LOG_TRIVIAL(warning) << "[ACTIVATE_EVT] Windows session unlocked";
+            wxGetApp().notify_foreground_change(true);
+            break;
+        }
+        break;
+    }
+    case WM_POWERBROADCAST: {
+        if (wParam == PBT_POWERSETTINGCHANGE) {
+            auto* power_settings = reinterpret_cast<POWERBROADCAST_SETTING*>(lParam);
+            if (IsEqualGUID(power_settings->PowerSetting, GUID_CONSOLE_DISPLAY_STATE)) {
+                // GUID_CONSOLE_DISPLAY_STATE Data: 0x0=off, 0x1=on, 0x2=dimmed
+                DWORD display_state = power_settings->Data[0];
+                bool is_screen_on = (display_state == 0x1);
+                BOOST_LOG_TRIVIAL(warning) << "[ACTIVATE_EVT] Console display state changed: "
+                                           << (is_screen_on ? "on" : (display_state == 0x2 ? "dimmed" : "off"));
+                wxGetApp().notify_foreground_change(is_screen_on);
+            }
+        }
+        break;
     }
     }
     return wxFrame::MSWWindowProc(nMsg, wParam, lParam);
@@ -1420,6 +1451,14 @@ void MainFrame::register_win32_callbacks()
         if (! RegisterRawInputDevices(devices, device_count, sizeof(RAWINPUTDEVICE)))
             BOOST_LOG_TRIVIAL(error) << "RegisterRawInputDevices failed";
     }
+
+    // Register for Windows session change notifications (lock/unlock)
+    if (!::WTSRegisterSessionNotification(this->GetHWND(), NOTIFY_FOR_THIS_SESSION))
+        BOOST_LOG_TRIVIAL(error) << "WTSRegisterSessionNotification failed";
+
+    // Register for console display state notifications (screen on/off/dimmed)
+    if (!::RegisterPowerSettingNotification(this->GetHWND(), &GUID_CONSOLE_DISPLAY_STATE, DEVICE_NOTIFY_WINDOW_HANDLE))
+        BOOST_LOG_TRIVIAL(error) << "RegisterPowerSettingNotification failed";
 }
 #endif // _WIN32
 
@@ -4012,6 +4051,12 @@ void MainFrame::RunScript(wxString js)
 {
     if (m_webview != nullptr)
         m_webview->RunScript(js);
+}
+
+void MainFrame::NotifyActivateChange(bool active)
+{
+    BOOST_LOG_TRIVIAL(warning) << "[ACTIVATE_EVT] OrcaSlicer switched to " << (active ? "foreground" : "background");
+    wxGetApp().notify_foreground_change(active);
 }
 
 void MainFrame::downloadOpenProject(const std::string& fileUrl, const std::string& fileName, std::string completeFilePath)

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -199,6 +199,9 @@ protected:
     WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam) override;
 #endif
 
+    // Log and dispatch foreground/background change to Flutter subscribers
+    void NotifyActivateChange(bool active);
+
 public:
     MainFrame();
     ~MainFrame() = default;

--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -1219,6 +1219,7 @@ void SSWCP_Instance::sw_UnsubscribeAll() {
     wxGetApp().m_user_login_subscribers.clear();
     wxGetApp().m_cache_subscribers.clear();
     wxGetApp().m_user_update_privacy_subscribers.clear();
+    wxGetApp().m_foreground_change_subscribers.clear();
 
     send_to_js();
     finish_job();
@@ -1265,6 +1266,15 @@ void SSWCP_Instance::sw_Webview_Unsubscribe() {
     for (auto iter = privacy_map.begin(); iter != privacy_map.end();) {
         if (iter->first == m_webview) {
             iter = privacy_map.erase(iter);
+        } else {
+            iter++;
+        }
+    }
+
+    auto& foreground_map = wxGetApp().m_foreground_change_subscribers;
+    for (auto iter = foreground_map.begin(); iter != foreground_map.end();) {
+        if (iter->first == m_webview) {
+            iter = foreground_map.erase(iter);
         } else {
             iter++;
         }
@@ -3925,6 +3935,13 @@ void SSWCP_MachineOption_Instance::sw_exception_query()
 
 // SSWCP_MachineConnect_Instance
 void SSWCP_MachineConnect_Instance::process() {
+    if (m_cmd == "sw_SubscribeForegroundChange") {
+        if (m_event_id != "") {
+            m_header["event_id"] = m_event_id;
+            sw_SubscribeForegroundChange();
+        }
+        return;
+    }
     if (m_event_id != "") {
         json header;
         send_to_js();
@@ -4011,6 +4028,12 @@ void SSWCP_MachineConnect_Instance::sw_get_pin_code()
             handle_general_fail();
         }
     }
+}
+
+void SSWCP_MachineConnect_Instance::sw_SubscribeForegroundChange()
+{
+    auto self = shared_from_this();
+    wxGetApp().m_foreground_change_subscribers[m_webview] = self;
 }
 
 
@@ -7176,7 +7199,8 @@ std::unordered_set<std::string> SSWCP::m_machine_connect_cmd_list = {
     "sw_Disconnect",
     "sw_GetConnectedMachine",
     "sw_ConnectOtherMachine",
-    "sw_GetPincode"
+    "sw_GetPincode",
+    "sw_SubscribeForegroundChange"
 };
 
 std::unordered_set<std::string> SSWCP::m_project_cmd_list = {
@@ -7439,6 +7463,15 @@ void SSWCP::on_webview_delete(wxWebView* view)
     for (auto iter = page_state_map.begin(); iter != page_state_map.end();) {
         if (iter->first == view) {
             iter = page_state_map.erase(iter);
+        } else {
+            iter++;
+        }
+    }
+
+    auto& foreground_map = wxGetApp().m_foreground_change_subscribers;
+    for (auto iter = foreground_map.begin(); iter != foreground_map.end();) {
+        if (iter->first == view) {
+            iter = foreground_map.erase(iter);
         } else {
             iter++;
         }

--- a/src/slic3r/GUI/SSWCP.hpp
+++ b/src/slic3r/GUI/SSWCP.hpp
@@ -259,6 +259,9 @@ private:
 
     void sw_get_pin_code();
 
+    // Subscribe to foreground/background change events (event_id=205890)
+    void sw_SubscribeForegroundChange();
+
 };
 
 // mqtt-agent


### PR DESCRIPTION
## Summary

Extracts only the foreground/screen-state change subscription interface from the `feature_wcp_systeminfo` branch, This allows the Flutter webview to subscribe to app foreground/background state changes, so it can proactively handle MQTT reconnection when the screen turns off and back on — fixing the MQTT disconnection failure that occurs when the display goes off.

## Changes

- **GUI_App** ([GUI_App.hpp](src/slic3r/GUI/GUI_App.hpp) / [GUI_App.cpp](src/slic3r/GUI/GUI_App.cpp))
- Add `m_foreground_change_subscribers` map and `notify_foreground_change()` to push state changes to all subscribed webview instances.
- **MainFrame** ([MainFrame.hpp](src/slic3r/GUI/MainFrame.hpp) / [MainFrame.cpp](src/slic3r/GUI/MainFrame.cpp))
- Add `NotifyActivateChange()` dispatched from the `wxEVT_ACTIVATE` handler.
  - Windows: listen for session lock/unlock (`WM_WTSSESSION_CHANGE`) and console display on/off/dimmed (`WM_POWERBROADCAST` / `GUID_CONSOLE_DISPLAY_STATE`) notifications, registered via `WTSRegisterSessionNotification` / `RegisterPowerSettingNotification`.
- **SSWCP** ([SSWCP.hpp](src/slic3r/GUI/SSWCP.hpp) / [SSWCP.cpp](src/slic3r/GUI/SSWCP.cpp))
- Add `sw_SubscribeForegroundChange` command (event_id=205890). It is handled at the top of  `process()` with an early return so that `event_id` is written into `m_header` before subscribing (per follow-up fix `fc777a0`).
  - Register the command in `m_machine_connect_cmd_list`.
  - Clean up subscriptions in `sw_UnsubscribeAll`, `sw_Webview_Unsubscribe`, and `SSWCP::on_webview_delete`.
