### PR TITLE
fix: heap corruption from flush matrix desync after U1 nozzle switch

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9734,6 +9734,14 @@ void Sidebar::auto_calc_flushing_volumes(const int modify_id)
         multi_colours.push_back(single_filament);
     }
 
+    const size_t expectedMatrixSize = multi_colours.size() * multi_colours.size();
+    if (matrix.size() != expectedMatrixSize) {
+        BOOST_LOG_TRIVIAL(error) << "Invalid flushing volume matrix: modify_id=" << modify_id
+                                 << ", filament_count=" << multi_colours.size()
+                                 << ", matrix_size=" << matrix.size()
+                                 << ", expected_size=" << expectedMatrixSize;
+    }
+
     if (modify_id >= 0 && modify_id < multi_colours.size()) {
         for (int i = 0; i < multi_colours.size(); ++i) {
             // from to modify

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5720,6 +5720,13 @@ bool Tab::select_preset(std::string preset_name, bool delete_current /*=false*/,
                     oldFilamentColourModes[i] = oldFilamentColourModes[i] == 1 ? 1 : 0;
                 }
 
+                std::vector<double> oldFlushVolumesMatrix;
+                std::vector<double> oldFlushVolumesVector;
+                if (const ConfigOptionFloats* flushMatrix = projectConfig.option<ConfigOptionFloats>("flush_volumes_matrix"))
+                    oldFlushVolumesMatrix = flushMatrix->values;
+                if (const ConfigOptionFloats* flushVector = projectConfig.option<ConfigOptionFloats>("flush_volumes_vector"))
+                    oldFlushVolumesVector = flushVector->values;
+
                 m_preset_bundle->update_selections(*wxGetApp().app_config);
 
                 m_preset_bundle->filament_presets = oldFilamentPresets;
@@ -5727,6 +5734,11 @@ bool Tab::select_preset(std::string preset_name, bool delete_current /*=false*/,
                 projectConfig.option<ConfigOptionStrings>("filament_colour")->values = oldFilamentColors;
                 projectConfig.option<ConfigOptionStrings>("filament_multi_colors", true)->values = oldFilamentMultiColors;
                 projectConfig.option<ConfigOptionInts>("filament_colour_mode", true)->values = oldFilamentColourModes;
+
+                if (ConfigOptionFloats* flushMatrix = projectConfig.option<ConfigOptionFloats>("flush_volumes_matrix"))
+                    flushMatrix->values = oldFlushVolumesMatrix;
+                if (ConfigOptionFloats* flushVector = projectConfig.option<ConfigOptionFloats>("flush_volumes_vector"))
+                    flushVector->values = oldFlushVolumesVector;
 
                 std::vector<std::string> filamentColourModeStrings;
                 filamentColourModeStrings.reserve(oldFilamentColourModes.size());


### PR DESCRIPTION
# Description

## Symptom
OrcaSlicer crashed with 0xC0000374 (heap corruption) on Snapmaker U1 after
switching nozzles and then switching filaments. The crash site differed between
runs (the stringstream destructor in SplitFilamentMultiColors, the DynamicConfig
destructor at the end of auto_calc_flushing_volumes, etc.) — the classic
delayed-detection signature of heap corruption.

## Root Cause
The U1-specific filament carry-over block in Tab::select_preset calls
update_selections() (which restores the new machine's saved state, including
its flush matrix) and then restores the previous filament presets and colours —
but not flush_volumes_matrix / flush_volumes_vector. The matrix stayed sized
for the new nozzle's saved entry (1x1 for a single-filament machine) while 4
filaments were carried back, leaving 4 presets paired with a 1x1 matrix.
auto_calc_flushing_volumes then looped over the filament count and wrote
matrix[row * n + modify_id] past the 1-element buffer, corrupting adjacent
heap block headers