### PR TITLE
Added default value for "Flow Compensation Model" parameter

### DIFF
--- a/resources/profiles/Snapmaker/process/0.20mm High Quality @Snapmaker U1 (0.4 nozzle).json
+++ b/resources/profiles/Snapmaker/process/0.20mm High Quality @Snapmaker U1 (0.4 nozzle).json
@@ -30,7 +30,6 @@
     "internal_solid_infill_pattern": "rectilinear",
     "precise_outer_wall": "0",
     "seam_gap": "15%",
-    "small_area_infill_flow_compensation_model": [],
     "support_type": "tree(auto)",
     "wipe_speed": "50",
     "wipe_tower_extra_rib_length": "8",

--- a/resources/profiles/Snapmaker/process/0.20mm Standard @Snapmaker U1 (0.4 nozzle).json
+++ b/resources/profiles/Snapmaker/process/0.20mm Standard @Snapmaker U1 (0.4 nozzle).json
@@ -31,7 +31,6 @@
     "internal_solid_infill_pattern": "rectilinear",
     "precise_outer_wall": "0",
     "seam_gap": "15%",
-    "small_area_infill_flow_compensation_model": [],
     "support_type": "tree(auto)",
     "wipe_speed": "50",
     "wipe_tower_extra_rib_length": "8",

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2225,7 +2225,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream& file, ThumbnailsGenerato
     } else
         m_enable_extrusion_role_markers = false;
 
-    if (!print.config().small_area_infill_flow_compensation_model.empty())
+    if (m_config.small_area_infill_flow_compensation.value && !m_config.small_area_infill_flow_compensation_model.empty())
         m_small_area_infill_flow_compensator = make_unique<SmallAreaInfillFlowCompensator>(print.config());
 
     // Orca: Don't output Header block if BTT thumbnail is identified in the list


### PR DESCRIPTION
# Description

When selecting a 0.4mm nozzle with 0.2mm layer height, a default value has been added for the "Flow Compensation Model" parameter.

# Screenshots/Recordings/Graphs

<img width="1280" height="1182" alt="image" src="https://github.com/user-attachments/assets/d00c71c8-9c5c-4528-9589-9d889be136e4" />


