### PR TITLE
fix: restore mixed-filament confirmation when switching to Preview tab

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -339,7 +339,11 @@ static std::string flow_ratio_zero_error_text(const Plater::FlowRatioZeroDetail&
 // its own High/Low grouping. Plates without conflicts are not shown.
 static std::string filament_temp_mixing_warning_text_slice_all(const std::vector<Plater::PlateMixingInfo>& plates)
 {
-    std::string out = tr_u8("The following plates contain mixed high and low temperature materials:");
+    std::string out = tr_u8("Detected both high and low temperature materials. "
+                            "Mixed printing may result in extruder clogging, "
+                            "nozzle damage, or layer adhesion issues.");
+    out += "\n\n";
+    out += tr_u8("The following plates contain mixed high and low temperature materials:");
     out += "\n\n";
     for (const Plater::PlateMixingInfo& info : plates)
     {
@@ -10844,6 +10848,14 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
                     q->sync_flow_ratio_zero_notification();
                     q->sync_cold_plate_notification();
                     q->select_view_3D("Preview", true);
+                    return;
+                }
+                if (q->preview_switch_triggers_slice() && !q->guard_before_slice_plate()) {
+                    // Stay on the Prepare page (as in 2.3.5): the user declined
+                    // the mixed-filament confirmation, so neither switch to
+                    // Preview nor start slicing. The MainFrame tab is already
+                    // on tpPreview at this point, switch it back first.
+                    wxGetApp().mainframe->select_tab(size_t(MainFrame::tp3DEditor));
                     return;
                 }
             }
@@ -22660,6 +22672,23 @@ bool Plater::guard_before_slice_plate()
     sync_flow_ratio_zero_notification();
     sync_cold_plate_notification();
     return confirm_filament_temp_mixing_before_slice();
+}
+
+bool Plater::preview_switch_triggers_slice() const
+{
+    if (p->background_process.is_export_scheduled())
+        return false;
+    if (p->view3D->get_canvas3d()->check_volumes_outside_state() == ModelInstancePVS_Partly_Outside)
+        return false;
+    if (p->background_process.running() || p->m_is_slicing)
+        return false;
+
+    PartPlate* current_plate = p->partplate_list.get_curr_plate();
+    if (current_plate == nullptr)
+        return false;
+    return !p->model.objects.empty()
+        && current_plate->has_printable_instances()
+        && !current_plate->is_slice_result_valid();
 }
 
 bool Plater::guard_before_slice_all()

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -645,6 +645,9 @@ public:
     bool sync_cold_plate_notification();
     /// Check and guard filament temp mixing before slicing current plate.
     bool guard_before_slice_plate();
+    /// True when switching to Preview would auto-start slicing the current plate
+    /// (mirrors the slice branch of Plater::priv::set_current_panel's do_reslice).
+    bool preview_switch_triggers_slice() const;
     /// Check and guard filament temp mixing before slicing all plates.
     bool guard_before_slice_all();
     /// @brief Show confirmation dialog for allowed high/low temperature mixing before slice.


### PR DESCRIPTION
# Description

Restores the secondary confirmation dialog for mixed high/low temperature filaments when switching from the Prepare tab to the Preview tab.

## Background

When a plate mixes high-temperature and low-temperature filaments and "Allow high/low temperature filament mixing" is enabled in Preferences:

- Clicking **Slice Plate** or **Slice All** correctly shows a confirmation dialog before slicing starts.
- Switching from **Prepare** to **Preview** used to show the same confirmation (in 2.3.5), but a regression introduced by #589 silently dropped it — the switch auto-started slicing with no prompt.

(In 2.3.5 the Preview switch was implemented by re-posting the "Slice All" event, which incidentally carried the confirmation. #589 removed that repost — correctly, because it sliced *all* plates when only the selected plate should be sliced — but the confirmation was lost along with it.)

## Changes

- **Restore the confirmation on Preview tab switch** (`EVT_GLVIEWTOOLBAR_PREVIEW` handler in `Plater.cpp`): when the switch would auto-start slicing and the current plate has mixed high/low temperature filaments, show the same single-plate confirmation dialog as the **Slice Plate** button.
  - **Confirm** → slice only the currently selected plate (single plate, *not* all plates) and stay on the Preview page.
  - **Cancel** → stay on the Prepare page; no panel switch and no slicing (the MainFrame tab is switched back, mirroring the 2.3.5 behavior).
- **New predicate `Plater::preview_switch_triggers_slice()`** (`Plater.cpp` / `Plater.hpp`): mirrors the slice branch conditions of `Plater::priv::set_current_panel`'s `do_reslice` (non-empty model, printable instances on the current plate, stale slice result, no export/slicing in progress, model inside the print volume), so the dialog only appears when slicing would actually start.
- **Align the Slice All dialog text with the Slice Plate dialog**: `filament_temp_mixing_warning_text_slice_all()` now includes the same risk-warning sentence ("Mixed printing may result in extruder clogging, nozzle damage, or layer adhesion issues.") that was previously missing from the slice-all variant.

Hard-blocked plates (mixing not allowed via Preferences) keep the existing behavior: notification sync + no slicing, no dialog.

# Screenshots/Recordings/Graphs

N/A (behavioral fix; dialog layout unchanged — only the slice-all warning text gained the risk sentence).

## Tests

- [x] Incremental build of `libslic3r_gui` passes (MSVC).
- [ ] Manual, mixed filaments + mixing allowed in Preferences:
  - [ ] Slice Plate → confirmation shown once; Confirm slices.
  - [ ] Slice All → confirmation shown once with per-plate breakdown incl. risk sentence; Confirm slices.
  - [ ] Prepare → Preview switch → confirmation shown **once**; Confirm slices only the selected plate and lands on Preview.
  - [ ] Prepare → Preview switch → Cancel → stays on Prepare, no slicing starts.
  - [ ] Preview tab re-clicked while already on Preview → no unexpected dialog.
  - [ ] Preview thumbnail-triggered reslice → existing guards unaffected.
  - [ ] Mixing NOT allowed in Preferences → hard block (notification, no dialog), unchanged.
