### PR TITLE
Fix small area flow compensation on U1 and skip model parsing when sabled

### DIFF
--- a/resources/profiles/Snapmaker/process/0.20 Standard @Snapmaker U1 (0.4 nozzle).json
+++ b/resources/profiles/Snapmaker/process/0.20 Standard @Snapmaker U1 (0.4 nozzle).json
@@ -30,7 +30,6 @@
     "internal_solid_infill_pattern": "rectilinear",
     "precise_outer_wall": "0",
     "seam_gap": "15%",
-    "small_area_infill_flow_compensation_model": [],
     "support_type": "tree(auto)",
     "wipe_speed": "50",
     "wipe_tower_extra_rib_length": "8",

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2225,7 +2225,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream& file, ThumbnailsGenerato
     } else
         m_enable_extrusion_role_markers = false;
 
-    if (!print.config().small_area_infill_flow_compensation_model.empty())
+    if (m_config.small_area_infill_flow_compensation.value && !m_config.small_area_infill_flow_compensation_model.empty())
         m_small_area_infill_flow_compensator = make_unique<SmallAreaInfillFlowCompensator>(print.config());
 
     // Orca: Don't output Header block if BTT thumbnail is identified in the list


### PR DESCRIPTION
- Remove the empty small_area_infill_flow_compensation_model override in '0.20 Standard @Snapmaker U1 (0.4 nozzle)': the empty array took priority over the PrintConfig default 10-point model and silently disabled the feature for this preset.
- Only construct SmallAreaInfillFlowCompensator when the small_area_infill_flow_compensation toggle is enabled AND the model is non-empty (aligns with upstream OrcaSlicer #12528), so an invalid model is no longer parsed while the feature is turned off.
