### PR TITLE
fix: regenerate tree supports on move and grow branch bases near the bed

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -126,7 +126,12 @@ PrintBase::ApplyStatus PrintObject::set_instances(PrintInstances &&instances)
     	[](const PrintInstance& lhs, const PrintInstance& rhs) { return lhs.model_instance == rhs.model_instance && lhs.shift == rhs.shift; });
     if (! equal) {
         status = PrintBase::APPLY_STATUS_CHANGED;
-        if (m_print->invalidate_steps({ psSkirtBrim, psGCodeExport }) ||
+        // Tree support branches are routed against the machine border (bed bounds) anchored to the
+        // instance shift, so a pure XY translation makes the cached tree support layers stale and they
+        // have to be regenerated. Regular supports are computed in object coordinates and stay valid
+        // when the instance is translated, so the cheap skirt/gcode-only invalidation is kept for them.
+        if ((is_tree(m_config.support_type.value) && this->invalidate_step(posSupportMaterial)) ||
+            m_print->invalidate_steps({ psSkirtBrim, psGCodeExport }) ||
             (! equal_length && m_print->invalidate_step(psWipeTower)))
             status = PrintBase::APPLY_STATUS_INVALIDATED;
         m_instances = std::move(instances);

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -2431,7 +2431,10 @@ void TreeSupport::drop_nodes()
     const size_t top_interface_layers = config.support_interface_top_layers.value;
     const size_t bottom_interface_layers = config.support_interface_bottom_layers.value < 0 ? top_interface_layers : config.support_interface_bottom_layers.value;
     SupportNode::diameter_angle_scale_factor = diameter_angle_scale_factor;
-    float        DO_NOT_MOVER_UNDER_MM       = is_slim ? 0 : 5;                     // do not move contact points under 5mm
+    // Ported from BambuStudio d61ebefa2: bottom expansion grows branch radius in the first
+    // DO_NOT_MOVER_UNDER_MM above the bed so tree bases fill cavities/grooves instead of spilling
+    // out of them. Enabled only when the wall count is auto (<0) or dual-wall (>1) is requested.
+    const bool bottom_expand_enabled = config.tree_support_wall_count > 1 || config.tree_support_wall_count < 0;
 
     auto get_max_move_dist = [this, &config, tan_angle, wall_count, support_extrusion_width](const SupportNode *node, int power = 1) {
         if (node->max_move_dist == 0) {
@@ -2865,7 +2868,11 @@ void TreeSupport::drop_nodes()
                 to_outside             = projection_onto(next_collision, next_node->position);
                 direction_to_outer     = to_outside - node.position;
                 double dist_to_outer   = unscale_(direction_to_outer.cast<double>().norm());
-                next_node->radius      = std::max(node.radius, std::min(next_node->radius, dist_to_outer));
+                // Near the bed the branch keeps the full radius lineage and grows by half an extrusion
+                // width per layer (bottom expansion), which widens the base instead of dodging outward.
+                next_node->radius      = (bottom_expand_enabled && next_node->print_z < DO_NOT_MOVER_UNDER_MM && node.dist_mm_to_top > DO_NOT_MOVER_UNDER_MM) ?
+                                             node.radius + support_extrusion_width / 2. :
+                                             std::max(node.radius, std::min(next_node->radius, dist_to_outer));
                 get_max_move_dist(next_node);
                 m_ts_data->m_mutex.lock();
                 contact_nodes[layer_nr_next].push_back(next_node);

--- a/src/libslic3r/Support/TreeSupport.hpp
+++ b/src/libslic3r/Support/TreeSupport.hpp
@@ -431,7 +431,9 @@ private:
     size_t          m_highest_overhang_layer = 0;
     std::vector<std::vector<MinimumSpanningTree>> m_spanning_trees;
     std::vector< std::unordered_map<Line, bool, LineHash>> m_mst_line_x_layer_contour_caches;
-    float    DO_NOT_MOVER_UNDER_MM = 0.0;
+    // Contact points closer than this to the bed are not moved sideways; the first ~2 mm above the
+    // bed are also where bottom branch expansion applies (see drop_nodes bottom_expand_enabled).
+    float    DO_NOT_MOVER_UNDER_MM = 2.0;
     coordf_t base_radius                        = 0.0;
     const coordf_t MAX_BRANCH_RADIUS = 10.0;
     const coordf_t MIN_BRANCH_RADIUS = 0.4;


### PR DESCRIPTION
# Description

Two independent tree-support fixes:

**1. Tree supports were not regenerated after moving / centering an object**

- Tree support branches are routed against the machine border (bed bounds) anchored to the instance shift, but `PrintObject::set_instances()` only invalidated the Print-level steps (`psSkirtBrim`, `psGCodeExport`) on a pure XY translation, which never cascade to the PrintObject-level `posSupportMaterial` step.
- Result: after moving or centering an object, slicing kept reusing the supports computed for the old position, until some support option was toggled back and forth.
- Fix: for tree-support objects, also invalidate `posSupportMaterial` on instance changes. Regular supports are computed in object coordinates and stay valid on translation, so the cheap skirt/gcode-only invalidation is kept for them (no performance regression when dragging objects).

**2. Tree support branches spill out of grooves/cavities (ported from BambuStudio d61ebefa2, STUDIO-18228/18439, #10542/#10775)**

- Grow branch radius by half an extrusion width per layer for nodes in the first ~2 mm above the bed (when wall count is auto or dual-wall), so tree bases fill cavities/grooves instead of spilling out of them.
- `DO_NOT_MOVER_UNDER_MM` becomes a class constant of 2.0 mm (was a local `is_slim ? 0 : 5`).
- `drop_nodes()`: add `bottom_expand_enabled` gate and apply the radius growth when dropping nodes near the bed.

# Screenshots/Recordings/Graphs

To be attached during manual validation (groove test model): before this PR the groove model produced 559 fine support markers spilling outside the groove (vs BambuStudio 37 stout markers inside).

## Tests

- [x] Full Release build via VS2022 (orca-build) - compiles clean, app runs
- [ ] Manual: groove model - slice, then center the object, then re-slice: supports must be regenerated (G-code support markers change)
- [ ] Manual: branch bases near the bed are thicker and stay inside the groove
- Note: automated slice tests are not runnable in this fork (pre-existing test-infra limitation, verified against a stash baseline)
