### PR TITLE
Resolve CLI resource profiles by printer vendor

### DIFF
--- a/src/Snapmaker_Orca.cpp
+++ b/src/Snapmaker_Orca.cpp
@@ -57,6 +57,7 @@ using namespace nlohmann;
 #include "libslic3r/ModelArrange.hpp"
 #include "libslic3r/Platform.hpp"
 #include "libslic3r/Print.hpp"
+#include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/SLAPrint.hpp"
 #include "libslic3r/TriangleMesh.hpp"
 #include "libslic3r/Format/AMF.hpp"
@@ -1213,7 +1214,9 @@ int CLI::run(int argc, char **argv)
     Semver file_version;
     std::map<size_t, bool> orients_requirement;
     std::vector<Preset*> project_presets;
+    ResourceProfileResolver resource_profiles(boost::filesystem::path(resources_dir()) / "profiles");
     std::string new_printer_name, current_printer_name, new_process_name, current_process_name, current_printer_system_name, current_process_system_name, new_process_system_name, new_printer_system_name, printer_model_id, current_printer_model, printer_model;//, printer_inherits, print_inherits;
+    std::string current_printer_vendor, new_printer_vendor;
     std::vector<std::string> upward_compatible_printers, new_print_compatible_printers, current_print_compatible_printers, current_different_settings;
     std::vector<std::string> current_filaments_name, current_filaments_system_name, current_inherits_group;
     DynamicPrintConfig load_process_config, load_machine_config;
@@ -1505,6 +1508,11 @@ int CLI::run(int argc, char **argv)
                         current_filaments_system_name = current_filaments_name;
                         BOOST_LOG_TRIVIAL(info) << boost::format("no inherits_group: use system name the same as current name");
                     }
+                    current_printer_vendor = resource_profiles.vendor_for_printer(current_printer_system_name, current_printer_model);
+                    if (current_printer_vendor.empty())
+                        current_printer_vendor = resource_profiles.vendor_for_printer(current_printer_name, current_printer_model);
+                    BOOST_LOG_TRIVIAL(info) << boost::format("resolved current printer vendor %1% from preset %2%, model %3%")
+                        %current_printer_vendor %current_printer_system_name %current_printer_model;
                     filament_count = current_filaments_name.size();
                     upward_compatible_printers = config.option<ConfigOptionStrings>("upward_compatible_machine", true)->values;
                     current_print_compatible_printers  = config.option<ConfigOptionStrings>("print_compatible_printers", true)->values;
@@ -1758,6 +1766,43 @@ int CLI::run(int argc, char **argv)
         }
         return 0;
     };
+    auto load_system_preset = [&resource_profiles](Preset::Type preset_type, const std::string &preset_name,
+                                                   std::string &vendor_id, DynamicPrintConfig &config,
+                                                   std::string &config_type, std::string &config_name,
+                                                   std::string &filament_id, std::string &config_from) {
+        ResourceProfileResolver::ResolvedPreset resolved;
+        if (!resource_profiles.resolve_preset(preset_type, preset_name, vendor_id, resolved))
+            return CLI_FILE_NOTFOUND;
+
+        config      = std::move(resolved.config);
+        config_name = resolved.name;
+        config_from = "system";
+        filament_id = resolved.filament_id;
+        // The printer establishes the vendor context. A process or filament
+        // may legitimately fall back to a shared or uniquely-owned profile,
+        // which must not replace an already known printer vendor.
+        if (preset_type == Preset::TYPE_PRINTER || vendor_id.empty())
+            vendor_id = resolved.vendor_id;
+        switch (preset_type) {
+        case Preset::TYPE_PRINTER:  config_type = "machine"; break;
+        case Preset::TYPE_PRINT:    config_type = "process"; break;
+        case Preset::TYPE_FILAMENT: config_type = "filament"; break;
+        default:                    return CLI_CONFIG_FILE_ERROR;
+        }
+        return CLI_SUCCESS;
+    };
+    auto update_printer_model_id = [&resource_profiles, &printer_model_id](const std::string &model_name,
+                                                                           std::string &vendor_id) {
+        if (model_name.empty())
+            return;
+        ResourceProfileResolver::ResolvedPrinterModel resolved;
+        if (resource_profiles.resolve_printer_model(model_name, vendor_id, resolved)) {
+            printer_model_id = resolved.model_id;
+            vendor_id        = resolved.vendor_id;
+            BOOST_LOG_TRIVIAL(info) << boost::format("resolved printer model %1%, model_id %2%, vendor %3%")
+                %model_name %printer_model_id %vendor_id;
+        }
+    };
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< ":before load settings, file count="<< load_configs.size() << std::endl;
     //std::vector<std::string> filament_compatible_printers;
     // load config files supplied via --load
@@ -1789,19 +1834,10 @@ int CLI::run(int argc, char **argv)
 
             //get printer_model_id
             printer_model = config.option<ConfigOptionString>("printer_model", true)->value;
-            if (!printer_model.empty()) {
-                std::string printer_model_path = resources_dir() + "/profiles/BBL/machine_full/"+printer_model+".json";
-                if (boost::filesystem::exists(printer_model_path))
-                {
-                    std::map<std::string, std::string> key_values;
-
-                    load_key_values_from_json(printer_model_path, key_values);
-                    if (key_values.find("model_id") != key_values.end()) {
-                        printer_model_id = key_values["model_id"];
-                        BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< boost::format(":%1%, load printer_model_id %2% from current printer model %3%")%__LINE__ %printer_model_id %printer_model;
-                    }
-                }
-            }
+            new_printer_vendor = resource_profiles.vendor_for_printer(new_printer_system_name, printer_model);
+            if (new_printer_vendor.empty())
+                new_printer_vendor = resource_profiles.vendor_for_printer(new_printer_name, printer_model);
+            update_printer_model_id(printer_model, new_printer_vendor);
 
             //printer_inherits = config.option<ConfigOptionString>("inherits", true)->value;
             load_machine_config = std::move(config);
@@ -1989,19 +2025,7 @@ int CLI::run(int argc, char **argv)
 
                         //get printer_model_id
                         printer_model = config.option<ConfigOptionString>("printer_model", true)->value;
-                        if (!printer_model.empty()) {
-                            std::string printer_model_path = resources_dir() + "/profiles/BBL/machine_full/"+printer_model+".json";
-                            if (boost::filesystem::exists(printer_model_path))
-                            {
-                                std::map<std::string, std::string> key_values;
-
-                                load_key_values_from_json(printer_model_path, key_values);
-                                if (key_values.find("model_id") != key_values.end()) {
-                                    printer_model_id = key_values["model_id"];
-                                    BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< boost::format(":%1%, load printer_model_id %2% from current printer model %3%")%__LINE__ %printer_model_id %printer_model;
-                                }
-                            }
-                        }
+                        update_printer_model_id(printer_model, current_printer_vendor);
 
                         int orig_printable_width = 0, orig_printable_depth = 0, orig_printable_height = 0;
                         Pointfs orig_printable_area;
@@ -2051,38 +2075,22 @@ int CLI::run(int argc, char **argv)
         else {
             if (new_printer_name.empty() && !current_printer_system_name.empty()) {
                 //use the original printer name in 3mf
-                std::string system_printer_path = resources_dir() + "/profiles/BBL/machine_full/"+current_printer_system_name+".json";
-                if (! boost::filesystem::exists(system_printer_path)) {
-                    BOOST_LOG_TRIVIAL(warning) << __FUNCTION__<< boost::format(":%1%, can not find system preset file: %2% ")%__LINE__ %system_printer_path;
+                DynamicPrintConfig  config;
+                std::string config_type, config_name, filament_id, config_from;
+                int ret = load_system_preset(Preset::TYPE_PRINTER, current_printer_system_name, current_printer_vendor,
+                                             config, config_type, config_name, filament_id, config_from);
+                if (ret) {
+                    BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(":%1%, can not resolve system machine preset %2% for vendor %3%")
+                        %__LINE__ %current_printer_system_name %current_printer_vendor;
                     //use original one
                 }
                 else {
-                    DynamicPrintConfig  config;
-                    std::string config_type, config_name, filament_id, config_from;
-                    int ret = load_config_file(system_printer_path, config, config_type, config_name, filament_id, config_from);
-                    if (ret) {
-                        record_exit_reson(outfile_dir, ret, 0, cli_errors[ret], sliced_info);
-                        flush_and_exit(ret);
-                    }
-
                     upward_compatible_printers = config.option<ConfigOptionStrings>("upward_compatible_machine", true)->values;
                     config.set("printer_settings_id", config_name, true);
 
                     //get printer_model_id
                     printer_model = config.option<ConfigOptionString>("printer_model", true)->value;
-                    if (!printer_model.empty()) {
-                        std::string printer_model_path = resources_dir() + "/profiles/BBL/machine_full/"+printer_model+".json";
-                        if (boost::filesystem::exists(printer_model_path))
-                        {
-                            std::map<std::string, std::string> key_values;
-
-                            load_key_values_from_json(printer_model_path, key_values);
-                            if (key_values.find("model_id") != key_values.end()) {
-                                printer_model_id = key_values["model_id"];
-                                BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< boost::format(":%1%, load printer_model_id %2% from current printer model %3%")%__LINE__ %printer_model_id %printer_model;
-                            }
-                        }
-                    }
+                    update_printer_model_id(printer_model, current_printer_vendor);
 
                     load_machine_config = std::move(config);
                 }
@@ -2092,19 +2100,16 @@ int CLI::run(int argc, char **argv)
 
             if (new_process_name.empty() && !current_process_system_name.empty()) {
                 //use the original printer name in 3mf
-                std::string system_process_path = resources_dir() + "/profiles/BBL/process_full/"+current_process_system_name+".json";
-                if (! boost::filesystem::exists(system_process_path)) {
-                    BOOST_LOG_TRIVIAL(warning) << __FUNCTION__<< boost::format(":%1%, can not find system preset file: %2% ")%__LINE__ %system_process_path;
+                DynamicPrintConfig  config;
+                std::string config_type, config_name, filament_id, config_from;
+                int ret = load_system_preset(Preset::TYPE_PRINT, current_process_system_name, current_printer_vendor,
+                                             config, config_type, config_name, filament_id, config_from);
+                if (ret) {
+                    BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(":%1%, can not resolve system process preset %2% for vendor %3%")
+                        %__LINE__ %current_process_system_name %current_printer_vendor;
                     //use original one
                 }
                 else {
-                    DynamicPrintConfig  config;
-                    std::string config_type, config_name, filament_id, config_from;
-                    int ret = load_config_file(system_process_path, config, config_type, config_name, filament_id, config_from);
-                    if (ret) {
-                        record_exit_reson(outfile_dir, ret, 0, cli_errors[ret], sliced_info);
-                        flush_and_exit(ret);
-                    }
                     current_print_compatible_printers  = config.option<ConfigOptionStrings>("compatible_printers", true)->values;
                     config.set("print_settings_id", config_name, true);
                     load_process_config = std::move(config);
@@ -2162,22 +2167,19 @@ int CLI::run(int argc, char **argv)
                 current_index = 0;
                 for (int index = 0; index < current_filaments_system_name.size(); index++)
                 {
-                    std::string system_filament_path = resources_dir() + "/profiles/BBL/filament_full/"+current_filaments_system_name[index]+".json";
                     current_index++;
-                    if (! boost::filesystem::exists(system_filament_path)) {
-                        BOOST_LOG_TRIVIAL(warning) << __FUNCTION__<< boost::format(":%1%, can not find system preset file: %2% ")%__LINE__ %system_filament_path;
-                        continue;
-                    }
                     DynamicPrintConfig  config;
                     std::string config_type, config_name, filament_id, config_from;
-                    int ret = load_config_file(system_filament_path, config, config_type, config_name, filament_id, config_from);
+                    int ret = load_system_preset(Preset::TYPE_FILAMENT, current_filaments_system_name[index], current_printer_vendor,
+                                                 config, config_type, config_name, filament_id, config_from);
                     if (ret) {
-                        record_exit_reson(outfile_dir, ret, 0, cli_errors[ret], sliced_info);
-                        flush_and_exit(ret);
+                        BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(":%1%, can not resolve system filament preset %2% for vendor %3%")
+                            %__LINE__ %current_filaments_system_name[index] %current_printer_vendor;
+                        continue;
                     }
 
                     if (config_type != "filament") {
-                        BOOST_LOG_TRIVIAL(error) <<__FUNCTION__ << boost::format(": unknown config type %1% of file %2% in load-filaments") % config_type % system_filament_path;
+                        BOOST_LOG_TRIVIAL(error) <<__FUNCTION__ << boost::format(": unknown config type %1% of system preset %2% in load-filaments") % config_type % current_filaments_system_name[index];
                         record_exit_reson(outfile_dir, CLI_CONFIG_FILE_ERROR, 0, cli_errors[CLI_CONFIG_FILE_ERROR], sliced_info);
                         flush_and_exit(CLI_CONFIG_FILE_ERROR);
                     }
@@ -2187,7 +2189,7 @@ int CLI::run(int argc, char **argv)
                     load_filaments_config.push_back(std::move(config));
                     load_filaments_index.push_back(current_index);
                     load_filaments_inherit.push_back(config_name);
-                    BOOST_LOG_TRIVIAL(info) << boost::format("LINE %4%: load a filament config %1% from file %2%, index %3%")%config_name %system_filament_path %index %__LINE__;
+                    BOOST_LOG_TRIVIAL(info) << boost::format("LINE %4%: load a filament config %1% from vendor %2%, index %3%")%config_name %current_printer_vendor %index %__LINE__;
                 }
             }
         }
@@ -2201,19 +2203,16 @@ int CLI::run(int argc, char **argv)
     if (fetch_upward_values) {
         if (!current_printer_system_name.empty()) {
             //use the original printer name in 3mf
-            std::string system_printer_path = resources_dir() + "/profiles/BBL/machine_full/"+current_printer_system_name+".json";
-            if (! boost::filesystem::exists(system_printer_path)) {
-                BOOST_LOG_TRIVIAL(warning) << __FUNCTION__<< boost::format(":%1%, can not find system preset file: %2% ")%__LINE__ %system_printer_path;
+            DynamicPrintConfig  config;
+            std::string config_type, config_name, filament_id, config_from;
+            int ret = load_system_preset(Preset::TYPE_PRINTER, current_printer_system_name, current_printer_vendor,
+                                         config, config_type, config_name, filament_id, config_from);
+            if (ret) {
+                BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(":%1%, can not resolve system machine preset %2% for vendor %3%")
+                    %__LINE__ %current_printer_system_name %current_printer_vendor;
                 //skip
             }
             else {
-                DynamicPrintConfig  config;
-                std::string config_type, config_name, filament_id, config_from;
-                int ret = load_config_file(system_printer_path, config, config_type, config_name, filament_id, config_from);
-                if (ret) {
-                    record_exit_reson(outfile_dir, ret, 0, cli_errors[ret], sliced_info);
-                    flush_and_exit(ret);
-                }
                 upward_compatible_printers = config.option<ConfigOptionStrings>("upward_compatible_machine", true)->values;
             }
         }
@@ -2223,19 +2222,16 @@ int CLI::run(int argc, char **argv)
     if (fetch_compatible_values) {
         if (!current_process_system_name.empty()) {
             //use the original printer name in 3mf
-            std::string system_process_path = resources_dir() + "/profiles/BBL/process_full/"+current_process_system_name+".json";
-            if (! boost::filesystem::exists(system_process_path)) {
-                BOOST_LOG_TRIVIAL(warning) << __FUNCTION__<< boost::format(":%1%, can not find system preset file: %2% ")%__LINE__ %system_process_path;
+            DynamicPrintConfig  config;
+            std::string config_type, config_name, filament_id, config_from;
+            int ret = load_system_preset(Preset::TYPE_PRINT, current_process_system_name, current_printer_vendor,
+                                         config, config_type, config_name, filament_id, config_from);
+            if (ret) {
+                BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << boost::format(":%1%, can not resolve system process preset %2% for vendor %3%")
+                    %__LINE__ %current_process_system_name %current_printer_vendor;
                 //use original one
             }
             else {
-                DynamicPrintConfig  config;
-                std::string config_type, config_name, filament_id, config_from;
-                int ret = load_config_file(system_process_path, config, config_type, config_name, filament_id, config_from);
-                if (ret) {
-                    record_exit_reson(outfile_dir, ret, 0, cli_errors[ret], sliced_info);
-                    flush_and_exit(ret);
-                }
                 current_print_compatible_printers  = config.option<ConfigOptionStrings>("compatible_printers", true)->values;
             }
         }
@@ -2482,7 +2478,8 @@ int CLI::run(int argc, char **argv)
                 //printer safe check
                 BOOST_LOG_TRIVIAL(info) << boost::format("check printer cli safe params, current_printer_name %1%, new_printer_name %2%, printer_model %3%")%current_printer_name %new_printer_name %printer_model;
                 std::map<std::string, std::string> printer_params;
-                std::string cli_config_file = resources_dir() + "/profiles/BBL/cli_config.json";
+                const std::string &printer_vendor = !new_printer_vendor.empty() ? new_printer_vendor : current_printer_vendor;
+                std::string cli_config_file = resource_profiles.vendor_resource(printer_vendor, "cli_config.json").string();
                 boost::filesystem::path directory_path(cli_config_file);
 
                 BOOST_LOG_TRIVIAL(info) << boost::format("line %1% , will parse file %2%")%__LINE__ % cli_config_file;
@@ -3369,30 +3366,30 @@ int CLI::run(int argc, char **argv)
     std::vector<bool> downward_check_status;
     if (downward_check) {
         bool use_default = false;
-        std::string default_path;
         if (downward_settings.size() == 0) {
             //parse from internal
-            std::string cli_config_file = resources_dir() + "/profiles/BBL/cli_config.json";
-            load_downward_settings_list_from_config(cli_config_file, current_printer_name, current_printer_model, downward_settings);
+            std::string cli_config_file = resource_profiles.vendor_resource(current_printer_vendor, "cli_config.json").string();
+            if (!cli_config_file.empty())
+                load_downward_settings_list_from_config(cli_config_file, current_printer_name, current_printer_model, downward_settings);
             use_default = true;
-            default_path = resources_dir() + "/profiles/BBL/machine_full/";
         }
         for (auto const &file : downward_settings) {
             DynamicPrintConfig  config;
             std::string config_type, config_name, filament_id, config_from, downward_printer;
-            std::string file_path = use_default?(default_path+file+".json"):file;
-            int ret = load_config_file(file_path, config, config_type, config_name, filament_id, config_from);
+            int ret = use_default
+                ? load_system_preset(Preset::TYPE_PRINTER, file, current_printer_vendor, config, config_type, config_name, filament_id, config_from)
+                : load_config_file(file, config, config_type, config_name, filament_id, config_from);
             if (ret) {
                 record_exit_reson(outfile_dir, ret, 0, cli_errors[ret], sliced_info);
                 flush_and_exit(ret);
             }
             if ((config_type != "machine") || (config_from != "system")) {
-                BOOST_LOG_TRIVIAL(info) << boost::format("found invalid config type %1% or from %2% in file %3% when downward_check")%config_type %config_from %file_path;
+                BOOST_LOG_TRIVIAL(info) << boost::format("found invalid config type %1% or from %2% in preset %3% when downward_check")%config_type %config_from %file;
                 record_exit_reson(outfile_dir, ret, 0, cli_errors[CLI_CONFIG_FILE_ERROR], sliced_info);
                 flush_and_exit(ret);
 
             }
-            BOOST_LOG_TRIVIAL(info) << boost::format("downward_check: loaded machine config %1%, from %2%")%config_name %file_path ;
+            BOOST_LOG_TRIVIAL(info) << boost::format("downward_check: loaded machine config %1%, from %2%")%config_name %(use_default ? current_printer_vendor : file);
 
             printer_plate_info_t printer_plate;
             Pointfs temp_printable_area, temp_exclude_area;

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -312,6 +312,238 @@ PresetBundle& PresetBundle::operator=(const PresetBundle &rhs)
     return *this;
 }
 
+ResourceProfileResolver::ResourceProfileResolver(boost::filesystem::path profiles_dir)
+    : m_profiles_dir(std::move(profiles_dir))
+{
+    if (!boost::filesystem::is_directory(m_profiles_dir))
+        return;
+
+    auto index_names = [](const json &root, const char *key, std::set<std::string> &names) {
+        auto list = root.find(key);
+        if (list == root.end() || !list->is_array())
+            return;
+        for (const json &entry : *list) {
+            if (!entry.is_object())
+                continue;
+            auto name = entry.find(BBL_JSON_KEY_NAME);
+            if (name != entry.end() && name->is_string())
+                names.emplace(name->get<std::string>());
+        }
+    };
+
+    for (const boost::filesystem::directory_entry &entry : boost::filesystem::directory_iterator(m_profiles_dir)) {
+        if (!boost::filesystem::is_regular_file(entry.path()) || !is_json_file(entry.path().string()))
+            continue;
+        try {
+            boost::nowide::ifstream stream(entry.path().string());
+            json root;
+            stream >> root;
+            if (!root.is_object() || !root.contains(BBL_JSON_KEY_NAME))
+                continue;
+
+            ManifestIndex index;
+            index_names(root, BBL_JSON_KEY_MACHINE_MODEL_LIST, index.machine_models);
+            index_names(root, BBL_JSON_KEY_MACHINE_LIST, index.machines);
+            index_names(root, BBL_JSON_KEY_PROCESS_LIST, index.processes);
+            index_names(root, BBL_JSON_KEY_FILAMENT_LIST, index.filaments);
+            m_manifests.emplace(entry.path().stem().string(), std::move(index));
+        } catch (const std::exception &error) {
+            BOOST_LOG_TRIVIAL(warning) << "Skipping invalid profile manifest " << entry.path().string()
+                                       << ": " << error.what();
+        }
+    }
+}
+
+const std::set<std::string> *ResourceProfileResolver::names_for_type(const ManifestIndex &index, Preset::Type type) const
+{
+    switch (type) {
+    case Preset::TYPE_PRINTER:  return &index.machines;
+    case Preset::TYPE_PRINT:    return &index.processes;
+    case Preset::TYPE_FILAMENT: return &index.filaments;
+    default:                    return nullptr;
+    }
+}
+
+std::string ResourceProfileResolver::unique_vendor_for_name(const std::string &name, Preset::Type type) const
+{
+    std::string match;
+    for (const auto &[vendor_id, index] : m_manifests) {
+        const std::set<std::string> *names = names_for_type(index, type);
+        if (names == nullptr || names->find(name) == names->end())
+            continue;
+        if (!match.empty())
+            return {};
+        match = vendor_id;
+    }
+    return match;
+}
+
+std::string ResourceProfileResolver::unique_vendor_for_model(const std::string &name) const
+{
+    std::string match;
+    for (const auto &[vendor_id, index] : m_manifests) {
+        if (index.machine_models.find(name) == index.machine_models.end())
+            continue;
+        if (!match.empty())
+            return {};
+        match = vendor_id;
+    }
+    return match;
+}
+
+std::string ResourceProfileResolver::vendor_for_printer(const std::string &printer_preset_name,
+                                                         const std::string &printer_model_name) const
+{
+    const std::string model_vendor   = printer_model_name.empty() ? std::string() : unique_vendor_for_model(printer_model_name);
+    const std::string printer_vendor = printer_preset_name.empty() ? std::string() : unique_vendor_for_name(printer_preset_name, Preset::TYPE_PRINTER);
+    if (!model_vendor.empty() && !printer_vendor.empty() && model_vendor != printer_vendor)
+        return {};
+    return !model_vendor.empty() ? model_vendor : printer_vendor;
+}
+
+PresetBundle *ResourceProfileResolver::load_base_bundle()
+{
+    if (m_base_bundle != nullptr)
+        return m_base_bundle.get();
+    if (m_base_bundle_failed || m_manifests.find(PresetBundle::ORCA_FILAMENT_LIBRARY) == m_manifests.end())
+        return nullptr;
+
+    try {
+        auto bundle = std::make_unique<PresetBundle>();
+        bundle->load_vendor_configs_from_json(m_profiles_dir.string(), PresetBundle::ORCA_FILAMENT_LIBRARY,
+                                              PresetBundle::LoadSystem,
+                                              ForwardCompatibilitySubstitutionRule::EnableSilent);
+        m_base_bundle = std::move(bundle);
+        return m_base_bundle.get();
+    } catch (const std::exception &error) {
+        m_base_bundle_failed = true;
+        BOOST_LOG_TRIVIAL(warning) << "Unable to load shared system filament profiles: " << error.what();
+        return nullptr;
+    }
+}
+
+PresetBundle *ResourceProfileResolver::load_vendor(const std::string &vendor_id)
+{
+    if (vendor_id == PresetBundle::ORCA_FILAMENT_LIBRARY)
+        return load_base_bundle();
+
+    auto loaded = m_loaded_vendors.find(vendor_id);
+    if (loaded != m_loaded_vendors.end())
+        return loaded->second.get();
+    if (m_manifests.find(vendor_id) == m_manifests.end() || m_failed_vendors.find(vendor_id) != m_failed_vendors.end())
+        return nullptr;
+
+    try {
+        auto bundle = std::make_unique<PresetBundle>();
+        bundle->load_vendor_configs_from_json(m_profiles_dir.string(), vendor_id, PresetBundle::LoadSystem,
+                                              ForwardCompatibilitySubstitutionRule::EnableSilent,
+                                              load_base_bundle());
+        PresetBundle *result = bundle.get();
+        m_loaded_vendors.emplace(vendor_id, std::move(bundle));
+        return result;
+    } catch (const std::exception &error) {
+        m_failed_vendors.emplace(vendor_id);
+        BOOST_LOG_TRIVIAL(warning) << "Unable to load system profile vendor " << vendor_id << ": " << error.what();
+        return nullptr;
+    }
+}
+
+bool ResourceProfileResolver::resolve_preset(Preset::Type type, const std::string &name,
+                                             const std::string &vendor_hint, ResolvedPreset &out)
+{
+    std::string vendor_id;
+    if (!vendor_hint.empty()) {
+        auto manifest = m_manifests.find(vendor_hint);
+        if (manifest != m_manifests.end()) {
+            const std::set<std::string> *names = names_for_type(manifest->second, type);
+            if (names != nullptr && names->find(name) != names->end())
+                vendor_id = vendor_hint;
+        }
+    }
+    if (vendor_id.empty()) {
+        vendor_id = unique_vendor_for_name(name, type);
+        if (vendor_id.empty() && type == Preset::TYPE_FILAMENT) {
+            // OrcaFilamentLibrary intentionally ships an empty manifest, so its
+            // directly selectable @System presets can only be discovered after
+            // the canonical shared bundle has been loaded.
+            PresetBundle *base_bundle = load_base_bundle();
+            const Preset *base_preset = base_bundle == nullptr ? nullptr : base_bundle->filaments.find_preset(name, false);
+            if (base_preset != nullptr && !base_preset->is_default) {
+                out.config      = base_preset->config;
+                out.name        = base_preset->name;
+                out.vendor_id   = PresetBundle::ORCA_FILAMENT_LIBRARY;
+                out.filament_id = base_preset->filament_id;
+                return true;
+            }
+        }
+        if (vendor_id.empty())
+            return false;
+    }
+
+    PresetBundle *bundle = load_vendor(vendor_id);
+    if (bundle == nullptr)
+        return false;
+
+    const Preset *preset = nullptr;
+    switch (type) {
+    case Preset::TYPE_PRINTER:  preset = bundle->printers.find_preset(name, false); break;
+    case Preset::TYPE_PRINT:    preset = bundle->prints.find_preset(name, false); break;
+    case Preset::TYPE_FILAMENT: preset = bundle->filaments.find_preset(name, false); break;
+    default:                    return false;
+    }
+    if (preset == nullptr || preset->is_default)
+        return false;
+
+    out.config      = preset->config;
+    out.name        = preset->name;
+    out.vendor_id   = vendor_id;
+    out.filament_id = preset->filament_id;
+    return true;
+}
+
+bool ResourceProfileResolver::resolve_printer_model(const std::string &name, const std::string &vendor_hint,
+                                                    ResolvedPrinterModel &out)
+{
+    std::string vendor_id;
+    if (!vendor_hint.empty()) {
+        auto manifest = m_manifests.find(vendor_hint);
+        if (manifest != m_manifests.end() && manifest->second.machine_models.find(name) != manifest->second.machine_models.end())
+            vendor_id = vendor_hint;
+    }
+    if (vendor_id.empty()) {
+        vendor_id = unique_vendor_for_model(name);
+        if (vendor_id.empty())
+            return false;
+    }
+
+    PresetBundle *bundle = load_vendor(vendor_id);
+    if (bundle == nullptr)
+        return false;
+    auto vendor = bundle->vendors.find(vendor_id);
+    if (vendor == bundle->vendors.end())
+        return false;
+
+    auto model = std::find_if(vendor->second.models.begin(), vendor->second.models.end(), [&name](const VendorProfile::PrinterModel &candidate) {
+        return candidate.id == name || candidate.name == name || candidate.model_id == name;
+    });
+    if (model == vendor->second.models.end())
+        return false;
+
+    out.name      = model->name;
+    out.id        = model->id;
+    out.model_id  = model->model_id;
+    out.vendor_id = vendor_id;
+    return true;
+}
+
+boost::filesystem::path ResourceProfileResolver::vendor_resource(const std::string &vendor_id,
+                                                                 const boost::filesystem::path &relative_path) const
+{
+    if (vendor_id.empty() || relative_path.empty() || relative_path.is_absolute() || m_manifests.find(vendor_id) == m_manifests.end())
+        return {};
+    return (m_profiles_dir / vendor_id / relative_path).lexically_normal();
+}
+
 void PresetBundle::reset(bool delete_files)
 {
     // Clear the existing presets, delete their respective files.

--- a/src/libslic3r/PresetBundle.hpp
+++ b/src/libslic3r/PresetBundle.hpp
@@ -8,6 +8,8 @@
 #include "MixedFilament.hpp"
 
 #include <memory>
+#include <map>
+#include <set>
 #include <unordered_map>
 #include <array>
 #include <vector>
@@ -462,6 +464,66 @@ private:
     int m_errors = 0;
     std::vector<unsigned int> m_last_filament_id_remap;
 
+};
+
+// Read-only resolver used by non-GUI callers which need the flattened system
+// presets shipped under resources/profiles. A printer-derived vendor hint is
+// preferred; an unambiguous global owner is used when the hint cannot satisfy
+// the request. Ambiguous logical names (for example, "Generic PLA") still
+// require the printer vendor context.
+class ResourceProfileResolver
+{
+public:
+    struct ResolvedPreset {
+        DynamicPrintConfig config;
+        std::string        name;
+        std::string        vendor_id;
+        std::string        filament_id;
+    };
+
+    struct ResolvedPrinterModel {
+        std::string name;
+        std::string id;
+        std::string model_id;
+        std::string vendor_id;
+    };
+
+    explicit ResourceProfileResolver(boost::filesystem::path profiles_dir);
+
+    // Return an empty string when the model / machine is unknown or resolves
+    // to conflicting vendors.
+    std::string vendor_for_printer(const std::string &printer_preset_name,
+                                   const std::string &printer_model_name) const;
+
+    bool resolve_preset(Preset::Type type, const std::string &name,
+                        const std::string &vendor_hint, ResolvedPreset &out);
+    bool resolve_printer_model(const std::string &name, const std::string &vendor_hint,
+                               ResolvedPrinterModel &out);
+
+    // Auxiliary files (such as cli_config.json) are vendor scoped and optional.
+    boost::filesystem::path vendor_resource(const std::string &vendor_id,
+                                            const boost::filesystem::path &relative_path) const;
+
+private:
+    struct ManifestIndex {
+        std::set<std::string> machine_models;
+        std::set<std::string> machines;
+        std::set<std::string> processes;
+        std::set<std::string> filaments;
+    };
+
+    const std::set<std::string> *names_for_type(const ManifestIndex &index, Preset::Type type) const;
+    std::string unique_vendor_for_name(const std::string &name, Preset::Type type) const;
+    std::string unique_vendor_for_model(const std::string &name) const;
+    PresetBundle *load_base_bundle();
+    PresetBundle *load_vendor(const std::string &vendor_id);
+
+    boost::filesystem::path                              m_profiles_dir;
+    std::map<std::string, ManifestIndex>                 m_manifests;
+    std::unique_ptr<PresetBundle>                        m_base_bundle;
+    bool                                                 m_base_bundle_failed {false};
+    std::map<std::string, std::unique_ptr<PresetBundle>> m_loaded_vendors;
+    std::set<std::string>                                m_failed_vendors;
 };
 
 ENABLE_ENUM_BITMASK_OPERATORS(PresetBundle::LoadConfigBundleAttribute)

--- a/tests/libslic3r/CMakeLists.txt
+++ b/tests/libslic3r/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(${_TEST_NAME}_tests
 	test_placeholder_parser.cpp
 	test_polygon.cpp
 	test_profile_load_util.cpp
+	test_resource_profile_resolver.cpp
 	test_mutable_polygon.cpp
 	test_mutable_priority_queue.cpp
 	test_stl.cpp

--- a/tests/libslic3r/test_resource_profile_resolver.cpp
+++ b/tests/libslic3r/test_resource_profile_resolver.cpp
@@ -1,0 +1,95 @@
+#include <catch2/catch.hpp>
+
+#include "libslic3r/PresetBundle.hpp"
+
+#include <boost/filesystem.hpp>
+
+using namespace Slic3r;
+
+namespace {
+
+boost::filesystem::path profile_resources()
+{
+    return boost::filesystem::path(TEST_DATA_DIR).parent_path().parent_path() / "resources" / "profiles";
+}
+
+} // namespace
+
+TEST_CASE("resource profile resolver derives a single printer vendor", "[Config][ResourceProfileResolver]")
+{
+    ResourceProfileResolver resolver(profile_resources());
+
+    CHECK(resolver.vendor_for_printer("Snapmaker U1 (0.4 nozzle)", "Snapmaker U1") == "Snapmaker");
+    CHECK(resolver.vendor_for_printer("Bambu Lab X1 Carbon 0.4 nozzle", "Bambu Lab X1 Carbon") == "BBL");
+    CHECK(resolver.vendor_for_printer("Snapmaker U1 (0.4 nozzle)", "Bambu Lab X1 Carbon").empty());
+
+    CHECK(boost::filesystem::exists(resolver.vendor_resource("BBL", "cli_config.json")));
+    CHECK_FALSE(boost::filesystem::exists(resolver.vendor_resource("Snapmaker", "cli_config.json")));
+}
+
+TEST_CASE("resource profile resolver returns flattened Snapmaker U1 presets", "[Config][ResourceProfileResolver]")
+{
+    ResourceProfileResolver                 resolver(profile_resources());
+    ResourceProfileResolver::ResolvedPreset preset;
+
+    REQUIRE(resolver.resolve_preset(Preset::TYPE_PRINTER, "Snapmaker U1 (0.4 nozzle)", "Snapmaker", preset));
+    CHECK(preset.vendor_id == "Snapmaker");
+    CHECK(preset.config.opt_string("printer_model") == "Snapmaker U1");
+    CHECK(preset.config.opt_enum<GCodeFlavor>("gcode_flavor") == gcfKlipper);
+    REQUIRE(preset.config.option<ConfigOptionFloats>("nozzle_diameter") != nullptr);
+    CHECK(preset.config.option<ConfigOptionFloats>("nozzle_diameter")->values.size() == 4);
+
+    REQUIRE(resolver.resolve_preset(Preset::TYPE_PRINT, "0.20 Standard @Snapmaker U1 (0.4 nozzle)", "Snapmaker", preset));
+    CHECK(preset.config.opt_float("layer_height") == Approx(0.2));
+    REQUIRE(preset.config.option<ConfigOptionStrings>("compatible_printers") != nullptr);
+    CHECK(preset.config.option<ConfigOptionStrings>("compatible_printers")->values ==
+          std::vector<std::string>{"Snapmaker U1 (0.4 nozzle)"});
+
+    REQUIRE(resolver.resolve_preset(Preset::TYPE_FILAMENT, "Generic PLA", "Snapmaker", preset));
+    CHECK(preset.config.opt_string("filament_type", static_cast<unsigned int>(0)) == "PLA");
+
+    // The same logical filament name is shipped by multiple vendors and must
+    // not be selected without the printer-derived vendor context.
+    CHECK_FALSE(resolver.resolve_preset(Preset::TYPE_FILAMENT, "Generic PLA", "", preset));
+}
+
+TEST_CASE("resource profile resolver returns model ids and keeps BBL working", "[Config][ResourceProfileResolver]")
+{
+    ResourceProfileResolver                       resolver(profile_resources());
+    ResourceProfileResolver::ResolvedPrinterModel model;
+    ResourceProfileResolver::ResolvedPreset       preset;
+
+    REQUIRE(resolver.resolve_printer_model("Snapmaker U1", "Snapmaker", model));
+    CHECK(model.model_id == "SM_U1");
+
+    REQUIRE(resolver.resolve_printer_model("Bambu Lab X1 Carbon", "BBL", model));
+    CHECK(model.model_id == "BL-P001");
+    REQUIRE(resolver.resolve_preset(Preset::TYPE_PRINTER, "Bambu Lab X1 Carbon 0.4 nozzle", "BBL", preset));
+    CHECK(preset.config.opt_string("printer_model") == "Bambu Lab X1 Carbon");
+
+    // A vendor argument is a preference, not a hard scope. Stale or partial
+    // project metadata may provide the wrong hint, but a unique profile/model
+    // owner is still safe to select.
+    REQUIRE(resolver.resolve_printer_model("Snapmaker U1", "BBL", model));
+    CHECK(model.vendor_id == "Snapmaker");
+    REQUIRE(resolver.resolve_preset(Preset::TYPE_PRINTER, "Snapmaker U1 (0.4 nozzle)", "BBL", preset));
+    CHECK(preset.vendor_id == "Snapmaker");
+}
+
+TEST_CASE("resource profile resolver supports shared filament inheritance", "[Config][ResourceProfileResolver]")
+{
+    ResourceProfileResolver                 resolver(profile_resources());
+    ResourceProfileResolver::ResolvedPreset preset;
+
+    // Sovol's instantiated filament inherits Generic PLA @System from the
+    // canonical OrcaFilamentLibrary bundle rather than from Sovol itself.
+    REQUIRE(resolver.resolve_preset(Preset::TYPE_FILAMENT, "Sovol SV06 ACE PLA", "Sovol", preset));
+    CHECK(preset.vendor_id == "Sovol");
+    CHECK(preset.config.opt_string("filament_type", static_cast<unsigned int>(0)) == "PLA");
+
+    // Directly selected shared presets are absent from the intentionally empty
+    // OrcaFilamentLibrary manifest, but are valid for any printer vendor.
+    REQUIRE(resolver.resolve_preset(Preset::TYPE_FILAMENT, "Generic PLA @System", "Sovol", preset));
+    CHECK(preset.vendor_id == PresetBundle::ORCA_FILAMENT_LIBRARY);
+    CHECK(preset.config.opt_string("filament_type", static_cast<unsigned int>(0)) == "PLA");
+}


### PR DESCRIPTION
## Summary

This is a focused follow-up to #689 for the profile-resolution part of headless CLI slicing. It does not replace the existing crash fixes in #560, #561, #562, or #761.

The CLI currently resolves embedded system presets and printer model metadata through hard-coded `profiles/BBL` paths. This change introduces an internal `ResourceProfileResolver` that:

- derives the vendor from the printer preset and/or printer model;
- loads flattened machine, process, and filament presets from that vendor bundle;
- resolves vendor-specific printer model IDs (including Snapmaker U1 `SM_U1`);
- supports shared `OrcaFilamentLibrary` inheritance;
- rejects ambiguous names unless printer vendor context disambiguates them; and
- resolves optional vendor-scoped resources such as `cli_config.json`.

Bambu Lab remains the same supported path, but it is no longer the only hard-coded profile root. There are no public CLI syntax changes.

## Relationship to existing PRs

- #560 hardens CLI plate loading.
- #561 and #761 address the process-only `normalize_fdm()` null dereference.
- #562 removes a GUI filament-state dependency from CLI extruder expansion.

Those fixes are complementary and intentionally excluded from this diff.

## Validation

- Clean arm64 Release build of `Snapmaker_Orca` and `libslic3r_tests`: passed.
- `libslic3r_tests '[ResourceProfileResolver]'`: 34 assertions in 4 test cases, all passed.
- Coverage includes Snapmaker U1 vendor discovery, flattened U1 machine/process/filament presets, `SM_U1`, shared filaments, ambiguous `Generic PLA`, and BBL regression behavior.
- Local combined validation branch using the exact commits from #560, #562, and #761:
  - Snapmaker U1 / 0.20 Standard / 20 mm cube CLI slice: exit 0 in 2.07 s.
  - Bambu Lab X1 Carbon / 0.20 Standard / 20 mm cube CLI slice: resolved `BL-P001` under vendor `BBL`, exit 0 in 2.07 s.

The combined validation branch and test models are not part of this PR.
