### PR TITLE
feat: render official filament gradients bottom-to-top

### DIFF
--- a/resources/profiles/Snapmaker/filament/filaments_colours.json
+++ b/resources/profiles/Snapmaker/filament/filaments_colours.json
@@ -578,6 +578,7 @@
 			"filament_color": [
 				{
 					"sku": "34262",
+					"TD": 5.5,
 					"mode": 0,
 					"filament_color": [
 						"#08ABFB"
@@ -590,6 +591,7 @@
 				},
 				{
 					"sku": "34263",
+					"TD": 5.5,
 					"mode": 0,
 					"filament_color": [
 						"#D93B90"
@@ -602,6 +604,7 @@
 				},
 				{
 					"sku": "34264",
+					"TD": 9.5,
 					"mode": 0,
 					"filament_color": [
 						"#F9ED3D"
@@ -614,6 +617,7 @@
 				},
 				{
 					"sku": "34265",
+					"TD": 8.8,
 					"mode": 0,
 					"filament_color": [
 						"#9199A4"

--- a/src/libslic3r/FilamentColorLibrary.cpp
+++ b/src/libslic3r/FilamentColorLibrary.cpp
@@ -113,7 +113,7 @@ int JsonMode(const nlohmann::json& j)
     nlohmann::json::const_iterator it = j.find("mode");
     if (it == j.end() || !it->is_number_integer())
         return 0;
-    return it->get<int>() == 1 ? 1 : 0;
+    return it->get<int>();
 }
 
 bool JsonBool(const nlohmann::json& j, const char* key, bool defaultValue)
@@ -247,9 +247,9 @@ std::string GetFilamentMatchName(const std::string& name)
 
 FilamentColorMode FilamentColorModeFromConfig(int modeValue)
 {
-    if (modeValue == static_cast<int>(FilamentColorMode::Gradient))
-        return FilamentColorMode::Gradient;
-    return FilamentColorMode::Segment;
+    if (modeValue == static_cast<int>(FilamentColorMode::Segment))
+        return FilamentColorMode::Segment;
+    return FilamentColorMode::Gradient;
 }
 
 int FilamentColorModeToConfig(FilamentColorMode mode)
@@ -462,7 +462,10 @@ bool FilamentColorLibrary::LoadIndex()
             FilamentColorItem colorItem;
             colorItem.sku = JsonString(colorJson, "sku");
             colorItem.colorNames = JsonStringMap(colorJson, "color_name");
-            colorItem.colorData.mode = FilamentColorModeFromConfig(JsonMode(colorJson));
+            nlohmann::json::const_iterator tdIt = colorJson.find("TD");
+            if (tdIt != colorJson.end() && tdIt->is_number())
+                colorItem.tdValue = tdIt->get<double>();
+            const int modeValue = JsonMode(colorJson);
 
             bool hasInvalidColor = false;
             for (const std::string& rawColor : JsonStringArray(colorJson, "filament_color"))
@@ -478,6 +481,8 @@ bool FilamentColorLibrary::LoadIndex()
                 continue;
             }
 
+            colorItem.colorData.mode = FilamentColorModeFromConfig(modeValue);
+
             if (colorItem.sku.empty() || colorItem.colorData.colors.empty())
             {
                 BOOST_LOG_TRIVIAL(warning) << "Skip incomplete color item for official filament: "
@@ -485,10 +490,11 @@ bool FilamentColorLibrary::LoadIndex()
                 continue;
             }
 
-            if ((colorItem.colorData.mode == FilamentColorMode::Gradient && colorItem.colorData.colors.size() < 2) ||
-                (colorItem.colorData.mode == FilamentColorMode::Segment && colorItem.colorData.colors.size() > 2))
+            const bool isGradient = colorItem.colorData.IsGradient();
+            if ((isGradient && colorItem.colorData.colors.size() < 2) ||
+                (!isGradient && colorItem.colorData.colors.size() > 2))
             {
-                // Gradient requires at least 2 colors; segment supports at most 2 colors.
+                // Gradients require at least 2 colors; segments support at most 2 colors.
                 BOOST_LOG_TRIVIAL(warning) << "Skip color item with invalid color count: " << colorItem.sku;
                 continue;
             }

--- a/src/libslic3r/FilamentColorLibrary.hpp
+++ b/src/libslic3r/FilamentColorLibrary.hpp
@@ -10,8 +10,8 @@ namespace Slic3r
 
 enum class FilamentColorMode
 {
-    Segment = 0, //Single colors or side by side segments
-    Gradient = 1
+    Segment = 0, // Single colors or side-by-side segments.
+    Gradient = 1 // Gradient stops ordered from bottom to top.
 };
 
 std::string NormalizeFilamentHexColor(const std::string& color);
@@ -44,6 +44,7 @@ struct FilamentColorItem
 {
     std::unordered_map<std::string, std::string> colorNames;
     std::string sku;
+    double tdValue = 0.0;
     FilamentColor colorData;
 };
 

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -72,10 +72,15 @@ std::vector<FilamentColorMode> LoadFilamentColourModes(const AppConfig &config, 
     std::vector<FilamentColorMode> modes;
     const std::vector<std::string> modeValues = SplitPrinterSetting(config, printerName, "filament_colour_mode");
     modes.reserve(modeValues.size());
-    for (const std::string &modeValue : modeValues)
+    for (size_t i = 0; i < modeValues.size(); ++i)
     {
-        const bool isGradient = modeValue == std::to_string(FilamentColorModeToConfig(FilamentColorMode::Gradient));
-        modes.emplace_back(isGradient ? FilamentColorMode::Gradient : FilamentColorMode::Segment);
+        const char* begin = modeValues[i].c_str();
+        char* end = nullptr;
+        const long parsedMode = std::strtol(begin, &end, 10);
+        int modeValue = 0;
+        if (end != begin && *end == '\0')
+            modeValue = parsedMode == 0 ? 0 : 1;
+        modes.emplace_back(FilamentColorModeFromConfig(modeValue));
     }
     return modes;
 }

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2072,7 +2072,7 @@ void PrintConfigDef::init_fff_params()
 
     def = this->add("filament_colour_mode", coInts);
     def->label = L("Filament color display mode");
-    def->tooltip = L("Filament color display mode: 0 for split colors, 1 for gradient.");
+    def->tooltip = L("Filament color display mode: 0 for split colors, 1 for vertical gradient.");
     def->mode = comAdvanced;
     def->cli = ConfigOptionDef::nocli;
     def->min = 0;

--- a/src/slic3r/GUI/FilamentColorUtils.cpp
+++ b/src/slic3r/GUI/FilamentColorUtils.cpp
@@ -57,9 +57,12 @@ wxBitmap* GetFilamentColorIconFromNormalized(const std::vector<std::string>& nor
     for (const std::string& color : normalizedColors)
         wxColors.emplace_back(WxColorFromHex(color));
 
-    const bool isGradient = normalizedColors.size() > 1 && mode == FilamentColorMode::Gradient;
-    return get_color_block_bitmap_cached(wxColors, isGradient, iconWidth, iconHeight, wxString::FromUTF8(label.c_str()),
-                                         lightBorderColor);
+    FilamentColorMode renderMode = FilamentColorMode::Segment;
+    if (normalizedColors.size() > 1 && mode == FilamentColorMode::Gradient)
+        renderMode = FilamentColorMode::Gradient;
+
+    return get_color_block_bitmap_cached(wxColors, renderMode, iconWidth, iconHeight,
+                                         wxString::FromUTF8(label.c_str()), lightBorderColor);
 }
 
 } // namespace

--- a/src/slic3r/GUI/MixedFilamentBadge.cpp
+++ b/src/slic3r/GUI/MixedFilamentBadge.cpp
@@ -3,6 +3,7 @@
 #include "Widgets/Label.hpp"
 #include "MixedColorMatchHelpers.hpp"
 #include "BitmapCache.hpp"
+#include "libslic3r/FilamentColorLibrary.hpp"
 #include "libslic3r/MixedFilament.hpp"
 
 #include <wx/image.h>
@@ -284,7 +285,7 @@ wxBitmap* get_color_block_bitmap_cached(const ColorBlockParams& params)
     return cache.insert(key, bmp);
 }
 
-wxBitmap* get_color_block_bitmap_cached(const std::vector<wxColour>& colors, bool is_gradient,
+wxBitmap* get_color_block_bitmap_cached(const std::vector<wxColour>& colors, FilamentColorMode mode,
                                         int width, int height, const wxString& label,
                                         const wxColour& lightBorderColor,
                                         const CornerRadius& radius)
@@ -309,8 +310,12 @@ wxBitmap* get_color_block_bitmap_cached(const std::vector<wxColour>& colors, boo
             drawColors.emplace_back(color.IsOk() ? color : wxColour("#26A69A"));
     }
 
-    const bool useGradient = is_gradient && drawColors.size() > 1;
-    std::string key = useGradient ? "official-grad:" : "official-seg:";
+    FilamentColorMode renderMode = FilamentColorMode::Segment;
+    if (drawColors.size() > 1 && mode == FilamentColorMode::Gradient)
+        renderMode = FilamentColorMode::Gradient;
+
+    const bool useGradient = renderMode == FilamentColorMode::Gradient;
+    std::string key = useGradient ? "official-grad-bt:" : "official-seg:";
     key += "h" + std::to_string(height) + ":w" + std::to_string(width) + ":" + label.ToStdString();
     for (const wxColour& color : drawColors)
     {
@@ -350,20 +355,34 @@ wxBitmap* get_color_block_bitmap_cached(const std::vector<wxColour>& colors, boo
         dc.SetBrush(wxBrush(drawColors.front()));
         dc.DrawRectangle(0, 0, width, height);
     }
-    else if (useGradient)
+    // Reserved horizontal-gradient renderer. Re-enable when official filament data defines that direction.
+    // else if (useHorizontalGradient)
+    // {
+    //     dc.SetBrush(wxBrush(drawColors.front()));
+    //     dc.DrawRectangle(0, 0, width, height);
+    //     const int segmentCount = static_cast<int>(drawColors.size()) - 1;
+    //     int left = 0;
+    //     for (int index = 0; index < segmentCount; ++index)
+    //     {
+    //         const int right = index == segmentCount - 1 ? width : width * (index + 1) / segmentCount;
+    //         const int segmentWidth = right - left;
+    //         if (segmentWidth > 0)
+    //             dc.GradientFillLinear(wxRect(left, 0, segmentWidth, height), drawColors[static_cast<size_t>(index)],
+    //                                   drawColors[static_cast<size_t>(index + 1)], wxEAST);
+    //         left = right;
+    //     }
+    // }
+    else if (renderMode == FilamentColorMode::Gradient)
     {
         dc.SetBrush(wxBrush(drawColors.front()));
         dc.DrawRectangle(0, 0, width, height);
-        const int segmentCount = static_cast<int>(drawColors.size()) - 1;
-        int left = 0;
-        for (int index = 0; index < segmentCount; ++index)
+        for (int y = height - 1; y >= 0; --y)
         {
-            const int right = index == segmentCount - 1 ? width : width * (index + 1) / segmentCount;
-            const int segmentWidth = right - left;
-            if (segmentWidth > 0)
-                dc.GradientFillLinear(wxRect(left, 0, segmentWidth, height), drawColors[static_cast<size_t>(index)],
-                                      drawColors[static_cast<size_t>(index + 1)], wxEAST);
-            left = right;
+            const double position = static_cast<double>(height - 1 - y) /
+                                    static_cast<double>(std::max(1, height - 1));
+            const wxColour color = interpolate_color(drawColors, position);
+            dc.SetPen(wxPen(color));
+            dc.DrawLine(0, y, width, y);
         }
     }
     else

--- a/src/slic3r/GUI/MixedFilamentBadge.hpp
+++ b/src/slic3r/GUI/MixedFilamentBadge.hpp
@@ -8,6 +8,7 @@
 #include <string>
 
 namespace Slic3r {
+enum class FilamentColorMode;
 struct MixedFilament;
 struct MixedFilamentDisplayContext;
 }
@@ -48,8 +49,8 @@ wxColour interpolate_color(const std::vector<wxColour>& colors, double pos);
 // Key format:  "solid:#RRGGBB:hH:wW:label"  or  "grad:#RRGGBB:#RRGGBBBT:hH:wW:label"
 wxBitmap* get_color_block_bitmap_cached(const ColorBlockParams& params);
 
-// Cached bitmap for official filament colour blocks. Multiple colours are drawn left to right.
-wxBitmap* get_color_block_bitmap_cached(const std::vector<wxColour>& colors, bool is_gradient,
+// Cached bitmap for official filament colour blocks.
+wxBitmap* get_color_block_bitmap_cached(const std::vector<wxColour>& colors, FilamentColorMode mode,
                                         int width, int height, const wxString& label,
                                         const wxColour& lightBorderColor,
                                         const CornerRadius& radius = {});

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -2785,9 +2785,9 @@ void MixedFilamentBatchDialog::update_mapping_legend()
                             const int mode_val    = (phy_id >= 1 && phy_id <= m_physical_color_modes.size()) ?
                                                         m_physical_color_modes[phy_id - 1] :
                                                         0;
-                            bool      is_gradient = (FilamentColorModeFromConfig(mode_val) == FilamentColorMode::Gradient);
-                            src_bmp = get_color_block_bitmap_cached(dual_colors, is_gradient, FromDIP(20), FromDIP(20), wxEmptyString,
-                                                                    wxNullColour);
+                            const FilamentColorMode colorMode = FilamentColorModeFromConfig(mode_val);
+                            src_bmp = get_color_block_bitmap_cached(dual_colors, colorMode, FromDIP(20), FromDIP(20),
+                                                                    wxEmptyString, wxNullColour);
                         }
                     }
                     if (!src_bmp) {

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5717,7 +5717,8 @@ bool Tab::select_preset(std::string preset_name, bool delete_current /*=false*/,
                         oldFilamentColors[i] = "#26A69A";
                     if (oldFilamentMultiColors[i].empty())
                         oldFilamentMultiColors[i] = oldFilamentColors[i];
-                    oldFilamentColourModes[i] = oldFilamentColourModes[i] == 1 ? 1 : 0;
+                    const FilamentColorMode mode = FilamentColorModeFromConfig(oldFilamentColourModes[i]);
+                    oldFilamentColourModes[i] = FilamentColorModeToConfig(mode);
                 }
 
                 m_preset_bundle->update_selections(*wxGetApp().app_config);
@@ -5730,8 +5731,8 @@ bool Tab::select_preset(std::string preset_name, bool delete_current /*=false*/,
 
                 std::vector<std::string> filamentColourModeStrings;
                 filamentColourModeStrings.reserve(oldFilamentColourModes.size());
-                for (int mode : oldFilamentColourModes)
-                    filamentColourModeStrings.emplace_back(mode == 1 ? "1" : "0");
+                for (const int mode : oldFilamentColourModes)
+                    filamentColourModeStrings.emplace_back(std::to_string(mode));
                 const std::string filamentColors = boost::algorithm::join(oldFilamentColors, ",");
                 const std::string filamentMultiColors = boost::algorithm::join(oldFilamentMultiColors, ",");
                 const std::string filamentColourModes = boost::algorithm::join(filamentColourModeStrings, ",");

--- a/src/slic3r/GUI/filamentsync/FilamentColorMapBox.cpp
+++ b/src/slic3r/GUI/filamentsync/FilamentColorMapBox.cpp
@@ -182,11 +182,11 @@ void FilamentColorMapBox::onPaint(wxPaintEvent&)
     // ---- 2. Top bar (above filament colour bitmap, clipped to top half) ----
     {
         std::vector<wxColour> aboveColors = getAllColors(m_aboveFilament.m_color);
-        bool aboveIsGradient = m_aboveFilament.m_color.NormalizedMode() == FilamentColorMode::Gradient;
+        const FilamentColorMode aboveMode = m_aboveFilament.m_color.NormalizedMode();
         const int barR = radius;
         CornerRadius topCorners = {barR, barR, 0, 0};
-        wxBitmap* aboveBmp = get_color_block_bitmap_cached(aboveColors, aboveIsGradient,
-            w, totalH, wxEmptyString, wxColour(), topCorners);
+        wxBitmap* aboveBmp = get_color_block_bitmap_cached(aboveColors, aboveMode, w, totalH, wxEmptyString,
+                                                           wxColour(), topCorners);
         wxDCClipper clip(gdc, wxRect(0, 0, w, splitY));
         if (aboveBmp && aboveBmp->IsOk())
             gdc.DrawBitmap(*aboveBmp, 0, 0);
@@ -226,10 +226,9 @@ void FilamentColorMapBox::onPaint(wxPaintEvent&)
         const int cr      = circleD / 2;
 
         std::vector<wxColour> belowColors = getAllColors(m_belowFilament.m_color);
-        bool belowIsGradient = m_belowFilament.m_color.NormalizedMode() == FilamentColorMode::Gradient;
-        wxBitmap* belowBmp = get_color_block_bitmap_cached(belowColors, belowIsGradient,
-            circleD, circleD, wxEmptyString, borderColour,
-            CornerRadius::Uniform(cr));
+        const FilamentColorMode belowMode = m_belowFilament.m_color.NormalizedMode();
+        wxBitmap* belowBmp = get_color_block_bitmap_cached(belowColors, belowMode, circleD, circleD, wxEmptyString,
+                                                           borderColour, CornerRadius::Uniform(cr));
         if (belowBmp && belowBmp->IsOk())
             gdc.DrawBitmap(*belowBmp, cx - cr, cy - cr);
 

--- a/src/slic3r/GUI/filamentsync/FilamentColorMapBox.cpp
+++ b/src/slic3r/GUI/filamentsync/FilamentColorMapBox.cpp
@@ -179,13 +179,13 @@ void FilamentColorMapBox::onPaint(wxPaintEvent&)
     gdc.SetBrush(g_cardBg);
     gdc.DrawRoundedRectangle(0, 0, w, totalH, radius);
 
-    // ---- 2. Top bar (above filament colour bitmap, clipped to top half) ----
+    // ---- 2. Top bar with the complete filament color range ----
     {
         std::vector<wxColour> aboveColors = getAllColors(m_aboveFilament.m_color);
         const FilamentColorMode aboveMode = m_aboveFilament.m_color.NormalizedMode();
         const int barR = radius;
         CornerRadius topCorners = {barR, barR, 0, 0};
-        wxBitmap* aboveBmp = get_color_block_bitmap_cached(aboveColors, aboveMode, w, totalH, wxEmptyString,
+        wxBitmap* aboveBmp = get_color_block_bitmap_cached(aboveColors, aboveMode, w, splitY, wxEmptyString,
                                                            wxColour(), topCorners);
         wxDCClipper clip(gdc, wxRect(0, 0, w, splitY));
         if (aboveBmp && aboveBmp->IsOk())

--- a/src/slic3r/GUI/filamentsync/MachineFilamentPicker.cpp
+++ b/src/slic3r/GUI/filamentsync/MachineFilamentPicker.cpp
@@ -208,11 +208,10 @@ private:
         int circleD    = circleR * 2;
 
         std::vector<wxColour> circleColors = getAllColors(data.m_color);
-        bool circleIsGradient = data.m_color.NormalizedMode() == FilamentColorMode::Gradient;
+        const FilamentColorMode circleMode = data.m_color.NormalizedMode();
         const wxColour circleBorder = isNone ? wxColour(0xCC, 0xCC, 0xCC) : g_circleStroke;
-        wxBitmap* circleBmp = get_color_block_bitmap_cached(circleColors, circleIsGradient,
-            circleD, circleD, wxEmptyString, circleBorder,
-            CornerRadius::Uniform(circleR));
+        wxBitmap* circleBmp = get_color_block_bitmap_cached(circleColors, circleMode, circleD, circleD, wxEmptyString,
+                                                            circleBorder, CornerRadius::Uniform(circleR));
         if (circleBmp && circleBmp->IsOk())
             dc.DrawBitmap(*circleBmp, circleCxPx - circleR, circleCyPx - circleR);
 


### PR DESCRIPTION
# Description

Renders official filament gradient colors vertically (bottom-to-top) across all
color swatches, and normalizes color-mode values end to end.

Main feature (6381d78):
- **Rendering**: gradient swatches are now drawn by per-scanline vertical
  interpolation (bottom-to-top) instead of the previous left-to-right
  segment-wise fill. `get_color_block_bitmap_cached()` now takes a
  `FilamentColorMode` instead of `bool is_gradient`; gradient mode degrades to
  segment when fewer than 2 colors are available. The bitmap cache key is
  bumped (`official-grad:` → `official-grad-bt:`) so stale left-to-right
  bitmaps are not reused. The horizontal renderer is kept (commented) as a
  reserved direction for future official filament data.
- **Data model**: `FilamentColorModeFromConfig()` now normalizes any non-zero
  config value to `Gradient` (0 → `Segment`), and `JsonMode()` returns the raw
  JSON integer instead of folding it to 0/1 up front. Official color library
  entries accept an optional `TD` field, parsed into `FilamentColorItem::tdValue`
  (data added for Full Spectrum SKUs 34262–34265).
- **Persistence**: per-printer `filament_colour_mode` settings are parsed
  strictly (`strtol`, whole token must be an integer; invalid input →
  `Segment`, non-zero → `Gradient`) instead of exact string comparison, so
  legacy/edited values like `"2"` or `"01"` load deterministically.
  `Tab::select_preset()` round-trips persisted modes through
  FromConfig/ToConfig and writes the normalized value back.

Follow-up fix (0f54b1a):
- The design-side (top half) color bar in the sync filament dialog was
  generated at full card height and clipped to the top half, hiding the lower
  part of the gradient. It is now generated at the top-half height
  (`splitY`) so the complete color range is visible.
