### PR TITLE
feat: mixed-filament — config-driven Full Spectrum palette for recommended batch match

### DIFF
--- a/localization/i18n/list.txt
+++ b/localization/i18n/list.txt
@@ -180,3 +180,5 @@ src/slic3r/Utils/Flashforge.cpp
 src/slic3r/GUI/Jobs/OAuthJob.cpp
 src/slic3r/GUI/BackgroundSlicingProcess.cpp
 src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
+src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+src/slic3r/GUI/MixedColorMatchHelpers.cpp

--- a/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
+++ b/localization/i18n/zh_CN/Snapmaker_Orca_zh_CN.po
@@ -15487,8 +15487,8 @@ msgstr "耗材管理列表仅存在单条耗材时，无法启用混色匹配功
 msgid "Color mapping list limit reached (max 64 colors). Excess colors will be removed."
 msgstr "颜色映射列表已达上限（64 色），超出颜色将被移除。"
 
-msgid "Automatically calculate the color mixing scheme that best matches the original model colors and complete color mapping.\nNote:\n1.Color mixing match is based on the official recommended CMYG filaments. The matched colors may differ from the original model.\n2.The order of the Color Mapping list may differ from that of the Color Mixing list."
-msgstr "自动计算最接近原模型颜色的混色方案，并一键完成颜色映射。\n提示：\n1.混色匹配基于官方推荐的 CMYG 耗材进行计算，匹配结果可能与模型原始颜色存在差异。\n2.颜色映射列表中的顺序可能与耗材混色列表的顺序不同。"
+msgid "Automatically calculate the color mixing scheme that best matches the original model colors and complete color mapping.\nNote:\n1. Color mixing match is based on the official recommended filaments. The matched colors may differ from the original model.\n2. The order of the Color Mapping list may differ from that of the Color Mixing list."
+msgstr "自动计算最接近原模型颜色的混色方案，并一键完成颜色映射。\n提示：\n1. 混色匹配基于官方推荐的耗材进行计算，匹配结果可能与模型原始颜色存在差异。\n2. 颜色映射列表中的顺序可能与耗材混色列表的顺序不同。"
 
 msgid "No model detected. Import a multi-color model to continue."
 msgstr "未检测到模型，请先导入多色模型。"
@@ -15541,8 +15541,11 @@ msgstr "开始匹配"
 msgid "Rematch"
 msgstr "重新匹配"
 
-msgid "Automatically uses official CMYG filaments for color mixing. The mix ratio for each color is limited to %d%%–%d%%."
-msgstr "自动选择官方 CMYG 耗材进行混色匹配。单色混色比例范围：%d%%–%d%%。"
+msgid "Automatically select an official filament set for color mixing match. Mix ratio for each color: 0%–70%."
+msgstr "自动选择官方混色耗材套装进行混色匹配。单色混色比例范围：0%–70%。"
 
 msgid "Manually select filaments from the current list for color mixing."
 msgstr "手动选择当前列表中的耗材进行混色匹配。"
+
+msgid "Official Full Spectrum filaments are not configured. Configured filaments will be used instead. Once the official filaments are added, the previously selected filaments can be replaced in the filament list without affecting the color mixing match result."
+msgstr "未配置官方 Full Spectrum 全光谱耗材，将自动使用已配置的耗材。完成官方耗材配置后，可在耗材列表中进行替换，不影响混色匹配结果。"

--- a/src/libslic3r/FilamentColorLibrary.cpp
+++ b/src/libslic3r/FilamentColorLibrary.cpp
@@ -368,8 +368,12 @@ std::vector<FullSpectrumPaletteEntry> BuildFullSpectrumPalette(const std::vector
             auto englishIt = item.colorNames.find("en");
             if (englishIt != item.colorNames.end())
                 entry.en_name = englishIt->second;
-            else if (!item.colorNames.empty())
-                entry.en_name = item.colorNames.begin()->second;
+            // No arbitrary-locale fallback when "en" is missing (the display-only
+            // fallback in english_color_name is a different context): en_name feeds the
+            // sort key and slot-name matching, so an unordered_map::begin() pick would
+            // make palette order and default slot anchoring depend on the hash layout
+            // and on which non-English translations the config carries. Leave it empty
+            // — same contract as GetColorNameForSort in FilamentColorDialog.
             palette.emplace_back(std::move(entry));
         }
     }

--- a/src/libslic3r/FilamentColorLibrary.cpp
+++ b/src/libslic3r/FilamentColorLibrary.cpp
@@ -398,6 +398,16 @@ std::vector<int> DefaultFullSpectrumSelections(const std::vector<FullSpectrumPal
 {
     static const char* slot_color_families[kFullSpectrumSlotCount] = {"cyan", "magenta", "yellow", "white"};
 
+    // Family identity is compared in the GetFilamentMatchName space, normalized on BOTH
+    // sides (same convention as FindFilamentByName): callers may pass the raw library
+    // name ("... @U1"), the full preset name ("... @U1 0.4 nozzle"), or the already
+    // stripped match name, while palette entries always carry raw library names. Without
+    // this the default-family preference silently never fires for the non-raw forms.
+    const std::string default_match = GetFilamentMatchName(default_family);
+    const auto is_default_family = [&default_match](const FullSpectrumPaletteEntry& entry) {
+        return GetFilamentMatchName(entry.family_name) == default_match;
+    };
+
     std::vector<int> selection(std::min<size_t>(static_cast<size_t>(kFullSpectrumSlotCount), palette.size()), -1);
     std::vector<bool> used(palette.size(), false);
 
@@ -411,7 +421,7 @@ std::vector<int> DefaultFullSpectrumSelections(const std::vector<FullSpectrumPal
         {
             if (used[i] || !ContainsAsciiCaseInsensitive(palette[i].en_name, slot_color_families[slot]))
                 continue;
-            if (palette[i].family_name == default_family)
+            if (is_default_family(palette[i]))
             {
                 candidate = static_cast<int>(i);
                 break;
@@ -431,10 +441,10 @@ std::vector<int> DefaultFullSpectrumSelections(const std::vector<FullSpectrumPal
     std::vector<size_t> fill_order;
     fill_order.reserve(palette.size());
     for (size_t i = 0; i < palette.size(); ++i)
-        if (!used[i] && palette[i].family_name == default_family)
+        if (!used[i] && is_default_family(palette[i]))
             fill_order.push_back(i);
     for (size_t i = 0; i < palette.size(); ++i)
-        if (!used[i] && palette[i].family_name != default_family)
+        if (!used[i] && !is_default_family(palette[i]))
             fill_order.push_back(i);
 
     size_t next = 0;

--- a/src/libslic3r/FilamentColorLibrary.cpp
+++ b/src/libslic3r/FilamentColorLibrary.cpp
@@ -396,9 +396,9 @@ std::vector<FullSpectrumPaletteEntry> BuildFullSpectrumPalette(const std::vector
 
 std::vector<int> DefaultFullSpectrumSelections(const std::vector<FullSpectrumPaletteEntry>& palette, const std::string& default_family)
 {
-    static const char* slot_color_families[] = {"cyan", "magenta", "yellow", "white"};
+    static const char* slot_color_families[kFullSpectrumSlotCount] = {"cyan", "magenta", "yellow", "white"};
 
-    std::vector<int> selection(std::min<size_t>(4, palette.size()), -1);
+    std::vector<int> selection(std::min<size_t>(static_cast<size_t>(kFullSpectrumSlotCount), palette.size()), -1);
     std::vector<bool> used(palette.size(), false);
 
     // Pass 1: named slots (cyan / magenta / yellow / white). Scanning in palette

--- a/src/libslic3r/FilamentColorLibrary.cpp
+++ b/src/libslic3r/FilamentColorLibrary.cpp
@@ -49,6 +49,24 @@ bool EndsWithCaseInsensitive(const std::string& value, const std::string& suffix
     return true;
 }
 
+std::string AsciiLowerCopy(const std::string& value)
+{
+    std::string lowered = value;
+    std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                   [](unsigned char ch)
+                   {
+                       return static_cast<char>(std::tolower(ch));
+                   });
+    return lowered;
+}
+
+bool ContainsAsciiCaseInsensitive(const std::string& value, const std::string& needle)
+{
+    if (needle.empty())
+        return true;
+    return AsciiLowerCopy(value).find(AsciiLowerCopy(needle)) != std::string::npos;
+}
+
 std::string NormalizeHexColorNoFallback(const std::string& color)
 {
     std::string value = TrimCopy(color);
@@ -322,6 +340,108 @@ FilamentColor FilamentColor::FromMultiColors(const std::string& multiColors, Fil
                                              const std::string& fallbackColor)
 {
     return FromColors(SplitFilamentMultiColors(multiColors), mode, fallbackColor);
+}
+
+std::vector<FullSpectrumPaletteEntry> BuildFullSpectrumPalette(const std::vector<FilamentColorInfo>& library_data)
+{
+    std::vector<FullSpectrumPaletteEntry> palette;
+    for (const FilamentColorInfo& info : library_data)
+    {
+        if (!ContainsAsciiCaseInsensitive(info.type, "Full Spectrum"))
+            continue;
+
+        for (const FilamentColorItem& item : info.colors)
+        {
+            // Only single-color SKUs qualify as palette candidates; skip dual-color /
+            // gradient entries so they don't pollute the palette.
+            if (item.colorData.colors.size() != 1)
+                continue;
+
+            FullSpectrumPaletteEntry entry;
+            entry.hex = NormalizeFilamentHexColor(item.colorData.colors.front());
+            if (entry.hex.empty())
+                continue;
+
+            entry.family_name = info.filamentName;
+            entry.color_names = item.colorNames;
+            entry.td_value = item.tdValue;
+            auto englishIt = item.colorNames.find("en");
+            if (englishIt != item.colorNames.end())
+                entry.en_name = englishIt->second;
+            else if (!item.colorNames.empty())
+                entry.en_name = item.colorNames.begin()->second;
+            palette.emplace_back(std::move(entry));
+        }
+    }
+
+    // Family-grouped dropdown order (phase-2 spec, test matrix #10): entries are
+    // grouped by family (families in alphabetical order), colors within a family by
+    // canonical EN name. Single-family configs (bundled today) get the same plain
+    // alphabetical list as before; multi-family configs (after hot update) show the
+    // PLA/PETG groups. Case-insensitive and locale-independent (EN name is the SKU's
+    // canonical identity). en_name then hex break remaining ties deterministically.
+    std::stable_sort(palette.begin(), palette.end(),
+                     [](const FullSpectrumPaletteEntry& lhs, const FullSpectrumPaletteEntry& rhs)
+                     {
+                         const std::string left = AsciiLowerCopy(lhs.family_name) + " " + AsciiLowerCopy(lhs.en_name) + " " + AsciiLowerCopy(lhs.hex);
+                         const std::string right = AsciiLowerCopy(rhs.family_name) + " " + AsciiLowerCopy(rhs.en_name) + " " + AsciiLowerCopy(rhs.hex);
+                         return left < right;
+                     });
+    return palette;
+}
+
+std::vector<int> DefaultFullSpectrumSelections(const std::vector<FullSpectrumPaletteEntry>& palette, const std::string& default_family)
+{
+    static const char* slot_color_families[] = {"cyan", "magenta", "yellow", "white"};
+
+    std::vector<int> selection(std::min<size_t>(4, palette.size()), -1);
+    std::vector<bool> used(palette.size(), false);
+
+    // Pass 1: named slots (cyan / magenta / yellow / white). Scanning in palette
+    // (alphabetical) order: the first in-family hit wins immediately; an out-of-family
+    // hit is only remembered while scanning continues for an in-family one.
+    for (size_t slot = 0; slot < selection.size(); ++slot)
+    {
+        int candidate = -1;
+        for (size_t i = 0; i < palette.size(); ++i)
+        {
+            if (used[i] || !ContainsAsciiCaseInsensitive(palette[i].en_name, slot_color_families[slot]))
+                continue;
+            if (palette[i].family_name == default_family)
+            {
+                candidate = static_cast<int>(i);
+                break;
+            }
+            if (candidate < 0)
+                candidate = static_cast<int>(i);
+        }
+        if (candidate >= 0)
+        {
+            selection[slot] = candidate;
+            used[candidate] = true;
+        }
+    }
+
+    // Pass 2: fill the remaining slots with unused entries — default family first, then
+    // the rest, both in palette order.
+    std::vector<size_t> fill_order;
+    fill_order.reserve(palette.size());
+    for (size_t i = 0; i < palette.size(); ++i)
+        if (!used[i] && palette[i].family_name == default_family)
+            fill_order.push_back(i);
+    for (size_t i = 0; i < palette.size(); ++i)
+        if (!used[i] && palette[i].family_name != default_family)
+            fill_order.push_back(i);
+
+    size_t next = 0;
+    for (size_t slot = 0; slot < selection.size() && next < fill_order.size(); ++slot)
+    {
+        if (selection[slot] >= 0)
+            continue;
+        selection[slot] = static_cast<int>(fill_order[next++]);
+    }
+
+    return selection;
 }
 
 FilamentColorLibrary& FilamentColorLibrary::Instance()

--- a/src/libslic3r/FilamentColorLibrary.hpp
+++ b/src/libslic3r/FilamentColorLibrary.hpp
@@ -61,7 +61,9 @@ struct FilamentColorInfo
 struct FullSpectrumPaletteEntry
 {
     std::string hex;         // normalized "#RRGGBB"
-    std::string en_name;     // canonical English color name (sort key, never empty for entries built by BuildFullSpectrumPalette)
+    std::string en_name;     // canonical English color name (sort key). Empty when the SKU has no "en"
+                             // entry — deliberately no arbitrary-locale fallback: this feeds sorting and
+                             // slot-name matching, not display (slot matching simply skips empty names)
     std::string family_name; // owning filament name, e.g. "Snapmaker PLA Full Spectrum @U1"
     double td_value = 0.0;   // transmittance density from FilamentColorItem::tdValue; 0 = no value
     std::unordered_map<std::string, std::string> color_names; // locale -> display name (copied from the SKU entry)

--- a/src/libslic3r/FilamentColorLibrary.hpp
+++ b/src/libslic3r/FilamentColorLibrary.hpp
@@ -56,6 +56,37 @@ struct FilamentColorInfo
     std::vector<FilamentColorItem> colors;
 };
 
+// One selectable color in the recommended-mode (Full Spectrum) color-mix palette.
+// Built by BuildFullSpectrumPalette from the hot-updated filaments_colours.json.
+struct FullSpectrumPaletteEntry
+{
+    std::string hex;         // normalized "#RRGGBB"
+    std::string en_name;     // canonical English color name (sort key, never empty for entries built by BuildFullSpectrumPalette)
+    std::string family_name; // owning filament name, e.g. "Snapmaker PLA Full Spectrum @U1"
+    double td_value = 0.0;   // transmittance density from FilamentColorItem::tdValue; 0 = no value
+    std::unordered_map<std::string, std::string> color_names; // locale -> display name (copied from the SKU entry)
+};
+
+// Recommended-mode palette for the batch color match: every library filament whose
+// filament_type contains "Full Spectrum" contributes its single-color SKUs (multi-color /
+// gradient SKUs are skipped, same rule as the GUI's legacy load_full_spectrum_colors filter).
+// Entries are sorted case-insensitively by "<family_name> <en_name> <hex>" — grouped by
+// family (families in alphabetical order), colors alphabetically within a family — so the
+// dropdown order matches the phase-2 test matrix #10 and is stable across UI locales.
+// Pure function over its input (no singleton access, no file IO) — unit-testable with
+// constructed FilamentColorInfo inputs.
+std::vector<FullSpectrumPaletteEntry> BuildFullSpectrumPalette(const std::vector<FilamentColorInfo>& library_data);
+
+// Default dropdown selections (palette indices, one per slot 0..3) per the phase-2 spec:
+// slots 1..4 prefer cyan / magenta / yellow / white, matched case-insensitively against the
+// EN color name; entries of default_family win over other families (palette order breaks
+// remaining ties). Slots with no name match fall back to the next unused entry —
+// default_family entries first, then the rest, both in palette order. default_family is a
+// library filament name, i.e. pass GetFilamentMatchName(full_spectrum_preset_name()) from
+// the GUI, not the raw preset name with the nozzle suffix. Always returns distinct
+// indices; returns fewer than 4 only when the palette itself has fewer than 4 entries.
+std::vector<int> DefaultFullSpectrumSelections(const std::vector<FullSpectrumPaletteEntry>& palette, const std::string& default_family);
+
 class FilamentColorLibrary
 {
 public:
@@ -63,6 +94,10 @@ public:
 
     bool EnsureLoaded();
     void Reload();
+
+    // Read-only view of the loaded entries (empty until EnsureLoaded succeeds). The view
+    // is invalidated by Reload()/Clear — copy what you need beyond the call site.
+    const std::vector<FilamentColorInfo>& GetAllFilamentInfos() const { return _filamentInfoVec; }
 
     bool FindFilamentById(const std::string& filamentId, FilamentColorInfo& outFilament);
     bool FindFilamentByName(const std::string& filamentName, FilamentColorInfo& outFilament);

--- a/src/libslic3r/FilamentColorLibrary.hpp
+++ b/src/libslic3r/FilamentColorLibrary.hpp
@@ -87,10 +87,12 @@ std::vector<FullSpectrumPaletteEntry> BuildFullSpectrumPalette(const std::vector
 // slots 1..4 prefer cyan / magenta / yellow / white, matched case-insensitively against the
 // EN color name; entries of default_family win over other families (palette order breaks
 // remaining ties). Slots with no name match fall back to the next unused entry —
-// default_family entries first, then the rest, both in palette order. default_family is a
-// library filament name, i.e. pass GetFilamentMatchName(full_spectrum_preset_name()) from
-// the GUI, not the raw preset name with the nozzle suffix. Always returns distinct
-// indices; returns fewer than 4 only when the palette itself has fewer than 4 entries.
+// default_family entries first, then the rest, both in palette order. default_family is
+// compared in the GetFilamentMatchName space on both sides (same convention as
+// FindFilamentByName), so any of the three family-name forms is accepted: the raw library
+// name ("... @U1"), the full preset name ("... @U1 0.4 nozzle"), or the stripped match
+// name. Always returns distinct indices; returns fewer than 4 only when the palette itself
+// has fewer than 4 entries.
 std::vector<int> DefaultFullSpectrumSelections(const std::vector<FullSpectrumPaletteEntry>& palette, const std::string& default_family);
 
 class FilamentColorLibrary

--- a/src/libslic3r/FilamentColorLibrary.hpp
+++ b/src/libslic3r/FilamentColorLibrary.hpp
@@ -56,6 +56,10 @@ struct FilamentColorInfo
     std::vector<FilamentColorItem> colors;
 };
 
+// Number of color slots in the recommended-mode (Full Spectrum) palette card —
+// product spec constant (2x2 slot grid); also the C/M/Y/W default-selection count.
+constexpr int kFullSpectrumSlotCount = 4;
+
 // One selectable color in the recommended-mode (Full Spectrum) color-mix palette.
 // Built by BuildFullSpectrumPalette from the hot-updated filaments_colours.json.
 struct FullSpectrumPaletteEntry

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -709,11 +709,20 @@ std::string find_selectable_full_spectrum_family_preset(const std::string& famil
     // suffix), never by name composition: composing "family + nozzle + nozzle" would
     // re-encode the naming convention and inherit its case-sensitivity pitfalls
     // (see #742, the U1 preset filename case mismatch).
+    // Normalize BOTH sides: FullSpectrumPaletteEntry::family_name comes verbatim from
+    // filaments_colours.json ("... @U1"), which GetFilamentMatchName would strip from the
+    // preset side ("... @U1 0.4 nozzle" -> "..."). Without this the raw-vs-normalized
+    // comparison never matches and every family is reported as not configured (the
+    // Confirm-time note in MixedFilamentBatchDialog fired unconditionally).
+    const std::string family_match_name = GetFilamentMatchName(family_name);
+    if (family_match_name.empty())
+        return std::string();
+
     const double nozzle = current_nozzle_diameter();
     std::string fallback_sku;   // 0.4 SKU of the family, if present (selectable or not)
     std::string first_match;    // first visible+compatible match, lowest preference
     for (const Preset& preset : pb->filaments) {
-        if (GetFilamentMatchName(preset.name) != family_name)
+        if (GetFilamentMatchName(preset.name) != family_match_name)
             continue;
         const bool selectable = preset.is_visible && preset.is_compatible;
         if (!selectable)

--- a/src/slic3r/GUI/MixedColorMatchHelpers.cpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.cpp
@@ -20,6 +20,7 @@
 #include "libslic3r/LocalesUtils.hpp"
 #include "libslic3r/Model.hpp"
 #include "libslic3r/Print.hpp"
+#include "libslic3r/FilamentColorLibrary.hpp" // GetFilamentMatchName (family preset scan)
 
 namespace Slic3r { namespace GUI {
 wxColour parse_mixed_color(const std::string& value)
@@ -679,7 +680,7 @@ std::string full_spectrum_preset_name()
 
     // Fallback: the canonical 0.4 SKU (shipped today). If even that is missing
     // (profile not loaded), return the literal name so upstream fallback chains
-    // (load_full_spectrum_colors -> canonical CMYW palette) take over.
+    // (load_recommended_palette -> canonical palette) take over.
     return std::string(kFullSpectrumBase) + format_nozzle_label(kFallbackNozzle) + " nozzle";
 }
 
@@ -694,6 +695,41 @@ bool full_spectrum_preset_exists_for_current_nozzle()
     auto*            pb        = wxGetApp().preset_bundle;
     const std::string candidate = std::string(kFullSpectrumBase) + format_nozzle_label(nozzle) + " nozzle";
     return pb != nullptr && pb->filaments.find_preset(candidate) != nullptr;
+}
+
+std::string find_selectable_full_spectrum_family_preset(const std::string& family_name)
+{
+    if (family_name.empty())
+        return std::string();
+    auto* pb = wxGetApp().preset_bundle;
+    if (pb == nullptr)
+        return std::string();
+
+    // Scan by MATCH IDENTITY (GetFilamentMatchName strips the "<diameter> nozzle"
+    // suffix), never by name composition: composing "family + nozzle + nozzle" would
+    // re-encode the naming convention and inherit its case-sensitivity pitfalls
+    // (see #742, the U1 preset filename case mismatch).
+    const double nozzle = current_nozzle_diameter();
+    std::string fallback_sku;   // 0.4 SKU of the family, if present (selectable or not)
+    std::string first_match;    // first visible+compatible match, lowest preference
+    for (const Preset& preset : pb->filaments) {
+        if (GetFilamentMatchName(preset.name) != family_name)
+            continue;
+        const bool selectable = preset.is_visible && preset.is_compatible;
+        if (!selectable)
+            continue;
+        const bool current_nozzle = preset.name.find(format_nozzle_label(nozzle) + " nozzle") != std::string::npos;
+        const bool fallback_nozzle = preset.name.find(format_nozzle_label(kFallbackNozzle) + " nozzle") != std::string::npos;
+        if (current_nozzle)
+            return preset.name;              // highest preference: current nozzle SKU
+        if (fallback_nozzle)
+            fallback_sku = preset.name;      // second preference: 0.4 SKU
+        else if (first_match.empty())
+            first_match = preset.name;       // lowest preference: any other SKU
+    }
+    if (!fallback_sku.empty())
+        return fallback_sku;
+    return first_match;
 }
 
 MixedFilamentDisplayContext build_mixed_filament_display_context(const std::vector<std::string>& physical_colors)
@@ -1784,112 +1820,6 @@ void populate_mixed_filaments_from_mappings(
 
         result.mixed_filaments.push_back(std::move(mf));
     }
-}
-
-std::vector<std::string> recommend_best_filament_combo(
-    const std::vector<ModelColorEntry>&  model_colors,
-    const std::vector<std::string>&      all_preset_colors,
-    int                                  min_component_percent,
-    int                                  max_component_percent,
-    std::shared_ptr<std::atomic<bool>>   cancel_token)
-{
-    if (model_colors.empty() || all_preset_colors.size() < 4)
-        return {};
-
-    // Loose bounds only: this function scores colour COMBOS, it does not impose the
-    // final per-component cap (that is the Pass-2 batch_match_model_colors job, which
-    // independently validates min∈[0,50]/max∈[50,100]). So the legal range here is the
-    // full [0,100] for both — narrower limits (e.g. mirroring batch_match_model_colors's
-    // [0,50]/[50,100]) would wrongly reject valid callers like the worker's min=15.
-    // min>max is a genuine logic error: the search window is empty and every combo
-    // silently scores as "no valid recipe". Reject with a log instead of returning {}.
-    if (min_component_percent < 0 || min_component_percent > 100 ||
-        max_component_percent < 0 || max_component_percent > 100 ||
-        min_component_percent > max_component_percent) {
-        BOOST_LOG_TRIVIAL(warning)
-            << "recommend_best_filament_combo: invalid percent range min="
-            << min_component_percent << " max=" << max_component_percent
-            << " (need 0..100 and min<=max); returning empty";
-        return {};
-    }
-
-    // Step 1: Top-15 pre-filter by single-color ΔE
-    const size_t top_n = std::min<size_t>(15, all_preset_colors.size());
-    std::vector<std::pair<double, size_t>> ranked;
-    ranked.reserve(all_preset_colors.size());
-
-    // Average ΔE of each preset color against all model colors → quick filter
-    for (size_t fidx = 0; fidx < all_preset_colors.size(); ++fidx) {
-        wxColour fc;
-        if (!try_parse_color_match_hex(all_preset_colors[fidx], fc)) continue;
-        double sum_de = 0.0;
-        for (const auto& mc : model_colors)
-            sum_de += color_delta_e00(fc, mc.color);
-        ranked.emplace_back(sum_de / std::max(1.0, double(model_colors.size())), fidx);
-    }
-    std::sort(ranked.begin(), ranked.end(),
-        [](const auto& a, const auto& b) { return a.first < b.first; });
-    ranked.resize(top_n);
-
-    // Step 2: Enumerate C(N,4) combos from top-15 candidates
-    struct ComboScore { size_t i0, i1, i2, i3; double score; };
-    std::vector<ComboScore> combos;
-    const size_t n = ranked.size();
-    for (size_t i0 = 0; i0 + 3 < n; ++i0) {
-        for (size_t i1 = i0 + 1; i1 + 2 < n; ++i1) {
-            for (size_t i2 = i1 + 1; i2 + 1 < n; ++i2) {
-                for (size_t i3 = i2 + 1; i3 < n; ++i3) {
-                    if (cancel_token && cancel_token->load()) return {};
-
-                    // Build 4-color palette from original indices
-                    std::vector<std::string> combo_colors = {
-                        all_preset_colors[ranked[i0].second],
-                        all_preset_colors[ranked[i1].second],
-                        all_preset_colors[ranked[i2].second],
-                        all_preset_colors[ranked[i3].second]
-                    };
-
-                    // Score: average batch match ΔE over model colors (single-threaded, small loop).
-                    // check_compatible=false: this function is called only from the RECOMMENDED-mode
-                    // worker, whose palette is a single Full Spectrum PLA preset (same material by
-                    // construction) — no cross-type pair can exist, so the filter is a no-op. It
-                    // also keeps the worker off preset_bundle: build_compatibility_matrix reads
-                    // preset_bundle->filament_presets unsynchronized, which would race the UI thread
-                    // (data-race UB) from this worker call site. The slice gate still enforces real
-                    // incompatibility at slice time.
-                    double sum_de = 0.0;
-                    int matched = 0;
-                    for (const auto& mc : model_colors) {
-                        auto recipe = build_best_color_match_recipe(combo_colors, mc.color, min_component_percent, max_component_percent,
-                                                                     /*check_compatible=*/ false);
-                        if (recipe.valid) {
-                            sum_de += recipe.delta_e;
-                            ++matched;
-                        }
-                    }
-                    if (matched == 0) continue;
-
-                    double avg_de = sum_de / double(matched);
-                    double score = 1.0 / (1.0 + avg_de); // lower ΔE → higher score
-                    combos.push_back({ranked[i0].second, ranked[i1].second,
-                                      ranked[i2].second, ranked[i3].second, score});
-                }
-            }
-        }
-    }
-
-    if (combos.empty()) return {};
-
-    // Step 3: Return best combo
-    std::sort(combos.begin(), combos.end(),
-        [](const auto& a, const auto& b) { return a.score > b.score; });
-
-    return {
-        all_preset_colors[combos[0].i0],
-        all_preset_colors[combos[0].i1],
-        all_preset_colors[combos[0].i2],
-        all_preset_colors[combos[0].i3]
-    };
 }
 
 void apply_batch_match_to_model(const BatchMatchResult& result)

--- a/src/slic3r/GUI/MixedColorMatchHelpers.hpp
+++ b/src/slic3r/GUI/MixedColorMatchHelpers.hpp
@@ -33,7 +33,8 @@ namespace Slic3r { namespace GUI {
 // (build_mixed_filament_display_context, extract_model_colors, etc.) -- caller
 // MUST be on the UI thread. No worker-thread call site exists today; the worker
 // lambda in launch_background_match captures values by copy precisely to keep
-// off preset_bundle (see load_full_spectrum_colors's safety note).
+// off preset_bundle (see load_recommended_palette's safety note in
+// MixedFilamentBatchDialog.cpp).
 std::string full_spectrum_preset_name();
 
 // True iff a Full Spectrum preset exists for the printer's *current* nozzle
@@ -41,6 +42,17 @@ std::string full_spectrum_preset_name();
 // (reads preset_bundle, same convention as above). Used by the batch-match guard
 // to gate Recommended mode on preset availability rather than a hard-coded 0.4.
 bool full_spectrum_preset_exists_for_current_nozzle();
+
+// Resolve the selectable (visible + compatible) preset of a Full Spectrum FAMILY
+// (a library filament name, e.g. "Snapmaker PETG Full Spectrum @U1" -- pass
+// FullSpectrumPaletteEntry::family_name or GetFilamentMatchName(preset_name)).
+// Nozzle preference order: current-nozzle SKU, then the 0.4 SKU, then the first
+// selectable match. Matching is by GetFilamentMatchName identity (never by name
+// composition), so it is immune to the naming-convention case pitfalls (#742).
+// Returns the preset name, or "" when the family has no selectable preset (also
+// for an empty family_name). UI-thread only (reads preset_bundle, same
+// convention as above).
+std::string find_selectable_full_spectrum_family_preset(const std::string& family_name);
 
 // ---- CIELAB color space types ----
 
@@ -209,6 +221,12 @@ struct BatchMatchResult
     int                            error_code   = 0; // 0=ok, 1=partial, 2=cancelled, 3=timeout
     bool                           is_recommended_mode       = false;
     std::vector<std::string>       recommended_physical_colors;
+    // Per-slot library FAMILY of the recommended palette. INVARIANT: parallel to
+    // recommended_physical_colors (same size; the canonical-fallback path fills the
+    // default family name per slot). Empty for manual mode. Single writer: the
+    // launch_background_match worker lambda (value projection -- treat as derived
+    // data, do not mutate elsewhere).
+    std::vector<std::string>       recommended_physical_family_names;
 };
 
 /// Extract all unique colors from a multi-color 3D model.
@@ -265,15 +283,5 @@ void populate_mixed_filaments_from_mappings(
 /// Walks every volume's mmu_segmentation_facets and remaps original
 /// extruder_id→target_filament_id from the match result.
 void apply_batch_match_to_model(const BatchMatchResult& result);
-
-/// Recommend best 4-color filament combo from available presets.
-/// Pre-filters to Top-15 by single-color ΔE, then scores C(15,4)=1365 combos.
-/// Returns empty vector if fewer than 4 candidates available.
-std::vector<std::string> recommend_best_filament_combo(
-    const std::vector<ModelColorEntry>&  model_colors,
-    const std::vector<std::string>&      all_preset_colors,
-    int                                  min_component_percent = 15,
-    int                                  max_component_percent = 100,
-    std::shared_ptr<std::atomic<bool>>   cancel_token = nullptr);
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -19,7 +19,6 @@
 #include "PartPlate.hpp"
 #include "BitmapCache.hpp"
 
-#include <unordered_map>
 #include <set>
 #include <algorithm>
 #include <cctype>
@@ -33,10 +32,12 @@
 
 namespace Slic3r { namespace GUI {
 
-// Canonical Full Spectrum palette used as a fallback when load_full_spectrum_colors() fails
-// to read the live preset (library not loaded, preset missing, or <4 validated colors).
-// Mirrors filaments_colours.json's "Snapmaker PLA Full Spectrum @U1" single-color SKUs.
-// Single source of truth for the fallback path in both build_recommended_card and
+// Canonical Full Spectrum palette used as a fallback when the config-driven palette comes
+// up short (library not loaded, no Full Spectrum family in filaments_colours.json, or <4
+// validated single-color SKUs). Mirrors the "Snapmaker PLA Full Spectrum @U1" SKUs shipped
+// in filaments_colours.json; the live config (hot-updatable) is the real palette source —
+// this constant only keeps the mode usable when the config is missing.
+// Single source of truth for the fallback path in the ctor palette load and
 // launch_background_match — avoids the old duplicate CMYW_ENTRIES / CMYW_COLORS constants.
 static const std::vector<std::string> FULL_SPECTRUM_FALLBACK_COLORS = {
     "#08ABFB", // semi-translucent cyan
@@ -72,31 +73,11 @@ static constexpr size_t kMaxColors = 64;
 static constexpr double kDeltaEGoodMax = 4.0;  // <4.0 → Good
 static constexpr double kDeltaEFairMax = 8.0;  // <8.0 → Fair, else Poor
 
-// Recommended-mode (Full Spectrum) per-color transmittance-density (TD) values. These are NOT
-// in the filament data model (filaments_colours.json carries no TD field), so they are pinned
-// here as product constants — provided by product spec (snapshot in code per request).
-//
-// KEYED BY COLOR FAMILY (canonical color name), NOT by palette position. The recommended card's
-// swatch order is normally preset-order (C/M/Y/G), but a match's ΔE fallback path
-// (launch_background_match) can reorder the palette, so positional indexing would bind the
-// wrong TD to a color after reorder. Looking up by the color's identity avoids that.
-//
-// Each entry: {substring-to-match-against-English-name, TD-label, TD-value}. The match is
-// case-insensitive substring on the EN color name (which is always present in FilamentColorItem
-// .colorNames regardless of UI locale — it's the SKU's canonical name in filaments_colours.json).
-// White (W:8.8) is included per spec; Full Spectrum has no White SKU today, so it only surfaces
-// if a White-named color is ever added to the preset.
-// Each entry: {substring-to-match, TD-value}. The substring IS the family display name —
-// tooltip shows it verbatim (e.g. "cyan 5.5"), no separate label/abbreviation needed.
-struct TdEntry { const char* family; double value; };
-static const std::vector<TdEntry> FULL_SPECTRUM_TD = {
-    {"cyan",    5.5},
-    {"magenta", 5.5},
-    {"yellow",  9.5},
-    {"white",   8.8},
-    {"gray",    6.5},
-    {"grey",    6.5}, // spelling variant, defensive
-};
+// Forward declarations — the dialog ctor (and build_footer's Confirm handler) run before
+// these file-static helpers' definitions further down. Definitions carry the full docs.
+static std::vector<FullSpectrumPaletteEntry> load_recommended_palette();
+static std::string                          default_full_spectrum_family_name();
+static bool                                 full_spectrum_family_preset_selectable(const std::string& family_name);
 
 // Effective primary colour of a physical slot for the match. Dual-color slots carry
 // their real colours in filament_multi_colors while filament_colour may stay empty or
@@ -334,19 +315,37 @@ MixedFilamentBatchDialog::MixedFilamentBatchDialog(wxWindow* parent)
     // Pre-warm FilamentColorLibrary on the main thread. EnsureLoaded() is NOT thread-safe
     // (_loaded is an unlocked bool, and it performs file I/O + JSON parse), so it MUST run
     // before the worker thread in launch_background_match() starts. After warm-up, the
-    // worker's only call into the library is the read-only FindFilamentByName (a map lookup),
-    // which is safe to run concurrently with the main thread. See load_full_spectrum_colors().
+    // worker never touches the library — launch_background_match snapshots the selected
+    // palette colors by value on the UI thread (see load_recommended_palette's safety note).
     FilamentColorLibrary::Instance().EnsureLoaded();
+    // Recommended-mode palette (phase 2): config-driven, loaded on the UI thread BEFORE
+    // build_ui so build_recommended_card can populate the dropdowns. Defaults to the spec's
+    // C/M/Y/W slots via DefaultFullSpectrumSelections (family-anchored, alphabetical
+    // fallback — see FilamentColorLibrary). Short/degenerate configs fall back to the
+    // canonical palette inside load_recommended_palette.
+    m_recommended_palette = load_recommended_palette();
+    {
+        const auto defaults = DefaultFullSpectrumSelections(m_recommended_palette, default_full_spectrum_family_name());
+        for (int i = 0; i < 4; ++i)
+            m_recommended_selections[i] = i < static_cast<int>(defaults.size()) ? defaults[i] : -1;
+    }
     // Match targets = the project's FULL palette (physical filament_colour + enabled mixed
     // display_colors), NOT just the model's painted volumes. See load_palette_colors.
     load_palette_colors();
     build_ui();
     set_match_buttons_state(false);
-    m_btn_start_match->Enable(!m_model_colors.empty() && m_physical_colors.size() >= 2);
+    m_btn_start_match->Enable(!m_model_colors.empty()
+                              && m_physical_colors.size() >= 2);
 
-    // Default to recommended mode — show CMYK card
+    // Default to recommended mode — show the palette card
     if (m_recommended_card) {
         m_recommended_card->Show(true);
+        // Re-apply the combo icons now that the card is visible: SetIcon on a hidden
+        // window may not render (the same reason on_method_changed re-applies them on
+        // every mode switch). The card was built hidden (card->Hide()).
+        for (int i = 0; i < 4; ++i)
+            if (m_recommended_combo[i])
+                set_recommended_combo_icon(i);
         m_recommended_card->Layout();
     }
 
@@ -916,221 +915,161 @@ static wxString get_full_spectrum_preset_label()
     return wxString::FromUTF8(preset_name);
 }
 
-// Load the real recommended-mode palette colors from the Full Spectrum filament preset
-// (filaments_colours.json via FilamentColorLibrary). Returns the list of validated hex colors
-// (one per single-color SKU); empty on any failure so the caller falls back to the canonical
-// CMYW palette. NOTE: only the swatch COLORS come from here — the name column is the preset
-// label (see get_full_spectrum_preset_label), NOT the per-color name.
+// Library-family identity of the canonical Full Spectrum preset (nozzle suffix stripped) —
+// the anchor family for default dropdown selections and preset-label display. See
+// DefaultFullSpectrumSelections in FilamentColorLibrary.
+static std::string default_full_spectrum_family_name()
+{
+    return GetFilamentMatchName(full_spectrum_preset_name());
+}
+
+// True iff at least one filament preset matching the library family identity (nozzle suffix
+// stripped) is visible and compatible with the current printer — the same gate the Plater
+// apply path uses when writing per-slot Full Spectrum presets into slots 1-4.
+// Drives the Confirm-time "not configured" note (spec §5.1). Thin wrapper over the shared
+// find_selectable_full_spectrum_family_preset so the note and the actual write-back can
+// never drift apart. UI-thread only (reads preset_bundle, same convention as the other
+// preset readers in this file).
+static bool full_spectrum_family_preset_selectable(const std::string& family_name)
+{
+    return !find_selectable_full_spectrum_family_preset(family_name).empty();
+}
+
+// Load the recommended-mode palette from the hot-updated config: EVERY Full Spectrum family
+// in filaments_colours.json contributes its single-color SKUs (BuildFullSpectrumPalette —
+// see FilamentColorLibrary for the filter + alphabetical sort). Phase 2: the palette is
+// config-driven; "take whatever the config gives". When the config yields <4 entries the
+// canonical fallback colors are synthesized as unnamed entries of the default family so the
+// mode stays usable (matching the V1.0 fixed-CMYG behavior).
 //
 // Safety review closure (harness: input-validation, thread-safety):
-//   - (N) hex validation: every hex is re-checked via try_parse_color_match_hex; invalid
-//     values are skipped with a warning (defense-in-depth on top of FilamentColorLibrary's
-//     own NormalizeFilamentHexColor).
+//   - (N) hex validation: every hex is re-checked via try_parse_color_match_hex (defense in
+//     depth on top of FilamentColorLibrary's NormalizeFilamentHexColor, which BuildFullSpectrumPalette
+//     already applies); invalid entries are dropped with a warning BEFORE indices are handed
+//     out, so palette indices stay contiguous.
 //   - Thread safety: FilamentColorLibrary::EnsureLoaded() is NOT thread-safe (_loaded is an
-//     unlocked bool). The dialog ctor pre-warms it on the main thread; this function only
-//     does a read-only FindFilamentByName afterwards, so it is safe to call from the worker
-//     thread in launch_background_match. EnsureLoaded() here is a cheap no-op after warm-up.
+//     unlocked bool). The dialog ctor pre-warms it on the main thread and calls this BEFORE
+//     build_ui / any worker thread exists — UI-thread only by construction.
 //   - (HIGH) distinct logging: each failure path emits its own BOOST_LOG_TRIVIAL(warning).
-static std::vector<std::string> load_full_spectrum_colors()
+static std::vector<FullSpectrumPaletteEntry> load_recommended_palette()
 {
-    if (!FilamentColorLibrary::Instance().EnsureLoaded()) {
+    std::vector<FullSpectrumPaletteEntry> palette;
+    if (FilamentColorLibrary::Instance().EnsureLoaded()) {
+        palette = BuildFullSpectrumPalette(FilamentColorLibrary::Instance().GetAllFilamentInfos());
+    } else {
         BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: FilamentColorLibrary not loaded, fallback to canonical palette";
-        return {};
-    }
-    FilamentColorInfo info;
-    if (!FilamentColorLibrary::Instance().FindFilamentByName(full_spectrum_preset_name(), info)) {
-        BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: Full Spectrum preset not found in color library, fallback";
-        return {};
     }
 
-    std::vector<std::string> result;
-    for (const FilamentColorItem& item : info.colors) {
-        // Only single-color SKUs qualify as palette candidates; skip dual-color / gradient
-        // entries (e.g. PLA Silk's Sunset Ember) so they don't pollute the palette.
-        if (item.colorData.colors.size() != 1)
-            continue;
-        const std::string& hex = item.colorData.colors[0];
-        // (N) Re-validate hex: FilamentColorLibrary normalises format, but double-check the
-        // color is wxColour-constructible before it flows into get_extruder_color_icon /
-        // recommend_best_filament_combo.
+    for (auto it = palette.begin(); it != palette.end();) {
         wxColour parsed;
-        if (!try_parse_color_match_hex(wxString::FromUTF8(hex.c_str()), parsed)) {
-            BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: invalid hex '" << hex << "' in Full Spectrum, skipped";
-            continue;
+        if (try_parse_color_match_hex(wxString::FromUTF8(it->hex.c_str()), parsed)) {
+            ++it;
+        } else {
+            BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: invalid hex '" << it->hex << "' in Full Spectrum palette, dropped";
+            it = palette.erase(it);
         }
-        result.push_back(hex);
     }
-    return result;
+
+    if (palette.size() < 4) {
+        static const char* fallback_names[4] = {"Cyan", "Magenta", "Yellow", "Gray"};
+        palette.clear();
+        for (size_t i = 0; i < FULL_SPECTRUM_FALLBACK_COLORS.size() && i < 4; ++i) {
+            FullSpectrumPaletteEntry entry;
+            entry.hex         = FULL_SPECTRUM_FALLBACK_COLORS[i];
+            entry.en_name     = fallback_names[i];
+            entry.family_name = default_full_spectrum_family_name();
+            palette.push_back(std::move(entry));
+        }
+        BOOST_LOG_TRIVIAL(warning) << "MixedFilamentBatchDialog: config palette <4 entries, synthesized canonical fallback";
+    }
+    return palette;
 }
 
-// Full Spectrum palette as raw FilamentColorItems — same single-color-SKU filter and hex
-// re-validation as load_full_spectrum_colors(), but keeps each item's colorNames map so the
-// caller (build_recommended_card's tooltip) can show the localized per-color name. Returns
-// empty on any failure; callers fall back to positional defaults. NOT thread-safe beyond the
-// EnsureLoaded warm-up done in the ctor (see load_full_spectrum_colors's safety note).
-static std::vector<FilamentColorItem> load_full_spectrum_items()
-{
-    if (!FilamentColorLibrary::Instance().EnsureLoaded()) return {};
-    FilamentColorInfo info;
-    if (!FilamentColorLibrary::Instance().FindFilamentByName(full_spectrum_preset_name(), info)) return {};
-
-    std::vector<FilamentColorItem> result;
-    for (const FilamentColorItem& item : info.colors) {
-        if (item.colorData.colors.size() != 1) continue;
-        wxColour parsed;
-        if (!try_parse_color_match_hex(wxString::FromUTF8(item.colorData.colors[0].c_str()), parsed))
-            continue;
-        result.push_back(item);
-    }
-    return result;
-}
-
-// Look up a name from a FilamentColorItem's colorNames map for a specific language key.
-// On hit, writes the decoded name into `out` and returns true; on miss, returns false and
-// leaves `out` untouched. The JSON keys are short codes ("zh_CN","en"); callers try the full
+// Look up a name from a palette entry's color_names map for a specific language key. On hit,
+// writes the decoded name into `out` and returns true; on miss, returns false and leaves
+// `out` untouched. The JSON keys are short codes ("zh_CN","en"); callers try the full
 // locale, then the base language, then a fallback.
 //
 // NOTE: must NOT return `&wxString::FromUTF8(...)` — that yields a pointer to a temporary
 // wxString, which is destroyed at the semicolon, leaving a dangling pointer (UB / crash on
 // deref). The bool+out-param form keeps ownership with the caller.
-static bool color_name_for_lang(const FilamentColorItem& item, const wxString& key, wxString& out)
+static bool color_name_for_lang(const FullSpectrumPaletteEntry& entry, const wxString& key, wxString& out)
 {
-    auto it = item.colorNames.find(into_u8(key));
-    if (it == item.colorNames.end()) return false;
+    auto it = entry.color_names.find(into_u8(key));
+    if (it == entry.color_names.end()) return false;
     out = wxString::FromUTF8(it->second.c_str());
     return true;
 }
 
-// The ENGLISH color name — always present in colorNames (it's the SKU's canonical name in
-// filaments_colours.json) regardless of UI locale. Used as a STABLE identity for TD family
-// matching (FULL_SPECTRUM_TD is keyed by EN substrings: cyan/magenta/yellow/...). Falls back
-// to whatever name is present, then to a positional "F<n>" label.
-static wxString english_color_name(const FilamentColorItem& item, int position)
+// The ENGLISH color name — the SKU's canonical name in filaments_colours.json regardless of
+// UI locale. Falls back to whatever name is present, then to the entry's en_name field (set
+// directly for synthesized fallback entries), then to a positional "F<n>" label.
+static wxString english_color_name(const FullSpectrumPaletteEntry& entry, int position)
 {
     wxString s;
-    if (color_name_for_lang(item, "en", s)) return s;
-    if (!item.colorNames.empty())
-        return wxString::FromUTF8(item.colorNames.begin()->second.c_str());
+    if (color_name_for_lang(entry, "en", s)) return s;
+    if (!entry.color_names.empty())
+        return wxString::FromUTF8(entry.color_names.begin()->second.c_str());
+    if (!entry.en_name.empty())
+        return wxString::FromUTF8(entry.en_name.c_str());
     return wxString::Format("F%d", position + 1);
 }
 
-// Pick a localized color name from a FilamentColorItem's colorNames map, honouring the app's
-// current language. Falls back to English, then to the SKU, then to the positional label.
-static wxString localized_color_name(const FilamentColorItem& item, int position)
+// Pick a localized color name from a palette entry's color_names map, honouring the app's
+// current language. Falls back to English, then to the entry's en_name field, then to the
+// positional label.
+static wxString localized_color_name(const FullSpectrumPaletteEntry& entry, int position)
 {
     // current_language_code() returns e.g. "zh_CN" / "en" / "en_US". Try the exact code first,
     // then the base language (strip region suffix), then English.
     const wxString lang = wxGetApp().current_language_code();
     wxString s;
-    if (color_name_for_lang(item, lang, s)) return s;
+    if (color_name_for_lang(entry, lang, s)) return s;
     const wxString base = lang.BeforeFirst('_');
-    if (color_name_for_lang(item, base, s)) return s;
-    if (color_name_for_lang(item, wxString("en"), s)) return s;
-    return english_color_name(item, position);
+    if (color_name_for_lang(entry, base, s)) return s;
+    if (color_name_for_lang(entry, wxString("en"), s)) return s;
+    return english_color_name(entry, position);
 }
 
-// Resolve the TD family for a filament color by matching the ENGLISH color name against the
-// canonical-family substrings in FULL_SPECTRUM_TD (e.g. "Semi-Translucent Cyan" → family "C").
-// Returns nullptr if no family matches. Case-insensitive substring match on the EN name so it
-// tolerates adjectives ("Semi-Translucent") and prefix/suffix variation.
+// Display label of the entry's owning family. The default family (the one whose preset the
+// apply path writes into slots 1-4) shows its preset label; other families (e.g. a future
+// PETG Full Spectrum with no shipped preset) fall back to the raw library name.
 //
-// Why English: the EN name is the SKU's canonical identity in filaments_colours.json and is
-// always present regardless of UI locale, so family detection is locale-independent and stable.
-static const TdEntry* resolve_td_family(const wxString& english_name)
+// This is also the dropdown row label: per dev-owner clarification the row text shows the
+// FILAMENT name only (V1.0 convention) — the color identity is carried by the swatch and
+// the per-row tooltip (color name + TD), not by the label.
+static wxString family_display_label(const FullSpectrumPaletteEntry& entry)
 {
-    wxString lower = english_name.Lower();
-    for (const TdEntry& e : FULL_SPECTRUM_TD)
-        if (lower.find(e.family) != wxString::npos) return &e;
-    return nullptr;
+    if (entry.family_name == default_full_spectrum_family_name())
+        return get_full_spectrum_preset_label();
+    return wxString::FromUTF8(entry.family_name.c_str());
 }
 
-// Build the hover tooltip string for one recommended-mode row. Two lines:
-//   <preset label>          e.g. "Snapmaker PLA Full Spectrum"
+// Build the hover tooltip string for one palette entry. Two lines:
+//   <family label>          e.g. "Snapmaker PLA Full Spectrum"
 //   <color name> TD : <val> e.g. "Translucent Cyan TD : 5.5"
-// The color name is localized; TD is resolved by the color's family via its English name
-// (see resolve_td_family), NOT by palette position — so the TD stays bound to the right color
-// even when the match reorders the palette. When TD is unknown (color family not in
-// FULL_SPECTRUM_TD) the value shows "-".
-static wxString make_recommended_tooltip(const wxString& localized_name, const wxString& english_name)
+// The TD value is displayed as-read from the config (FilamentColorLibrary
+// tdValue); when the config has no TD field yet it is simply 0.0.
+static wxString make_recommended_tooltip(const wxString& family_label, const wxString& localized_name, double entry_td)
 {
-    const TdEntry* td = resolve_td_family(english_name);
-    const wxString td_disp = td ? wxString::Format("%.1f", td->value) : wxString("-");
+    const wxString td_disp = wxString::Format("%.1f", entry_td);
     return wxString::Format("%s\n%s %s : %s",
-        get_full_spectrum_preset_label(),
+        family_label,
         localized_name,
         _L("TD"),
         td_disp);
 }
 
-void MixedFilamentBatchDialog::update_recommended_card()
+// Tooltip for the palette entry at palette_idx — the same text used for the dropdown
+// row (SetItemTooltip) and for the closed control (SetToolTip below): the per-row
+// tips only reach the popup list, so the SELECTED entry's tip is attached to the
+// ComboBox itself on build and refreshed on selection change.
+static wxString recommended_entry_tooltip(const std::vector<FullSpectrumPaletteEntry>& palette, int palette_idx)
 {
-    if (!m_recommended_card) return;
-    const auto& colors = m_result.recommended_physical_colors;
-    if (colors.size() < 4) return;
-
-    // NOTE: the name column shows the preset label (Snapmaker PLA Full Spectrum …) on every
-    // row, NOT the per-color name — per product spec only the swatch color varies per row.
-    // So no hex→name lookup is needed for the LABEL; the tooltip, however, shows the per-color
-    // name and DOES need to resolve colors[i] → the right FilamentColorItem.
-
-    // Re-load items and index them by HEX so each row resolves the correct color identity.
-    // This is essential after a match: launch_background_match's ΔE fallback can REORDER the
-    // palette, so colors[i] may not sit at position i in the preset's natural order. Looking
-    // up by hex (rather than positional items[i]) binds the tooltip's name + TD to the actual
-    // color on the swatch, not its grid slot. Hex comparison is case-insensitive to tolerate
-    // "#08abfb" vs "#08ABFB" between config and library.
-    const std::vector<FilamentColorItem> items = load_full_spectrum_items();
-    std::unordered_map<std::string, const FilamentColorItem*> by_hex;
-    by_hex.reserve(items.size());
-    for (const FilamentColorItem& item : items) {
-        if (item.colorData.colors.size() == 1) {
-            std::string h = item.colorData.colors[0];
-            std::transform(h.begin(), h.end(), h.begin(),
-                           [](unsigned char ch) { return std::tolower(ch); });
-            by_hex.emplace(std::move(h), &item);
-        }
-    }
-    auto find_item = [&](const std::string& hex) -> const FilamentColorItem* {
-        std::string h = hex;
-        std::transform(h.begin(), h.end(), h.begin(),
-                       [](unsigned char ch) { return std::tolower(ch); });
-        auto it = by_hex.find(h);
-        return it != by_hex.end() ? it->second : nullptr;
-    };
-
-    for (int i = 0; i < 4; ++i) {
-        // Update swatch bitmap
-        if (m_recommended_swatches[i]) {
-            wxBitmap* icon = get_extruder_color_icon(
-                colors[i], std::to_string(i + 1),
-                FromDIP(20), FromDIP(20));
-            if (icon)
-                m_recommended_swatches[i]->SetBitmap(*icon);
-        }
-
-        // Update label text — the preset name (same on all four rows).
-        if (m_recommended_labels[i]) {
-            m_recommended_labels[i]->SetLabel(get_full_spectrum_preset_label());
-        }
-
-        // Refresh the row tooltip to reflect the now-rendered swatch color. Resolve the color
-        // identity by HEX (colors[i]) so the name + TD match the actual swatch even if the
-        // palette was reordered by the match. Falls back to a positional label if the hex is
-        // unknown (e.g. library reload failed / a color outside the Full Spectrum preset).
-        if (i < static_cast<int>(colors.size())) {
-            const FilamentColorItem* item = find_item(colors[i]);
-            const wxString ename = item ? english_color_name(*item, i)
-                                        : wxString::Format("F%d", i + 1);
-            const wxString cname = item ? localized_color_name(*item, i) : ename;
-            const wxString tip = make_recommended_tooltip(cname, ename);
-            if (m_recommended_swatches[i]) m_recommended_swatches[i]->SetToolTip(tip);
-            if (m_recommended_labels[i])   m_recommended_labels[i]->SetToolTip(tip);
-            wxWindow* row = m_recommended_swatches[i] ? m_recommended_swatches[i]->GetParent() : nullptr;
-            if (row) row->SetToolTip(tip);
-        }
-    }
-
-    m_recommended_card->Layout();
+    const FullSpectrumPaletteEntry& entry = palette[palette_idx];
+    return make_recommended_tooltip(family_display_label(entry),
+                                    localized_color_name(entry, palette_idx),
+                                    entry.td_value);
 }
 
 // ---------------------------------------------------------------------------
@@ -1514,98 +1453,86 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     // see §137).
     s->AddSpacer(FromDIP(10)); // title-to-grid gap per Figma spec
 
-    // Load the real palette colors from the Full Spectrum preset (filaments_colours.json).
-    // Falls back to the canonical palette when the preset is missing or yields <4 validated
-    // single-color SKUs. Only the swatch COLORS come from here; the name column is the preset
-    // label (see get_full_spectrum_preset_label). See load_full_spectrum_colors() for the
-    // safety review (hex validation, thread safety, distinct logging).
-    std::vector<std::string> palette = load_full_spectrum_colors();
-    if (palette.size() < 4) {
-        palette.clear();
-        for (const std::string& c : FULL_SPECTRUM_FALLBACK_COLORS)
-            palette.push_back(c);
-    }
-    const int fill_count = std::min<int>(4, static_cast<int>(palette.size()));
+    // Phase 2: the four slots are selectable dropdowns over the config-driven palette
+    // (m_recommended_palette, loaded in the ctor — alphabetical, all Full Spectrum families).
+    // Combo row j lists palette entry j, so combo row == palette index (no row→index map).
+    // Mirrors build_manual_card's ComboBox rows so the two mode cards look and behave alike.
 
-    // Also load the raw FilamentColorItems (same filter/validation) so the per-row hover
-    // tooltip can show the localized color NAME. Loaded in lock-step with `palette` (same
-    // preset, same single-color-SKU filter, same order) so palette[i] ↔ items[i]. If the
-    // loader fails (library not loaded / preset missing) items is empty and the tooltip
-    // builder falls back to the positional label "F<i+1>".
-    const std::vector<FilamentColorItem> items = load_full_spectrum_items();
-
-    // 2x2 grid: numbered swatch (20x20) + bordered name field. update_recommended_card()
-    // refreshes swatches after a match reflects the palette order chosen by
-    // recommend_best_filament_combo.
+    // 2x2 grid of dropdown rows, same pinned column width as the manual card so slots stay
+    // aligned across a mode switch.
     auto* grid = new wxFlexGridSizer(2, FromDIP(12), FromDIP(12));
     grid->AddGrowableCol(0, 1);
     grid->AddGrowableCol(1, 1);
     for (int i = 0; i < 4; ++i) {
-        // Per Figma (node 28325:94417 "Container"): the WHOLE row is a bordered container
-        // (1px #dbdbdb, sharp corners — no rounded-* class, height 30, horizontal padding 9px)
-        // holding swatch + name together. The previous implementation bordered only the name
-        // `field`, leaving the numbered swatch sitting outside the border — the most visible
-        // mismatch with Figma. Sharp corners: the spec shows a plain `border border-[#dbdbdb]`
-        // with no `rounded-*` utility, so SetCornerRadius is 0 (StaticBox's default is 0, but
-        // we set it explicitly for clarity against future edits).
-        auto* panel = new StaticBox(card, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE);
-        panel->SetCornerRadius(FromDIP(0));
-        panel->SetBorderWidth(FromDIP(1));
-        panel->SetBorderColorNormal(StateColor::darkModeColorFor(wxColour("#DBDBDB")));
-        panel->SetBackgroundColor(StateColor(std::pair(wxColour("#FFFFFF"), static_cast<int>(StateColor::Normal))));
-        // Pin a fixed column width so the 2×2 slots stay equal — see build_manual_card for
-        // the wxFlexGridSizer rationale (keeps recommended + manual rows aligned on switch).
-        // Height 30 matches Figma; pinning min+max keeps the four rows visually uniform.
+        auto* panel = new wxPanel(card, wxID_ANY);
+        // wxPanel doesn't inherit the card's bg — set white explicitly so the row doesn't
+        // show the dialog's #F8F7F7 through (same as build_manual_card rows).
+        panel->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
+        // Pin a fixed column width so the 2×2 slots stay equal regardless of label length
+        // (see build_manual_card for the wxFlexGridSizer rationale). Height pinned to 30
+        // like the manual card's rows (upstream #735 convention), so mode switching doesn't
+        // shift the cards below.
         panel->SetMinSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), FromDIP(30)));
         panel->SetMaxSize(wxSize(FromDIP(FILAMENT_COL_WIDTH_DIP), FromDIP(30)));
         auto* r = new wxBoxSizer(wxHORIZONTAL);
-        // Numbered color swatch (20×20, stored for later update). Guard with fill_count so a
-        // short palette can never read out of bounds (the fallback above always yields 4).
-        // wxLEFT=9 is the bordered container's left inset (Figma: px=9).
-        if (i < fill_count) {
-            wxBitmap* icon = get_extruder_color_icon(palette[i], std::to_string(i + 1), FromDIP(20), FromDIP(20));
-            if (icon) {
-                auto* sw = new wxStaticBitmap(panel, wxID_ANY, *icon);
-                // §17: wxStaticBitmap does not inherit the panel bg. The icon is opaque so it
-                // covers the control, but set the bg explicitly to match the card and resist
-                // GTK theme override.
-                sw->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
-                m_recommended_swatches[i] = sw;
-                r->Add(sw, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(9));
+
+        // §68: read-only selection would normally call for wxChoice, but this custom
+        // ComboBox carries a numbered color icon (SetIcon in set_recommended_combo_icon)
+        // that wxChoice cannot render — same intentional choice as build_manual_card.
+        auto* cb = new ComboBox(panel, wxID_ANY, wxEmptyString,
+                                 wxDefaultPosition, wxSize(-1, FromDIP(30)),
+                                 0, nullptr, wxCB_READONLY);
+        for (size_t j = 0; j < m_recommended_palette.size(); ++j) {
+            const FullSpectrumPaletteEntry& entry = m_recommended_palette[j];
+            // List row per spec §4 (dev-owner clarification): plain (un-numbered) color swatch
+            // + the FILAMENT name only (V1.0 convention) — e.g. "Snapmaker PLA Full Spectrum".
+            // The color identity is carried by the swatch and the per-row tooltip below.
+            wxBitmap* icon = FilamentColorUtils::GetFilamentColorIcon(std::string(), FilamentColorMode::Segment,
+                entry.hex, std::string(), FromDIP(20), FromDIP(20));
+            const int append_idx = cb->Append(family_display_label(entry),
+                                              icon ? icon->ConvertToImage() : wxNullImage);
+            // Per-row hover tooltip (spec §4.1): "<family> / <color name> TD : <value>". The
+            // custom ComboBox/DropDown shows per-row tooltips natively while the list is open.
+            cb->SetItemTooltip(append_idx, recommended_entry_tooltip(m_recommended_palette, static_cast<int>(j)));
+        }
+        if (m_recommended_selections[i] >= 0 && m_recommended_selections[i] < static_cast<int>(m_recommended_palette.size()))
+            cb->SetSelection(m_recommended_selections[i]);
+        else if (!m_recommended_palette.empty()) {
+            // Keep the recorded selection in lock-step with what the combo shows — the
+            // restore gate and the match input both read m_recommended_selections.
+            m_recommended_selections[i] = 0;
+            cb->SetSelection(0);
+        }
+        // Closed-control hover: SetItemTooltip only attaches tips to the popup list, so the
+        // ComboBox itself never shows anything on hover. Attach the SELECTED entry's tooltip
+        // to the control (wxWindow::SetToolTip works on the TextInput base) and keep it in
+        // sync on selection change (wxEVT_COMBOBOX handler below).
+        if (m_recommended_selections[i] >= 0 && m_recommended_selections[i] < static_cast<int>(m_recommended_palette.size()))
+            cb->SetToolTip(recommended_entry_tooltip(m_recommended_palette, m_recommended_selections[i]));
+        m_recommended_combo[i] = cb;
+        // Combined arrow+badge icon (slot number 1-4 over the selected color) so the combo
+        // keeps its drop-down arrow alongside the numbered swatch (ComboBox hides the arrow
+        // when an item image is set). MUST run after the m_recommended_combo[i] assignment:
+        // set_recommended_combo_icon reads that member and early-returns while it is null
+        // (unlike the manual card, this card is visible on first show with no later
+        // re-application to paper over a missing icon).
+        set_recommended_combo_icon(i);
+        cb->Bind(wxEVT_COMBOBOX, [this, i](wxCommandEvent&) {
+            if (m_recommended_combo[i]) {
+                const int sel = m_recommended_combo[i]->GetSelection();
+                if (sel >= 0 && sel < static_cast<int>(m_recommended_palette.size())) {
+                    // Record the user's selection so the failed/cancelled re-match restore gate
+                    // (input_intact) can detect that the recommended input changed.
+                    m_recommended_selections[i] = sel;
+                    set_recommended_combo_icon(i);
+                    // Closed-control tooltip follows the new selection (see build comment).
+                    m_recommended_combo[i]->SetToolTip(recommended_entry_tooltip(m_recommended_palette, sel));
+                }
             }
-        }
-        // Name — the preset label (same on every row; only the swatch color varies, per product
-        // spec). 14px per Figma, with wxST_ELLIPSIZE_END so a long preset name ("Snapmaker PLA
-        // Full Spectrum @U1 0.4 nozzle") truncates instead of wrapping and breaking the row.
-        // The name sits directly in the bordered row (no separate bordered `field`); wxLEFT=8
-        // is the swatch→name gap (Figma: gap 8), wxRIGHT=8 the trailing inset (Figma 9 − 1px).
-        auto* name = new wxStaticText(panel, wxID_ANY, get_full_spectrum_preset_label(),
-                                       wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
-        name->SetFont(Label::Body_14);
-        name->SetForegroundColour(StateColor::darkModeColorFor(wxColour("#242424")));
-        name->SetBackgroundColour(StateColor::darkModeColorFor(wxColour("#FFFFFF")));
-        m_recommended_labels[i] = name;
-        r->Add(name, 1, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, FromDIP(8));
+            on_recommended_selection_changed();
+        });
+        r->Add(cb, 1, wxALIGN_CENTER_VERTICAL);
         panel->SetSizer(r);
-        // Per-row hover tooltip: per-color NAME (localized) + COLOR hex + TD value (product spec).
-        // TD is resolved by the color's ENGLISH family name (cyan→C, magenta→M, ...), NOT by
-        // palette position — so it stays bound to the right color even when a match reorders the
-        // palette. The tooltip is set on the row panel AND its children (swatch, name): wx child
-        // windows do NOT inherit the parent tooltip, so without setting it on each child, hovering
-        // directly over the swatch/name shows nothing. update_recommended_card re-applies it after
-        // a match.
-        if (i < fill_count) {
-            const wxString ename = (i < static_cast<int>(items.size()))
-                ? english_color_name(items[i], i)
-                : wxString::Format("F%d", i + 1);
-            const wxString cname = (i < static_cast<int>(items.size()))
-                ? localized_color_name(items[i], i)
-                : ename;
-            const wxString tip = make_recommended_tooltip(cname, ename);
-            panel->SetToolTip(tip);
-            if (m_recommended_swatches[i]) m_recommended_swatches[i]->SetToolTip(tip);
-            name->SetToolTip(tip);
-        }
         grid->Add(panel, 0, wxEXPAND);
     }
     s->Add(grid, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(16));
@@ -1884,6 +1811,29 @@ void MixedFilamentBatchDialog::build_footer()
         // (see handle_batch_match_result), so there is nothing to re-check here — Confirm
         // proceeds directly. Overflow, if any, is dropped silently at apply time by
         // add_batch_custom_filaments.
+        //
+        // Phase-2 note (spec §5.1): in recommended mode, when any Full Spectrum family the
+        // user picked has no selectable preset (not configured for this printer — the same
+        // is_visible && is_compatible gate the Plater apply path uses when deciding whether
+        // to write the preset into slots 1-4), show a one-shot informational note: the match
+        // colors are still applied to the slots, only the preset assignment falls back to
+        // the currently configured filaments. Non-blocking — OK proceeds to EndModal.
+        if (m_result.is_recommended_mode) {
+            bool any_family_missing = false;
+            for (int i = 0; i < 4 && !any_family_missing; ++i) {
+                const int sel = m_recommended_selections[i];
+                if (sel < 0 || sel >= static_cast<int>(m_recommended_palette.size())) continue;
+                if (!full_spectrum_family_preset_selectable(m_recommended_palette[sel].family_name))
+                    any_family_missing = true;
+            }
+            if (any_family_missing) {
+                RichMessageDialog note(this,
+                    _L("Official Full Spectrum filaments are not configured. Configured filaments will be used instead. Once the official filaments are added, the previously selected filaments can be replaced in the filament list without affecting the color mixing match result."),
+                    _L("Note"), wxOK);
+                note.CentreOnScreen();
+                note.ShowModal();
+            }
+        }
         EndModal(wxID_OK);
     });
 
@@ -1992,8 +1942,10 @@ void MixedFilamentBatchDialog::set_match_buttons_state(bool matching)
     if (m_method_combo) m_method_combo->Enable(!matching);
     if (m_tray_combo)   m_tray_combo->Enable(!matching);
     if (m_view_combo)   m_view_combo->Enable(!matching);
-    for (int i = 0; i < 4; ++i)
-        if (m_filament_combo[i]) m_filament_combo[i]->Enable(!matching);
+    for (int i = 0; i < 4; ++i) {
+        if (m_filament_combo[i])     m_filament_combo[i]->Enable(!matching);
+        if (m_recommended_combo[i])  m_recommended_combo[i]->Enable(!matching);
+    }
     // Button-type controls have state-dependent enable conditions (tray arrows depend on
     // m_tray_index; add/remove depend on m_manual_filament_count). Disable them directly while
     // matching, and on restore delegate to the existing helpers so the boundary conditions are
@@ -2048,12 +2000,16 @@ void MixedFilamentBatchDialog::on_method_changed(wxCommandEvent&)
         m_manual_card->Show(m_matching_method == MANUAL);
     if (m_recommended_card)
         m_recommended_card->Show(m_matching_method == RECOMMENDED);
-    // Re-apply combo icons: set_manual_combo_icon was called during build
+    // Re-apply combo icons: set_*_combo_icon was called during build
     // while the card was hidden (SetIcon may not render on a hidden window).
     if (m_matching_method == MANUAL) {
         for (int i = 0; i < 4; ++i)
             if (m_filament_combo[i])
                 set_manual_combo_icon(i, m_filament_combo[i]->GetSelection());
+    } else {
+        for (int i = 0; i < 4; ++i)
+            if (m_recommended_combo[i])
+                set_recommended_combo_icon(i);
     }
     // Card visibility changed — the filament-config card swaps between manual and recommended,
     // whose content heights differ, so re-layout the scrolled region (not just the card itself)
@@ -2074,8 +2030,7 @@ void MixedFilamentBatchDialog::update_method_combo_tooltip()
     // adding a permanent subtitle row to the UI.
     m_method_combo->SetToolTip(m_matching_method == MANUAL
         ? _L("Manually select filaments from the current list for color mixing.")
-        : wxString::Format(_L("Automatically uses official CMYG filaments for color mixing. The mix ratio for each color is limited to %d%%–%d%%."),
-             kMinComponentPercent, kMaxComponentPercent));
+        : _L("Automatically select an official filament set for color mixing match. Mix ratio for each color: 0%–70%."));
 }
 
 void MixedFilamentBatchDialog::on_manual_selection_changed()
@@ -2092,6 +2047,18 @@ void MixedFilamentBatchDialog::on_manual_selection_changed()
     // NOT cleared here. It persists until the next Start/Re-match (which Hides all banners).
     // This is acceptable: the advisory is still contextually relevant while the user is
     // picking filaments for the over-limit model.
+    if (m_match_completed)
+        check_manual_recipe_ratio();
+}
+
+void MixedFilamentBatchDialog::on_recommended_selection_changed()
+{
+    // Mirror on_manual_selection_changed: preserve the previous match result, only
+    // Start/Re-match clears it. No selection-validity gating — duplicates and
+    // unselected slots are allowed; the worker degrades gracefully either way.
+    set_match_buttons_state(false);
+    // check_manual_recipe_ratio is a manual-mode no-op (early-returns for RECOMMENDED);
+    // kept for symmetry with on_manual_selection_changed's post-match re-evaluation.
     if (m_match_completed)
         check_manual_recipe_ratio();
 }
@@ -2220,6 +2187,76 @@ void MixedFilamentBatchDialog::set_manual_combo_icon(int row, int filament_idx)
     cb->SetMaxSize(wxSize(-1, FromDIP(30)));
 }
 
+void MixedFilamentBatchDialog::set_recommended_combo_icon(int row)
+{
+    // Same arrow+badge composition as set_manual_combo_icon, with two differences: the badge
+    // label is the SLOT number (1-4 — the fixed dropdown index per spec §4, not a palette
+    // index), and the swatch color is the palette entry currently selected in this slot.
+    if (row < 0 || row >= 4) return;
+    ComboBox* cb = m_recommended_combo[row];
+    if (!cb) return;
+    const int sel = m_recommended_selections[row];
+    if (sel < 0 || sel >= static_cast<int>(m_recommended_palette.size())) return;
+    const std::string& hex = m_recommended_palette[sel].hex;
+
+    const int pad = FromDIP(8), arr_w = FromDIP(8), badge_w = FromDIP(20), h = FromDIP(20), gap = FromDIP(8), text_gap = FromDIP(8);
+    const int total_w = pad + arr_w + gap + badge_w + text_gap;
+    wxImage  img(total_w, h, true);
+    img.InitAlpha();
+    memset(img.GetAlpha(), 0, total_w * h);
+
+    auto set_rgba = [&](int x, int y, unsigned char r, unsigned char g, unsigned char b, unsigned char a) {
+        if (x < 0 || x >= total_w || y < 0 || y >= h) return;
+        int pos = y * total_w + x;
+        img.GetData()[pos * 3]     = r;
+        img.GetData()[pos * 3 + 1] = g;
+        img.GetData()[pos * 3 + 2] = b;
+        img.GetAlpha()[pos]        = a;
+    };
+
+    // Arrow: paste SVG (transparent background, only arrow pixels opaque)
+    ScalableBitmap ab(cb, "drop_down", arr_w);
+    if (ab.bmp().IsOk()) {
+        wxImage aimg = ab.bmp().ConvertToImage();
+        if (!aimg.HasAlpha()) aimg.InitAlpha();
+        // Center by LOGICAL size: on macOS a raster may carry a Retina scale factor
+        // (physical = logical x2), so raw GetWidth()/GetHeight() mis-centers the paste.
+        // GetScaledSize() divides out the bitmap's own scale factor; it is an identity
+        // op for scale-1.0 rasters (Windows/Linux). Same fix pattern as the preview
+        // panel placeholder (see the GetScaledSize change in build_preview_card).
+        const int a_h = ab.bmp().GetScaledSize().y;
+        int ax = pad, ay = (h - a_h) / 2;
+        for (int y = 0; y < aimg.GetHeight() && ay + y < h; ++y)
+            for (int x = 0; x < aimg.GetWidth() && ax + x < total_w; ++x) {
+                unsigned char* s = aimg.GetData() + (y * aimg.GetWidth() + x) * 3;
+                unsigned char a = aimg.HasAlpha() ? *(aimg.GetAlpha() + y * aimg.GetWidth() + x) : 255;
+                if (a > 0) set_rgba(ax + x, ay + y, s[0], s[1], s[2], a);
+            }
+    }
+
+    // Badge: numbered slot swatch over the selected palette color (single-color by
+    // construction — palette entries are single-color SKUs).
+    const int bx = pad + arr_w + gap;
+    wxBitmap* badge_bmp = FilamentColorUtils::GetFilamentColorIcon(std::string(), FilamentColorMode::Segment,
+        hex, std::to_string(row + 1), FromDIP(20), FromDIP(20));
+    if (badge_bmp) {
+        wxImage bimg = badge_bmp->ConvertToImage();
+        // Logical-size centering, same rationale as the arrow paste above.
+        const int b_h = badge_bmp->GetScaledSize().y;
+        int by = (h - b_h) / 2;
+        for (int y = 0; y < bimg.GetHeight() && by + y < h; ++y)
+            for (int x = 0; x < bimg.GetWidth() && bx + x < total_w; ++x) {
+                unsigned char* s = bimg.GetData() + (y * bimg.GetWidth() + x) * 3;
+                set_rgba(bx + x, by + y, s[0], s[1], s[2], 255);
+            }
+    }
+
+    cb->SetIcon(wxBitmap(img));
+    // SetIcon triggers Rescale→messureSize which recalculates height; re-lock to 30
+    cb->SetMinSize(wxSize(-1, FromDIP(30)));
+    cb->SetMaxSize(wxSize(-1, FromDIP(30)));
+}
+
 void MixedFilamentBatchDialog::update_add_remove_buttons()
 {
     // Keep both buttons always visible and gray them out at their limits (remove at min=2,
@@ -2319,6 +2356,9 @@ void MixedFilamentBatchDialog::start_batch_match()
         dlg.ShowModal();
         return;
     }
+    // No selection-completeness gate: unselected slots / degenerate palettes degrade
+    // gracefully in the worker (selections with <4 colors fall back to the canonical
+    // FULL_SPECTRUM_FALLBACK_COLORS palette).
     m_match_running = true;
     m_error_panel->Hide();
     m_warning_panel->Hide();
@@ -2377,19 +2417,30 @@ void MixedFilamentBatchDialog::launch_background_match()
     const auto all_physical      = m_physical_colors;
 
     const auto matching_method = m_matching_method;
-    // Physical palette for recommended mode. Loaded from the real Full Spectrum preset
-    // (filaments_colours.json) on the main thread here, then captured by value into the
-    // worker lambda below — so the worker never touches FilamentColorLibrary. Falls back to
-    // FULL_SPECTRUM_FALLBACK_COLORS when the preset is missing or yields <4 validated colors.
-    // See load_full_spectrum_colors() for hex validation + distinct logging.
+    // Physical palette for recommended mode (phase 2): the four colors the user selected in
+    // the palette dropdowns, snapshotted here on the UI thread and captured by value into
+    // the worker lambda below — the worker never touches FilamentColorLibrary or the combos.
+    // The canonical constant only covers a degenerate mid-session palette (cannot happen via
+    // the UI — start_batch_match is gated on complete selections; kept as a guard).
     std::vector<std::string> preset_colors;
-    {
-        std::vector<std::string> palette = load_full_spectrum_colors();
-        if (palette.size() >= 4) {
-            preset_colors = std::move(palette);
-        } else {
-            BOOST_LOG_TRIVIAL(warning) << "launch_background_match: preset colors <4, fallback to canonical palette";
+    // Per-slot library family, parallel to preset_colors (see BatchMatchResult::
+    // recommended_physical_family_names). Snapshotted on the UI thread so the
+    // worker never touches FilamentColorLibrary for this either.
+    std::vector<std::string> preset_family_names;
+    if (m_matching_method == RECOMMENDED) {
+        for (int i = 0; i < 4; ++i) {
+            const int sel = m_recommended_selections[i];
+            if (sel >= 0 && sel < static_cast<int>(m_recommended_palette.size())) {
+                preset_colors.push_back(m_recommended_palette[sel].hex);
+                preset_family_names.push_back(m_recommended_palette[sel].family_name);
+            }
+        }
+        if (preset_colors.size() < 4) {
             preset_colors = FULL_SPECTRUM_FALLBACK_COLORS;
+            // Preserve the parallel-array invariant: synthesized canonical entries
+            // belong to the default family (same as load_recommended_palette's
+            // fallback synthesis).
+            preset_family_names.assign(preset_colors.size(), default_full_spectrum_family_name());
         }
     }
     // Use enabled_count() (skips deleted/disabled) to match the virtual ID
@@ -2404,7 +2455,7 @@ void MixedFilamentBatchDialog::launch_background_match()
     auto progress_bar = m_progress_bar;
 
     m_worker_thread = std::thread([this, model_colors, manual_colors, all_physical,
-                                    preset_colors, matching_method, existing_mixed_count,
+                                    preset_colors, preset_family_names, matching_method, existing_mixed_count,
                                     destroyed, cancel_token, progress_bar,
                                     manual_full_ids = std::move(manual_full_ids_c)]()
     {
@@ -2412,49 +2463,14 @@ void MixedFilamentBatchDialog::launch_background_match()
         if (matching_method == MANUAL) {
             physical_colors = manual_colors;
         } else {
+            // Phase 2: the palette IS the user's four dropdown selections, in slot order.
+            // No combo search anymore — the mixing algorithm and the 0–70% cap are unchanged
+            // (the cap is enforced in the Pass-2 batch_match_model_colors call below via
+            // match_max = kMaxComponentPercent).
             if (preset_colors.size() >= 4) {
-                // Combo search passes max=100 here: this stage only picks WHICH 4 preset
-                // colors form the palette; the per-component 70% cap is enforced later in
-                // the Pass-2 batch_match_model_colors call (match_max=kMaxComponentPercent).
-                auto best = recommend_best_filament_combo(model_colors, preset_colors, 15, 100, cancel_token);
-                // recommend_best_filament_combo returns {} for BOTH "no valid combo" and
-                // "cancelled" — distinguish here by re-checking the token. On cancel, skip
-                // the fallback palette + Pass-2 match (hundreds of ms of wasted work) and
-                // deliver a cancelled result directly so handle_batch_match_result shows no
-                // error banner and restores the prior result. Mirrors the cancel handling
-                // in batch_match_model_colors (error_code = 2).
-                if (cancel_token->load()) {
-                    // User cancellation (Stop Matching) — not an error. error_message is
-                    // intentionally empty: handle_batch_match_result treats error_code==2 as a
-                    // silent rollback and never displays it.
-                    BatchMatchResult cancelled;
-                    cancelled.success    = false;
-                    cancelled.error_code = 2;
-                    wxGetApp().CallAfter([this, destroyed, result = std::move(cancelled)]() mutable {
-                        if (destroyed->load()) return;
-                        handle_batch_match_result(result);
-                    });
-                    return;  // exit worker lambda — skip Pass-2 match + merge
-                }
-                if (best.empty()) {
-                    physical_colors.assign(preset_colors.begin(), preset_colors.begin() + std::min<size_t>(4, preset_colors.size()));
-                } else {
-                    // Restore original preset_colors order (the function returns the
-                    // chosen subset sorted by ΔE); keeps the palette order stable and
-                    // stays correct when the candidate set grows beyond 4.
-                    std::vector<std::string> remaining = best;
-                    for (const std::string& c : preset_colors) {
-                        auto it = std::find(remaining.begin(), remaining.end(), c);
-                        if (it != remaining.end()) {
-                            physical_colors.push_back(c);
-                            remaining.erase(it);
-                            if (physical_colors.size() >= 4) break;
-                        }
-                    }
-                    if (physical_colors.size() < 4)
-                        physical_colors = std::move(best);  // fallback
-                }
+                physical_colors = preset_colors;
             } else {
+                // Defensive only — see the preset_colors block above.
                 physical_colors = all_physical;
             }
         }
@@ -2642,6 +2658,12 @@ void MixedFilamentBatchDialog::launch_background_match()
             if (matching_method == RECOMMENDED) {
                 result.is_recommended_mode = true;
                 result.recommended_physical_colors = physical_colors;
+                // Families are parallel to the PALETTE snapshot, so only carry them
+                // when the palette actually made it into the result (the defensive
+                // all_physical branch below has no per-slot families — leave empty
+                // and let the Plater size guard fall back to the legacy behavior).
+                if (physical_colors.size() == preset_family_names.size())
+                    result.recommended_physical_family_names = preset_family_names;
             }
         }
 
@@ -2666,17 +2688,20 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
             set_error(wxString::FromUTF8(result.error_message));
         }
         // Restore the prior result ONLY when the user-facing input is unchanged since
-        // that result was produced (same mode + same manual filament selections).
-        // Otherwise we'd surface a preview built for a different input — e.g. after
-        // toggling Recommended↔Manual or changing a combo selection. m_result itself
-        // is preserved across failed matches (start_batch_match no longer clears it),
-        // so this gate is what prevents a stale result from being shown.
+        // that result was produced (same mode + same filament selections: manual combos for
+        // MANUAL, palette dropdowns for RECOMMENDED). Otherwise we'd surface a preview built
+        // for a different input — e.g. after toggling Recommended↔Manual or changing a combo
+        // selection. m_result itself is preserved across failed matches (start_batch_match
+        // no longer clears it), so this gate is what prevents a stale result from being shown.
         const bool input_intact = (m_matching_method == m_last_result_method
-            && (m_matching_method != MANUAL
-                || (m_manual_filament_count == m_last_result_manual_count
+            && (m_matching_method == MANUAL
+                ? (m_manual_filament_count == m_last_result_manual_count
                     && std::equal(m_filament_selections,
                                   m_filament_selections + m_manual_filament_count,
-                                  m_last_result_selections))));
+                                  m_last_result_selections))
+                : std::equal(m_recommended_selections,
+                             m_recommended_selections + 4,
+                             m_last_result_recommended_selections)));
         if (m_result.success && input_intact) {
             // rebuild_match_thumb_cache is needed because reset_match_preview already
             // cleared the thumb buckets at the start of this match attempt.
@@ -2697,11 +2722,13 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
     m_last_result_manual_count = m_manual_filament_count;
     for (int i = 0; i < m_manual_filament_count; ++i)
         m_last_result_selections[i] = m_filament_selections[i];
+    for (int i = 0; i < 4; ++i)
+        m_last_result_recommended_selections[i] = m_recommended_selections[i];
     m_match_completed = true;
     update_mapping_legend();
     rebuild_match_thumb_cache();
-    if (result.is_recommended_mode)
-        update_recommended_card();
+    // Phase 2: the recommended dropdowns show the USER's selections, which a match no longer
+    // reorders — the card needs no post-match refresh (the previous fixed-swatch card did).
     refresh_previews();
     // Post-match advisories — both run here so the relevant banner is in place when
     // Confirm lights up:

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.cpp
@@ -326,7 +326,7 @@ MixedFilamentBatchDialog::MixedFilamentBatchDialog(wxWindow* parent)
     m_recommended_palette = load_recommended_palette();
     {
         const auto defaults = DefaultFullSpectrumSelections(m_recommended_palette, default_full_spectrum_family_name());
-        for (int i = 0; i < 4; ++i)
+        for (int i = 0; i < kFullSpectrumSlotCount; ++i)
             m_recommended_selections[i] = i < static_cast<int>(defaults.size()) ? defaults[i] : -1;
     }
     // Match targets = the project's FULL palette (physical filament_colour + enabled mixed
@@ -343,7 +343,7 @@ MixedFilamentBatchDialog::MixedFilamentBatchDialog(wxWindow* parent)
         // Re-apply the combo icons now that the card is visible: SetIcon on a hidden
         // window may not render (the same reason on_method_changed re-applies them on
         // every mode switch). The card was built hidden (card->Hide()).
-        for (int i = 0; i < 4; ++i)
+        for (int i = 0; i < kFullSpectrumSlotCount; ++i)
             if (m_recommended_combo[i])
                 set_recommended_combo_icon(i);
         m_recommended_card->Layout();
@@ -970,10 +970,10 @@ static std::vector<FullSpectrumPaletteEntry> load_recommended_palette()
         }
     }
 
-    if (palette.size() < 4) {
-        static const char* fallback_names[4] = {"Cyan", "Magenta", "Yellow", "Gray"};
+    if (palette.size() < static_cast<size_t>(kFullSpectrumSlotCount)) {
+        static const char* fallback_names[kFullSpectrumSlotCount] = {"Cyan", "Magenta", "Yellow", "Gray"};
         palette.clear();
-        for (size_t i = 0; i < FULL_SPECTRUM_FALLBACK_COLORS.size() && i < 4; ++i) {
+        for (size_t i = 0; i < FULL_SPECTRUM_FALLBACK_COLORS.size() && i < static_cast<size_t>(kFullSpectrumSlotCount); ++i) {
             FullSpectrumPaletteEntry entry;
             entry.hex         = FULL_SPECTRUM_FALLBACK_COLORS[i];
             entry.en_name     = fallback_names[i];
@@ -1463,7 +1463,7 @@ void MixedFilamentBatchDialog::build_recommended_card(wxBoxSizer& parent)
     auto* grid = new wxFlexGridSizer(2, FromDIP(12), FromDIP(12));
     grid->AddGrowableCol(0, 1);
     grid->AddGrowableCol(1, 1);
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < kFullSpectrumSlotCount; ++i) {
         auto* panel = new wxPanel(card, wxID_ANY);
         // wxPanel doesn't inherit the card's bg — set white explicitly so the row doesn't
         // show the dialog's #F8F7F7 through (same as build_manual_card rows).
@@ -1820,7 +1820,7 @@ void MixedFilamentBatchDialog::build_footer()
         // the currently configured filaments. Non-blocking — OK proceeds to EndModal.
         if (m_result.is_recommended_mode) {
             bool any_family_missing = false;
-            for (int i = 0; i < 4 && !any_family_missing; ++i) {
+            for (int i = 0; i < kFullSpectrumSlotCount && !any_family_missing; ++i) {
                 const int sel = m_recommended_selections[i];
                 if (sel < 0 || sel >= static_cast<int>(m_recommended_palette.size())) continue;
                 if (!full_spectrum_family_preset_selectable(m_recommended_palette[sel].family_name))
@@ -2007,7 +2007,7 @@ void MixedFilamentBatchDialog::on_method_changed(wxCommandEvent&)
             if (m_filament_combo[i])
                 set_manual_combo_icon(i, m_filament_combo[i]->GetSelection());
     } else {
-        for (int i = 0; i < 4; ++i)
+        for (int i = 0; i < kFullSpectrumSlotCount; ++i)
             if (m_recommended_combo[i])
                 set_recommended_combo_icon(i);
     }
@@ -2192,7 +2192,7 @@ void MixedFilamentBatchDialog::set_recommended_combo_icon(int row)
     // Same arrow+badge composition as set_manual_combo_icon, with two differences: the badge
     // label is the SLOT number (1-4 — the fixed dropdown index per spec §4, not a palette
     // index), and the swatch color is the palette entry currently selected in this slot.
-    if (row < 0 || row >= 4) return;
+    if (row < 0 || row >= kFullSpectrumSlotCount) return;
     ComboBox* cb = m_recommended_combo[row];
     if (!cb) return;
     const int sel = m_recommended_selections[row];
@@ -2428,14 +2428,14 @@ void MixedFilamentBatchDialog::launch_background_match()
     // worker never touches FilamentColorLibrary for this either.
     std::vector<std::string> preset_family_names;
     if (m_matching_method == RECOMMENDED) {
-        for (int i = 0; i < 4; ++i) {
+        for (int i = 0; i < kFullSpectrumSlotCount; ++i) {
             const int sel = m_recommended_selections[i];
             if (sel >= 0 && sel < static_cast<int>(m_recommended_palette.size())) {
                 preset_colors.push_back(m_recommended_palette[sel].hex);
                 preset_family_names.push_back(m_recommended_palette[sel].family_name);
             }
         }
-        if (preset_colors.size() < 4) {
+        if (preset_colors.size() < static_cast<size_t>(kFullSpectrumSlotCount)) {
             preset_colors = FULL_SPECTRUM_FALLBACK_COLORS;
             // Preserve the parallel-array invariant: synthesized canonical entries
             // belong to the default family (same as load_recommended_palette's
@@ -2467,7 +2467,7 @@ void MixedFilamentBatchDialog::launch_background_match()
             // No combo search anymore — the mixing algorithm and the 0–70% cap are unchanged
             // (the cap is enforced in the Pass-2 batch_match_model_colors call below via
             // match_max = kMaxComponentPercent).
-            if (preset_colors.size() >= 4) {
+            if (preset_colors.size() >= static_cast<size_t>(kFullSpectrumSlotCount)) {
                 physical_colors = preset_colors;
             } else {
                 // Defensive only — see the preset_colors block above.
@@ -2700,7 +2700,7 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
                                   m_filament_selections + m_manual_filament_count,
                                   m_last_result_selections))
                 : std::equal(m_recommended_selections,
-                             m_recommended_selections + 4,
+                             m_recommended_selections + kFullSpectrumSlotCount,
                              m_last_result_recommended_selections)));
         if (m_result.success && input_intact) {
             // rebuild_match_thumb_cache is needed because reset_match_preview already
@@ -2722,7 +2722,7 @@ void MixedFilamentBatchDialog::handle_batch_match_result(const BatchMatchResult&
     m_last_result_manual_count = m_manual_filament_count;
     for (int i = 0; i < m_manual_filament_count; ++i)
         m_last_result_selections[i] = m_filament_selections[i];
-    for (int i = 0; i < 4; ++i)
+    for (int i = 0; i < kFullSpectrumSlotCount; ++i)
         m_last_result_recommended_selections[i] = m_recommended_selections[i];
     m_match_completed = true;
     update_mapping_legend();

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
@@ -152,7 +152,7 @@ private:
     int            m_last_result_selections[4] = {0, 1, 2, 3};
     int            m_last_result_manual_count  = 0;
     // Recommended-mode arm of the same snapshot: the palette indices that produced m_result.
-    int            m_last_result_recommended_selections[4] = {-1, -1, -1, -1};
+    int            m_last_result_recommended_selections[kFullSpectrumSlotCount] = {-1, -1, -1, -1};
     bool                               m_match_completed = false;
     bool                               m_match_running   = false; // UI-thread-only; do not access from worker
     std::shared_ptr<std::atomic<bool>> m_destroyed{std::make_shared<std::atomic<bool>>(false)};
@@ -265,9 +265,9 @@ private:
     // single-color SKUs, alphabetical); combo row j shows palette entry j, so combo row
     // == palette index and no row→index map is needed. m_recommended_selections[i] is
     // the palette index selected in slot i (-1 = none, e.g. degenerate short palette).
-    ComboBox* m_recommended_combo[4]          = {nullptr};
+    ComboBox* m_recommended_combo[kFullSpectrumSlotCount]          = {nullptr};
     std::vector<FullSpectrumPaletteEntry>     m_recommended_palette;
-    int m_recommended_selections[4]           = {-1, -1, -1, -1};
+    int m_recommended_selections[kFullSpectrumSlotCount]           = {-1, -1, -1, -1};
     wxWindow*       m_manual_row_panels[4]    = {nullptr};
     int             m_manual_filament_count   = 0; // computed in ctor based on physical filaments
     // Add/remove buttons (mirrors MixedFilamentDialog: hidden at min/max count)

--- a/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
+++ b/src/slic3r/GUI/MixedFilamentBatchDialog.hpp
@@ -3,6 +3,7 @@
 #include "GUI_Utils.hpp"
 #include "ThumbnailView.hpp" // ThumbnailView enum (lightweight; avoids pulling in GLCanvas3D.hpp)
 #include "MixedColorMatchHelpers.hpp"
+#include "libslic3r/FilamentColorLibrary.hpp" // FullSpectrumPaletteEntry (m_recommended_palette)
 #include "libslic3r/MixedFilament.hpp"
 
 #include <wx/wx.h>
@@ -40,7 +41,7 @@ private:
     void build_banners();                            // error + warning panels
     void build_mode_row();                           // Match Mode combo + segmented Start/Re-match tabs
     void build_manual_card(wxBoxSizer& parent);      // filament config (manual mode): ComboBox rows + add/remove
-    void build_recommended_card(wxBoxSizer& parent); // filament config (auto mode): numbered swatches + names
+    void build_recommended_card(wxBoxSizer& parent); // filament config (auto mode): selectable palette ComboBox rows
     void build_preview_card(wxBoxSizer& parent);     // single card: dual previews + badges + plate/view controls
     void build_mapping_card(wxBoxSizer& parent);     // color mapping card shell (title + info icon + grid host)
     // No build_progress(): the progress bar lives inside the footer panel (see build_footer).
@@ -49,12 +50,20 @@ private:
     void on_method_changed(wxCommandEvent&);
     void update_method_combo_tooltip(); // refresh combo tooltip to describe the active mode
     void on_manual_selection_changed();
+    // Recommended-mode counterpart of on_manual_selection_changed: clears the previous
+    // match result (Start/Re-match re-enables via set_match_buttons_state). No
+    // selection-validity gating — duplicates and unselected slots are allowed; the
+    // worker falls back to the canonical palette when fewer than four colors exist.
+    void on_recommended_selection_changed();
     void update_add_remove_buttons(); // mirrors MixedFilamentDialog: hide add at max, remove at min
     // Compose drop_down arrow + numbered color badge into one transparent icon and set it as
     // the combo's left icon. Mirrors MixedFilamentDialog::set_combo_combined_icon: ComboBox
     // shows only the selected item's image when present (no native arrow), so we bake both
     // the arrow and the badge into a single SetIcon() image to keep the arrow visible.
     void set_manual_combo_icon(int row, int filament_idx);
+    // Same arrow+badge composition as set_manual_combo_icon, but the badge shows the SLOT
+    // number (1-4) over the palette color currently selected in that slot's dropdown.
+    void set_recommended_combo_icon(int row);
 
     // Preview lifecycle
     void build_preview_panels();                         // create wxStaticBitmaps once + render initial thumbnails
@@ -87,7 +96,6 @@ private:
     void check_manual_recipe_ratio();
 
     void set_match_buttons_state(bool matching);
-    void update_recommended_card();
     // Predict whether applying m_result would exceed MAXIMUM_FILAMENT_NUMBER (64)
     // at the add_batch_custom_filaments gate (the authoritative cap). The estimate
     // is an UPPER BOUND: post_apply_total = n + enabled_mixed + new_mixed_rows.
@@ -143,6 +151,8 @@ private:
     MatchingMethod m_last_result_method      = RECOMMENDED;
     int            m_last_result_selections[4] = {0, 1, 2, 3};
     int            m_last_result_manual_count  = 0;
+    // Recommended-mode arm of the same snapshot: the palette indices that produced m_result.
+    int            m_last_result_recommended_selections[4] = {-1, -1, -1, -1};
     bool                               m_match_completed = false;
     bool                               m_match_running   = false; // UI-thread-only; do not access from worker
     std::shared_ptr<std::atomic<bool>> m_destroyed{std::make_shared<std::atomic<bool>>(false)};
@@ -247,11 +257,17 @@ private:
     ComboBox*       m_tray_combo    = nullptr;
 
     // Filament config cards (manual + recommended; only one visible per mode, both styled alike)
-    wxWindow*       m_manual_card             = nullptr;
-    wxWindow*       m_recommended_card        = nullptr;
-    wxStaticBitmap* m_recommended_swatches[4] = {nullptr};
-    wxStaticText*   m_recommended_labels[4]   = {nullptr};
-    ComboBox*       m_filament_combo[4]       = {nullptr};
+    wxWindow* m_manual_card             = nullptr;
+    wxWindow* m_recommended_card        = nullptr;
+    ComboBox* m_filament_combo[4]       = {nullptr}; // manual mode: physical filament selector
+    // Recommended mode (phase 2): config-driven palette. m_recommended_palette is the
+    // Full Spectrum palette built in the ctor (BuildFullSpectrumPalette — every family,
+    // single-color SKUs, alphabetical); combo row j shows palette entry j, so combo row
+    // == palette index and no row→index map is needed. m_recommended_selections[i] is
+    // the palette index selected in slot i (-1 = none, e.g. degenerate short palette).
+    ComboBox* m_recommended_combo[4]          = {nullptr};
+    std::vector<FullSpectrumPaletteEntry>     m_recommended_palette;
+    int m_recommended_selections[4]           = {-1, -1, -1, -1};
     wxWindow*       m_manual_row_panels[4]    = {nullptr};
     int             m_manual_filament_count   = 0; // computed in ctor based on physical filaments
     // Add/remove buttons (mirrors MixedFilamentDialog: hidden at min/max count)

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6,6 +6,7 @@
 #include "MixedFilamentBadge.hpp"
 #include "MixedFilamentColorMapPanel.hpp"
 #include "MixedColorMatchHelpers.hpp"
+#include "libslic3r/FilamentColorLibrary.hpp" // kFullSpectrumSlotCount (recommended slot write-back)
 #include "libslic3r/Config.hpp"
 #include "libslic3r/MixedFilament.hpp"
 #include "libslic3r/filament_mixer.h"
@@ -2818,7 +2819,7 @@ Sidebar::Sidebar(Plater *parent)
             // Confirm-time note in MixedFilamentBatchDialog makes). The
             // default-family single preset is only used for legacy results that
             // carry no per-slot family info (pre-phase-2 behavior).
-            for (size_t i = 0; i < std::min<size_t>(4, target_count); ++i) {
+            for (size_t i = 0; i < std::min<size_t>(static_cast<size_t>(kFullSpectrumSlotCount), target_count); ++i) {
                 std::string preset_name;
                 if (i < result.recommended_physical_family_names.size()) {
                     preset_name = find_selectable_full_spectrum_family_preset(result.recommended_physical_family_names[i]);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2597,8 +2597,8 @@ Sidebar::Sidebar(Plater *parent)
     p->m_btn_batch_match->SetStyle(ButtonStyle::Confirm, ButtonType::Compact);
     p->m_btn_batch_match->SetToolTip(_L("Automatically calculate the color mixing scheme that best matches the original model colors and complete color mapping.\n"
                                         "Note:\n"
-                                        "1.Color mixing match is based on the official recommended CMYG filaments. The matched colors may differ from the original model.\n"
-                                        "2.The order of the Color Mapping list may differ from that of the Color Mixing list."));
+                                        "1. Color mixing match is based on the official recommended filaments. The matched colors may differ from the original model.\n"
+                                        "2. The order of the Color Mapping list may differ from that of the Color Mixing list."));
     p->m_btn_batch_match->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
         if (!wxGetApp().preset_bundle) return;
         // No loaded model → batch match has nothing to map. Surface as a confirmation
@@ -2676,9 +2676,9 @@ Sidebar::Sidebar(Plater *parent)
         // NOTE: deliberately NO take_snapshot() here. The UndoRedo stack only
         // captures the Model (object painting), not the preset_bundle palette
         // or mixed_filaments. Snapshotting batch match would make Ctrl+Z revert
-        // painting while leaving the expanded CMYG palette in place → silent
+        // painting while leaving the expanded recommended palette in place → silent
         // wrong colors. Re-enable only after UndoRedo covers preset_bundle.
-        // For recommended mode, apply CMYG to the first 4 physical slots.
+        // For recommended mode, apply the matched palette colors to the first 4 physical slots.
         // < 4 filaments: expand to 4.  >= 4 filaments: keep every slot THROUGH
         // this stage (virtual ids / add_batch compute over the full slot
         // space).  The batch match is a project-wide re-plan of the filament
@@ -2694,7 +2694,7 @@ Sidebar::Sidebar(Plater *parent)
             const size_t current_count = pb->filament_presets.size();
             const size_t target_count  = std::max<size_t>(4, current_count);
 
-            // Build full palette: CMYG in slots 1-4, original in 5+.
+            // Build full palette: matched colors in slots 1-4, original in 5+.
             colors_vec = fc ? fc->values : std::vector<std::string>{};
             colors_vec.resize(target_count);
 
@@ -2718,7 +2718,7 @@ Sidebar::Sidebar(Plater *parent)
                     color_modes->values[i] = 0;
             }
 
-            // Write before set_num_filaments so auto_generate sees CMYG palette.
+            // Write before set_num_filaments so auto_generate sees the matched palette.
             if (fc) fc->values = colors_vec;
 
             // Snapshot the old mixed list BEFORE set_num_filaments clears
@@ -2810,14 +2810,30 @@ Sidebar::Sidebar(Plater *parent)
                 }
             }
 
-            // Write Full Spectrum to slots 1-4 only when the preset is
-            // selectable under the current printer (present + visible +
-            // compatible, matching the filament combobox filter).
-            const std::string full_spectrum_preset = full_spectrum_preset_name();
-            const Preset*     fs_preset = pb->filaments.find_preset(full_spectrum_preset);
-            if (fs_preset != nullptr && fs_preset->is_visible && fs_preset->is_compatible) {
-                for (size_t i = 0; i < std::min<size_t>(4, target_count); ++i)
-                    pb->set_filament_preset(i, full_spectrum_preset);
+            // Write a Full Spectrum preset into each of slots 1-4, per the FAMILY the
+            // user selected in that slot's palette dropdown (phase 2 multi-family:
+            // e.g. PLA in slots 1-2, PETG in 3-4). When a slot's family has no
+            // selectable preset, the slot KEEPS its current preset — per spec §5.1
+            // ("Configured filaments will be used instead", the same promise the
+            // Confirm-time note in MixedFilamentBatchDialog makes). The
+            // default-family single preset is only used for legacy results that
+            // carry no per-slot family info (pre-phase-2 behavior).
+            for (size_t i = 0; i < std::min<size_t>(4, target_count); ++i) {
+                std::string preset_name;
+                if (i < result.recommended_physical_family_names.size()) {
+                    preset_name = find_selectable_full_spectrum_family_preset(result.recommended_physical_family_names[i]);
+                    // Family not selectable: leave empty on purpose — the slot keeps
+                    // the user's configured preset (§5.1). Do NOT substitute the
+                    // default family here: the user explicitly chose this family.
+                } else {
+                    // Legacy result without per-slot family info: the pre-phase-2
+                    // single default-family preset, all-or-nothing per slot.
+                    const Preset* fs_preset = pb->filaments.find_preset(full_spectrum_preset_name());
+                    if (fs_preset != nullptr && fs_preset->is_visible && fs_preset->is_compatible)
+                        preset_name = fs_preset->name;
+                }
+                if (!preset_name.empty())
+                    pb->set_filament_preset(i, preset_name);
             }
 
             wxGetApp().plater()->on_filaments_change(static_cast<int>(target_count));
@@ -3010,6 +3026,9 @@ Sidebar::Sidebar(Plater *parent)
         for (size_t i = 0; i < fcombos.size(); ++i) {
             if (fcombos[i]) fcombos[i]->update();
         }
+        // No undo snapshot in this apply path: mark dirty so close-without-save prompts
+        // instead of silently dropping the match result.
+        wxGetApp().plater()->update_project_dirty_from_presets();
         // §70: wxPD_AUTO_HIDE only fires at 100%, so reach 100 here for a clean
         // dismiss (otherwise the bar visibly aborts when the dialog leaves scope).
         set_progress(100);

--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -26,6 +26,7 @@
 #include "libslic3r/Utils.hpp"
 #include "libslic3r/Preset.hpp"
 #include "libslic3r/PresetBundle.hpp"
+#include "libslic3r/FilamentColorLibrary.hpp"
 #include "common_func/common_func.hpp"
 #include "slic3r/GUI/GUI.hpp"
 #include "slic3r/GUI/GUI_App.hpp"
@@ -1959,6 +1960,12 @@ static bool reload_configs_update_gui()
 	GUI::wxGetApp().load_current_presets();
 	if (GUI::Plater* pl = GUI::wxGetApp().plater())
 		pl->set_bed_shape();
+
+	// The vendor directory copied in by an update also carries filaments_colours.json
+	// (hot-updated color palette / Full Spectrum SKUs). The color library caches that
+	// file for the process lifetime, so reload it here — same UI thread as the preset
+	// reload above — to make hot-updated colors visible without an app restart.
+	FilamentColorLibrary::Instance().Reload();
 
 	return true;
 }

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -5237,3 +5237,162 @@ TEST_CASE("Dual-color primary drops invalid tokens and falls back on empty", "[M
     CHECK(FilamentColor::FromColors(parts, FilamentColorMode::Segment).PrimaryColor() == "#AABBCC");
     CHECK(FilamentColor::FromColors({}, FilamentColorMode::Segment).PrimaryColor("#26A69A") == "#26A69A");
 }
+
+// ============================================================================
+// [MixedFilament][FilamentColor] — phase-2 recommended-mode palette. The
+// palette is config-driven: BuildFullSpectrumPalette enumerates every library
+// filament whose type contains "Full Spectrum" and keeps its single-color
+// SKUs, sorted family-grouped (families alphabetical, colors alphabetical
+// within each family); DefaultFullSpectrumSelections picks the default
+// dropdown slots (cyan/magenta/yellow/white, default family preferred). These
+// cases pin both pure functions against constructed library data.
+// ============================================================================
+namespace {
+
+static FilamentColorItem palette_item(const std::string &hex, const std::string &en_name, const std::string &zh_name)
+{
+    FilamentColorItem item;
+    item.colorData.colors = {hex};
+    item.colorNames = {{"en", en_name}, {"zh_CN", zh_name}};
+    return item;
+}
+
+static FilamentColorInfo palette_family(const std::string &name, const std::string &type, std::vector<FilamentColorItem> items)
+{
+    FilamentColorInfo info;
+    info.filamentName = name;
+    info.type = type;
+    info.colors = std::move(items);
+    return info;
+}
+
+static std::vector<FilamentColorInfo> full_spectrum_library(bool with_white, bool with_petg)
+{
+    std::vector<FilamentColorItem> pla = {
+        palette_item("#08ABFB", "Semi-Translucent Cyan", "半透青色"),
+        palette_item("#D93B90", "Semi-Translucent Magenta", "半透品红色"),
+        palette_item("#F9ED3D", "Semi-Translucent Yellow", "半透黄色"),
+        palette_item("#9199A4", "Semi-Translucent Gray", "半透灰色"),
+    };
+    if (with_white)
+        pla.push_back(palette_item("#FFFFFF", "Semi-Translucent White", "半透白色"));
+
+    std::vector<FilamentColorInfo> library = {
+        palette_family("Snapmaker PLA Basic @U1", "PLA", {palette_item("#FFFFFF", "White", "白色")}), // wrong type: excluded
+        palette_family("Snapmaker PLA Full Spectrum @U1", "PLA Full Spectrum", std::move(pla)),
+    };
+    if (with_petg) {
+        std::vector<FilamentColorItem> petg = {
+            palette_item("#08ABFB", "Semi-Translucent Cyan", "半透青色"),
+            palette_item("#D93B90", "Semi-Translucent Magenta", "半透品红色"),
+        };
+        library.push_back(palette_family("Snapmaker PETG Full Spectrum @U1", "PETG Full Spectrum", std::move(petg)));
+    }
+    return library;
+}
+
+} // namespace
+
+TEST_CASE("Full Spectrum palette enumerates single-color SKUs across families, alphabetically", "[MixedFilament][FilamentColor]")
+{
+    const auto palette = BuildFullSpectrumPalette(full_spectrum_library(true, true));
+    // 5 PLA entries (multi/gradient SKUs would be dropped) + 2 PETG entries; the
+    // PLA Basic "White" is excluded (its type has no "Full Spectrum").
+    REQUIRE(palette.size() == 7);
+    // Family-grouped (test matrix #10): families in alphabetical order (PETG < PLA),
+    // colors alphabetical within each family — cyan/magenta (PETG), then cyan/gray/
+    // magenta/white/yellow (PLA).
+    CHECK(palette[0].en_name == "Semi-Translucent Cyan");
+    CHECK(palette[0].family_name == "Snapmaker PETG Full Spectrum @U1");
+    CHECK(palette[1].en_name == "Semi-Translucent Magenta");
+    CHECK(palette[1].family_name == "Snapmaker PETG Full Spectrum @U1");
+    CHECK(palette[2].en_name == "Semi-Translucent Cyan");
+    CHECK(palette[2].family_name == "Snapmaker PLA Full Spectrum @U1");
+    CHECK(palette[3].en_name == "Semi-Translucent Gray");
+    CHECK(palette[3].family_name == "Snapmaker PLA Full Spectrum @U1");
+    CHECK(palette[4].en_name == "Semi-Translucent Magenta");
+    CHECK(palette[4].family_name == "Snapmaker PLA Full Spectrum @U1");
+    CHECK(palette[5].en_name == "Semi-Translucent White");
+    CHECK(palette[5].family_name == "Snapmaker PLA Full Spectrum @U1");
+    CHECK(palette[6].en_name == "Semi-Translucent Yellow");
+    CHECK(palette[6].family_name == "Snapmaker PLA Full Spectrum @U1");
+    // Hex normalization and the locale name map survive into the entry.
+    CHECK(palette[0].hex == "#08ABFB");
+    CHECK(palette[0].color_names.at("zh_CN") == "半透青色");
+}
+
+TEST_CASE("Full Spectrum palette default selections pick CMYW from the default family", "[MixedFilament][FilamentColor]")
+{
+    const auto palette = BuildFullSpectrumPalette(full_spectrum_library(true, true));
+    const std::string pla = "Snapmaker PLA Full Spectrum @U1";
+    const auto sel = DefaultFullSpectrumSelections(palette, pla);
+    REQUIRE(sel.size() == 4);
+    // Slots 1-4 = cyan/magenta/yellow/white of the PLA family; gray stays unselected
+    // (cyan is matched in-family even though PETG's cyan sorts first alphabetically).
+    CHECK(palette[sel[0]].en_name == "Semi-Translucent Cyan");
+    CHECK(palette[sel[0]].family_name == pla);
+    CHECK(palette[sel[1]].en_name == "Semi-Translucent Magenta");
+    CHECK(palette[sel[1]].family_name == pla);
+    CHECK(palette[sel[2]].en_name == "Semi-Translucent Yellow");
+    CHECK(palette[sel[3]].en_name == "Semi-Translucent White");
+    std::set<int> distinct(sel.begin(), sel.end());
+    CHECK(distinct.size() == 4);
+}
+
+TEST_CASE("Full Spectrum palette default selections fall back to gray without white", "[MixedFilament][FilamentColor]")
+{
+    // Bundled config today: no White SKU yet (arrives via hot update). Slot 4 falls
+    // back to the next unused default-family entry: gray.
+    const auto palette = BuildFullSpectrumPalette(full_spectrum_library(false, false));
+    REQUIRE(palette.size() == 4);
+    const auto sel = DefaultFullSpectrumSelections(palette, "Snapmaker PLA Full Spectrum @U1");
+    REQUIRE(sel.size() == 4);
+    CHECK(palette[sel[0]].en_name == "Semi-Translucent Cyan");
+    CHECK(palette[sel[1]].en_name == "Semi-Translucent Magenta");
+    CHECK(palette[sel[2]].en_name == "Semi-Translucent Yellow");
+    CHECK(palette[sel[3]].en_name == "Semi-Translucent Gray");
+}
+
+TEST_CASE("Full Spectrum palette default selections degrade on short palettes", "[MixedFilament][FilamentColor]")
+{
+    std::vector<FilamentColorInfo> library = {
+        palette_family("Snapmaker PLA Full Spectrum @U1", "PLA Full Spectrum",
+                       {palette_item("#08ABFB", "Semi-Translucent Cyan", "半透青色"),
+                        palette_item("#D93B90", "Semi-Translucent Magenta", "半透品红色")}),
+    };
+    const auto palette = BuildFullSpectrumPalette(library);
+    REQUIRE(palette.size() == 2);
+    const auto sel = DefaultFullSpectrumSelections(palette, "Snapmaker PLA Full Spectrum @U1");
+    CHECK(sel.size() == 2);
+    CHECK(palette[sel[0]].en_name == "Semi-Translucent Cyan");
+    CHECK(palette[sel[1]].en_name == "Semi-Translucent Magenta");
+
+    CHECK(BuildFullSpectrumPalette({}).empty());
+    CHECK(DefaultFullSpectrumSelections({}, "any").empty());
+}
+
+TEST_CASE("Full Spectrum palette passes config td values through as-read (no fallback)", "[MixedFilament][FilamentColor]")
+{
+    // TD comes from the hot-updated config (per-SKU "td" field, parsed by the config
+    // side). The palette builder passes the value through untouched — there is NO
+    // static fallback table: a color whose config entry has no td simply carries 0.0
+    // (test matrix #1: Cyan 5.5 -> 6.0 after hot update; #11: unread td shows 0.0).
+    FilamentColorItem cyan  = palette_item("#08ABFB", "Semi-Translucent Cyan", "半透青色");
+    cyan.tdValue = 6.0;  // post-hot-update value
+    FilamentColorItem gray  = palette_item("#9199A4", "Semi-Translucent Gray", "半透灰色");
+    gray.tdValue = 8.8;
+    FilamentColorItem white = palette_item("#FFFFFF", "Semi-Translucent White", "半透白色"); // no td in config
+
+    const std::vector<FilamentColorInfo> library = {
+        palette_family("Snapmaker PLA Full Spectrum @U1", "PLA Full Spectrum", {cyan, gray, white}),
+    };
+    const auto palette = BuildFullSpectrumPalette(library);
+    REQUIRE(palette.size() == 3);
+    // Palette is alphabetical: Cyan, Gray, White.
+    CHECK(palette[0].en_name == "Semi-Translucent Cyan");
+    CHECK(palette[0].td_value == 6.0);
+    CHECK(palette[1].en_name == "Semi-Translucent Gray");
+    CHECK(palette[1].td_value == 8.8);
+    CHECK(palette[2].en_name == "Semi-Translucent White");
+    CHECK(palette[2].td_value == 0.0);
+}

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -5416,3 +5416,39 @@ TEST_CASE("Full Spectrum palette leaves en_name empty without an en entry (no ar
     CHECK(palette[0].en_name.empty());
     CHECK(palette[0].hex == "#123456");
 }
+
+TEST_CASE("Full Spectrum default selections normalize the default family argument", "[MixedFilament][FilamentColor]")
+{
+    // Callers may pass any of the three family-name forms — the raw library name
+    // ("... @U1"), the full preset name ("... @U1 0.4 nozzle"), or the already-stripped
+    // match name — and all must anchor the default C/M/Y/W slots on that family.
+    // Regression: the GUI passes the stripped form, which silently never matched the raw
+    // family names the palette carries, so the default-family preference never fired
+    // (invisible with the single-family bundled config, wrong defaults after a
+    // multi-family hot update).
+    const auto palette = BuildFullSpectrumPalette(full_spectrum_library(true, true));
+    REQUIRE(palette.size() == 7);
+
+    const std::string default_family_forms[] = {
+        "Snapmaker PLA Full Spectrum @U1",             // raw library name
+        "Snapmaker PLA Full Spectrum @U1 0.4 nozzle",  // full preset name
+        "Snapmaker PLA Full Spectrum",                 // stripped match name (GUI form)
+    };
+    for (const std::string& default_family : default_family_forms)
+    {
+        SECTION(default_family)
+        {
+            const auto sel = DefaultFullSpectrumSelections(palette, default_family);
+            REQUIRE(sel.size() == 4);
+            // Every slot must land on the DEFAULT family (never the PETG entries that
+            // sort first alphabetically), cyan/magenta/yellow/white in slot order.
+            CHECK(palette[sel[0]].family_name == "Snapmaker PLA Full Spectrum @U1");
+            CHECK(palette[sel[0]].en_name == "Semi-Translucent Cyan");
+            CHECK(palette[sel[1]].en_name == "Semi-Translucent Magenta");
+            CHECK(palette[sel[2]].en_name == "Semi-Translucent Yellow");
+            CHECK(palette[sel[3]].en_name == "Semi-Translucent White");
+            std::set<int> distinct(sel.begin(), sel.end());
+            CHECK(distinct.size() == 4);
+        }
+    }
+}

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -5396,3 +5396,23 @@ TEST_CASE("Full Spectrum palette passes config td values through as-read (no fal
     CHECK(palette[2].en_name == "Semi-Translucent White");
     CHECK(palette[2].td_value == 0.0);
 }
+
+TEST_CASE("Full Spectrum palette leaves en_name empty without an en entry (no arbitrary pick)", "[MixedFilament][FilamentColor]")
+{
+    // A SKU carrying only zh_CN must NOT get its en_name from an arbitrary
+    // unordered_map::begin() pick: en_name feeds the sort key and slot-name matching,
+    // so an arbitrary locale's name there would make palette order and default slot
+    // anchoring depend on the hash layout and on which non-English translations the
+    // config happens to carry. Leave it empty instead (GetColorNameForSort contract).
+    FilamentColorItem no_en;
+    no_en.colorData.colors = {"#123456"};
+    no_en.colorNames       = {{"zh_CN", "半透青色"}};
+
+    const std::vector<FilamentColorInfo> library = {
+        palette_family("Snapmaker PLA Full Spectrum @U1", "PLA Full Spectrum", {no_en}),
+    };
+    const auto palette = BuildFullSpectrumPalette(library);
+    REQUIRE(palette.size() == 1);
+    CHECK(palette[0].en_name.empty());
+    CHECK(palette[0].hex == "#123456");
+}


### PR DESCRIPTION
## Summary

Follow-up to #702. Makes the **Recommended** mode of the batch color-match
dialog config-driven instead of hard-coded: the Full Spectrum palette (colors,
names, TD values) is built from `filaments_colours.json`, and each of the four
recommended slots becomes a selectable dropdown. Palette data hot-reloads after
OTA preset updates — no app restart required.

## What's new

### Config-driven palette (`FilamentColorLibrary`)
- `BuildFullSpectrumPalette` builds the palette from every Full Spectrum family
  in `filaments_colours.json` (single-color SKUs only, family-grouped
  alphabetical order); `DefaultFullSpectrumSelections` anchors the default
  C/M/Y/W slots on the default family with canonical fallback.
- TD values are read from config as-is (no hard-coded table).

### Recommended card UI (`MixedFilamentBatchDialog`)
- Four fixed slots become **selectable family dropdowns** with numbered slot
  badges and composited picker arrow / +/- icons.
- Per-row tooltips show the localized color name + configured TD value,
  including in the closed state.

### Thread safety & degradation
- Dropdown selections are snapshotted on the UI thread and captured by value
  into the matching worker.
- Fewer than 4 selections degrade gracefully to the canonical palette.

### Preset write-back on Confirm
- `find_selectable_full_spectrum_family_preset()` resolves a visible +
  compatible preset per selected family with nozzle preference
  (current nozzle > 0.4 SKU > first selectable), matched by
  `GetFilamentMatchName` identity; slots whose family has no selectable preset
  keep the configured filament.

### Integration
- `PresetUpdater` reloads `FilamentColorLibrary` after OTA preset updates so
  hot-updated colors/TD take effect without restart.
- Removed the hard-coded `FULL_SPECTRUM_TD` table and
  `load_full_spectrum_colors` from `MixedColorMatchHelpers`.
- zh_CN translations updated for the new copy.

## Tests
- `tests/libslic3r/test_mixed_filament.cpp`: +159 lines, 5 new cases — palette
  enumeration across families, default CMYW slot anchoring, fallback without
  white, degradation on short palettes, and TD pass-through as-read.

## Verification
- Windows (VS2022) build; libslic3r unit suite passes.
- Manual: recommended-mode slot switching, OTA hot update reload, non-0.4
  nozzle preset adaptation, <4-color degradation path.