### PR TITLE
fix: fall back to legacy color picker for incompatible filament presets

### DIFF
--- a/src/libslic3r/FilamentColorLibrary.cpp
+++ b/src/libslic3r/FilamentColorLibrary.cpp
@@ -242,6 +242,10 @@ std::string GetFilamentMatchName(const std::string& name)
             matchName = matchName.substr(0, nozzlePos);
     }
 
+    const size_t atPos = matchName.find('@');
+    if (atPos != std::string::npos)
+        matchName = TrimCopy(matchName.substr(0, atPos));
+
     return TrimCopy(matchName);
 }
 

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1048,6 +1048,13 @@ void PlaterPresetComboBox::ChangeExtruderColor()
         return;
 
     const std::string filamentPresetName = CurrentFilamentPresetName();
+    const Preset* currentPreset = m_collection != nullptr ? m_collection->find_preset(filamentPresetName, false, true) : nullptr;
+    if (currentPreset == nullptr || !currentPreset->is_compatible)
+    {
+        SelectLegacyFilamentColor();
+        return;
+    }
+
     const std::string filamentBaseName = FilamentBaseName(filamentPresetName);
     if (!IsSnapmakerFilamentName(filamentBaseName))
     {


### PR DESCRIPTION
- Strip '@' suffix in GetFilamentMatchName so names like "PLA @vendor" match the color library entry "PLA"
- In ChangeExtruderColor, fall back to the legacy wx color dialog when the current filament preset is missing or not compatible with the active printer, instead of opening the Snapmaker color library dialog