### PR TITLE
feat(http): cache negotiation (ETag/304) + Connection: close for local web server

### DIFF
--- a/src/slic3r/GUI/HttpServer.cpp
+++ b/src/slic3r/GUI/HttpServer.cpp
@@ -283,9 +283,36 @@ std::string get_file_content_type(const std::string& file_path)
     return "application/octet-stream";
 }
 
+// True if basename matches Flutter web's content-hashed naming (name.<hex-hash>.ext),
+// where <hex-hash> is at least 16 hex characters (Flutter emits 16-char truncated
+// digests). The hash is a content digest, so the URL changes whenever the content
+// changes and the file is safe to serve immutable. Expects a lowercased basename.
+bool is_content_hashed(const std::string& basename)
+{
+    const std::size_t last_dot = basename.find_last_of('.');
+    if (last_dot == std::string::npos || last_dot == 0)
+        return false;
+
+    const std::size_t hash_dot = basename.find_last_of('.', last_dot - 1);
+    if (hash_dot == std::string::npos)
+        return false;
+
+    const std::size_t hash_len = last_dot - hash_dot - 1;
+    if (hash_len < 16)
+        return false;
+
+    for (std::size_t i = hash_dot + 1; i < last_dot; ++i) {
+        const char c = basename[i];
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
+            return false;
+    }
+    return true;
+}
+
 // Return a Cache-Control value for a served file.
-// - main.<hash>.js / flutter_bootstrap.<hash>.js are content-hashed, so their URL
-//   changes whenever the content changes → safe to serve immutable.
+// - content-hashed files (name.<hex-hash>.ext, e.g. main.983d3eca8f92f614.js) are
+//   content-addressed, so their URL changes whenever the content changes → safe to
+//   serve immutable.
 // - index.html / version.json / manifest.json must always be fresh.
 // - canvaskit/** / fonts / images / other assets keep fixed names, so they are
 //   revalidated via Last-Modified + ETag (304 when unchanged — the 304 logic is in
@@ -299,9 +326,8 @@ std::string get_cache_control_header(const std::string& file_path)
     if (slash != std::string::npos)
         basename = lower.substr(slash + 1);
 
-    // Content-hashed JS: main.<hash>.js and flutter_bootstrap.<hash>.js
-    if ((boost::starts_with(basename, "main.") || boost::starts_with(basename, "flutter_bootstrap.")) &&
-        boost::ends_with(basename, ".js"))
+    // Content-hashed files (name.<hex-hash>.ext): immutable, the URL is content-addressed.
+    if (is_content_hashed(basename))
         return "public, max-age=31536000, immutable";
 
     // App shell + version probe: always fresh (tiny, re-downloaded each boot)
@@ -314,6 +340,19 @@ std::string get_cache_control_header(const std::string& file_path)
     // canvaskit / fonts / images / svgs / other assets: fixed names, so revalidate
     // via Last-Modified + ETag (304 when unchanged).
     return "no-cache";
+}
+
+// Writes the header lines shared by every response: the status line, the CORS
+// headers, and Connection: close. The server never reuses a connection, so the
+// explicit Connection: close stops clients from assuming HTTP/1.1 keep-alive and
+// racing against our socket close.
+void write_common_headers(std::stringstream& out, int status_code, const std::string& reason_phrase)
+{
+    out << "HTTP/1.1 " << status_code << " " << reason_phrase << "\r\n";
+    out << "Access-Control-Allow-Origin: *\r\n";
+    out << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
+    out << "Access-Control-Allow-Headers: Content-Type, Authorization\r\n";
+    out << "Connection: close\r\n";
 }
 
 bool should_report_file_progress(const std::string& url)
@@ -447,12 +486,9 @@ void session::read_next_line()
     if (headers.method == "OPTIONS") {
         // 构造OPTIONS响应（允许跨域）
         std::stringstream ssOut;
-        ssOut << "HTTP/1.1 200 OK\r\n";
-        ssOut << "Access-Control-Allow-Origin: *\r\n";                            // 允许所有源
-        ssOut << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";          // 允许的方法
-        ssOut << "Access-Control-Allow-Headers: Content-Type, Authorization\r\n"; // 允许的请求头
-        ssOut << "Content-Length: 0\r\n";                                         // 无响应体
-        ssOut << "\r\n";                                                          // 头和主体之间的空行（必须）
+        write_common_headers(ssOut, 200, "OK");
+        ssOut << "Content-Length: 0\r\n"; // 无响应体
+        ssOut << "\r\n";                  // 头和主体之间的空行（必须）
 
         // 异步发送响应
         async_write(socket, boost::asio::buffer(ssOut.str()), [this, self](const boost::beast::error_code& e, std::size_t s) {
@@ -1145,11 +1181,10 @@ void HttpServer::ResponseRedirect::write_response(std::stringstream& ssOut)
     const std::string sHTML          = "<html><body><p>redirect to url </p></body></html>";
     size_t            content_length = sHTML.size(); // 字节长度（与字符数相同，因无多字节字符）
 
-    ssOut << "HTTP/1.1 302 Found\r\n";
+    write_common_headers(ssOut, 302, "Found");
     ssOut << "Location: " << location_str << "\r\n";
     ssOut << "Content-Type: text/html\r\n";
     ssOut << "Content-Length: " << content_length << "\r\n"; // 正确计算长度
-    ssOut << "Access-Control-Allow-Origin: *\r\n";           // CORS头
     ssOut << "\r\n";                                         // 头和主体之间的空行（必须）
     ssOut << sHTML;                                          // 响应体（长度必须匹配）
 }
@@ -1159,10 +1194,9 @@ void HttpServer::ResponseNotFound::write_response(std::stringstream& ssOut)
     const std::string sHTML          = "<html><body><h1>404 Not Found</h1><p>There's nothing here.</p></body></html>";
     size_t            content_length = sHTML.size(); // 字节长度
 
-    ssOut << "HTTP/1.1 404 Not Found\r\n";
+    write_common_headers(ssOut, 404, "Not Found");
     ssOut << "Content-Type: text/html\r\n";
     ssOut << "Content-Length: " << content_length << "\r\n"; // 正确计算长度
-    ssOut << "Access-Control-Allow-Origin: *\r\n";           // CORS头
     ssOut << "\r\n";                                         // 头和主体之间的空行（必须）
     ssOut << sHTML;                                          // 响应体（长度必须匹配）
 }
@@ -1198,13 +1232,10 @@ void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
 
     if (can_revalidate && is_not_modified(m_if_modified_since, m_if_none_match, etag, last_write_time)) {
         // Client's cached copy is still current: no body.
-        ssOut << "HTTP/1.1 304 Not Modified\r\n";
+        write_common_headers(ssOut, 304, "Not Modified");
         ssOut << "Cache-Control: " << get_cache_control_header(file_path) << "\r\n";
         ssOut << "ETag: " << etag << "\r\n";
         ssOut << "Last-Modified: " << last_modified << "\r\n";
-        ssOut << "Access-Control-Allow-Origin: *\r\n";
-        ssOut << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
-        ssOut << "Access-Control-Allow-Headers: Content-Type, Authorization\r\n";
         ssOut << "\r\n";
         return;
     }
@@ -1241,7 +1272,7 @@ void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
         content_type = "font/woff2";
 
     // 构造响应头（严格使用\r\n，头结束后空行）
-    ssOut << "HTTP/1.1 200 OK\r\n";
+    write_common_headers(ssOut, 200, "OK");
     ssOut << "Content-Type: " << content_type << "\r\n";
     ssOut << "Content-Length: " << content_length << "\r\n"; // 必须与实际内容长度一致
     ssOut << "Cache-Control: " << get_cache_control_header(file_path) << "\r\n";
@@ -1249,10 +1280,7 @@ void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
         ssOut << "ETag: " << etag << "\r\n";
         ssOut << "Last-Modified: " << last_modified << "\r\n";
     }
-    ssOut << "Access-Control-Allow-Origin: *\r\n";           // CORS头
-    ssOut << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
-    ssOut << "Access-Control-Allow-Headers: Content-Type, Authorization\r\n";
-    ssOut << "\r\n";      // 头和主体之间的空行（必须）
+    ssOut << "\r\n";
     ssOut << fileContent; // 响应体（长度必须与Content-Length一致）
 }
 
@@ -1301,13 +1329,10 @@ bool HttpServer::ResponseFile::write_response(boost::asio::ip::tcp::socket& sock
         }
     } else if (can_revalidate && is_not_modified(m_if_modified_since, m_if_none_match, etag, last_write_time)) {
         // Client's cached copy is still current: no body, so no FileStreamWriter.
-        header_stream << "HTTP/1.1 304 Not Modified\r\n";
+        write_common_headers(header_stream, 304, "Not Modified");
         header_stream << "Cache-Control: " << get_cache_control_header(file_path) << "\r\n";
         header_stream << "ETag: " << etag << "\r\n";
         header_stream << "Last-Modified: " << last_modified << "\r\n";
-        header_stream << "Access-Control-Allow-Origin: *\r\n";
-        header_stream << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
-        header_stream << "Access-Control-Allow-Headers: Content-Type, Authorization\r\n";
         header_stream << "\r\n";
         file.close();
 
@@ -1316,7 +1341,7 @@ bool HttpServer::ResponseFile::write_response(boost::asio::ip::tcp::socket& sock
                                  [completion, str](const boost::beast::error_code& ec, std::size_t s) { completion(ec, s); });
         return true;
     } else {
-        header_stream << "HTTP/1.1 200 OK\r\n";
+        write_common_headers(header_stream, 200, "OK");
         header_stream << "Content-Type: " << get_file_content_type(file_path) << "\r\n";
         header_stream << "Content-Length: " << content_length << "\r\n";
         header_stream << "Cache-Control: " << get_cache_control_header(file_path) << "\r\n";
@@ -1324,9 +1349,6 @@ bool HttpServer::ResponseFile::write_response(boost::asio::ip::tcp::socket& sock
             header_stream << "ETag: " << etag << "\r\n";
             header_stream << "Last-Modified: " << last_modified << "\r\n";
         }
-        header_stream << "Access-Control-Allow-Origin: *\r\n";
-        header_stream << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
-        header_stream << "Access-Control-Allow-Headers: Content-Type, Authorization\r\n";
         header_stream << "\r\n";
     }
 

--- a/src/slic3r/GUI/HttpServer.cpp
+++ b/src/slic3r/GUI/HttpServer.cpp
@@ -1,21 +1,17 @@
 #include "HttpServer.hpp"
 #include <boost/log/trivial.hpp>
 #include <boost/algorithm/string.hpp>
-#include <boost/system/errc.hpp>
-#include <algorithm>
-#include <fstream>
-#include <limits>
-#include <vector>
+#include <boost/filesystem.hpp>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <ctime>
 #include <condition_variable>
 #include "GUI_App.hpp"
 #include "slic3r/Utils/Http.hpp"
 #include "slic3r/Utils/NetworkAgent.hpp"
 #include  "sentry_wrapper/SentryWrapper.hpp"
 #include <boost/beast/core/detail/base64.hpp>
-#include <boost/filesystem.hpp>
-#include <cstdio>
-#include <cstring>
-#include <ctime>
 #ifdef _WIN32
 #include <windows.h>
 #include <io.h>
@@ -36,134 +32,11 @@ std::string http_headers::get_header(const std::string& name) const
 
 namespace {
 
-constexpr std::size_t file_stream_chunk_size = 64 * 1024;
-
-class FileStreamWriter : public std::enable_shared_from_this<FileStreamWriter>
-{
-public:
-    FileStreamWriter(boost::asio::ip::tcp::socket& socket, std::ifstream file, std::string header, std::uintmax_t total_bytes,
-                     HttpServer::FileProgressCallback progress_callback, HttpServer::StreamCompletion completion)
-        : socket_(socket), file_(std::move(file)), header_(std::move(header)), total_bytes_(total_bytes),
-          progress_callback_(std::move(progress_callback)), completion_(std::move(completion))
-    {}
-
-    void start()
-    {
-        auto self = shared_from_this();
-        boost::asio::async_write(socket_, boost::asio::buffer(header_),
-                                 [this, self](const boost::beast::error_code& error, std::size_t bytes_transferred) {
-                                     handle_header_written(error, bytes_transferred);
-                                 });
-    }
-
-private:
-    void handle_header_written(const boost::beast::error_code& error, std::size_t bytes_transferred)
-    {
-        if (error) {
-            finish(error, bytes_transferred);
-            return;
-        }
-
-        if (total_bytes_ == 0) {
-            report_progress(false);
-            finish({}, 0);
-            return;
-        }
-
-        report_progress(false);
-        write_next_chunk();
-    }
-
-    void write_next_chunk()
-    {
-        const std::uintmax_t remaining_bytes = total_bytes_ - bytes_sent_;
-        const std::uintmax_t bytes_to_read   = std::min<std::uintmax_t>(remaining_bytes, file_stream_chunk_size);
-        if (bytes_to_read > static_cast<std::uintmax_t>(std::numeric_limits<std::streamsize>::max())) {
-            finish(boost::system::errc::make_error_code(boost::system::errc::file_too_large), 0);
-            return;
-        }
-
-        buffer_.resize(static_cast<std::size_t>(bytes_to_read));
-        file_.read(buffer_.data(), static_cast<std::streamsize>(bytes_to_read));
-        if (static_cast<std::uintmax_t>(file_.gcount()) != bytes_to_read) {
-            finish(boost::system::errc::make_error_code(boost::system::errc::io_error), 0);
-            return;
-        }
-
-        auto self = shared_from_this();
-        boost::asio::async_write(socket_, boost::asio::buffer(buffer_),
-                                 [this, self](const boost::beast::error_code& error, std::size_t bytes_transferred) {
-                                     handle_chunk_written(error, bytes_transferred);
-                                 });
-    }
-
-    void handle_chunk_written(const boost::beast::error_code& error, std::size_t bytes_transferred)
-    {
-        if (error) {
-            finish(error, bytes_transferred);
-            return;
-        }
-
-        bytes_sent_ += bytes_transferred;
-        if (progress_callback_) {
-            report_progress(false);
-        }
-
-        if (bytes_sent_ == total_bytes_) {
-            finish({}, bytes_transferred);
-            return;
-        }
-
-        write_next_chunk();
-    }
-
-    void finish(const boost::beast::error_code& error, std::size_t bytes_transferred)
-    {
-        if (finished_) return;
-        finished_ = true;
-        if (error && progress_callback_) report_progress(true);
-        completion_(error, bytes_transferred);
-    }
-
-    void report_progress(bool failed)
-    {
-        if (!progress_callback_) return;
-        FileProgress progress;
-        progress.bytes_sent  = bytes_sent_;
-        progress.total_bytes = total_bytes_;
-        progress.failed      = failed;
-        progress_callback_(progress);
-    }
-
-    boost::asio::ip::tcp::socket& socket_;
-    std::ifstream                 file_;
-    std::string                   header_;
-    std::vector<char>             buffer_;
-    std::uintmax_t                total_bytes_;
-    std::uintmax_t                bytes_sent_{0};
-    HttpServer::FileProgressCallback progress_callback_;
-    HttpServer::StreamCompletion     completion_;
-    bool                             finished_{false};
-};
-
-std::ifstream open_response_file(const std::string& file_path, bool native_path)
-{
-    std::ifstream file;
-    if (native_path) {
-        file.open(file_path, std::ios::binary);
-    } else {
-        std::string system_file_path = utf8_to_filesystem_encoding(file_path);
-        file.open(system_file_path, std::ios::binary);
-        if (!file) file.open(file_path, std::ios::binary);
-    }
-    return file;
-}
-
 // Locale-independent month/weekday names (HTTP dates are always English).
 static const char* k_http_month_names[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 static const char* k_http_day_names[]   = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
-// Resolve the on-disk path used to serve a file, mirroring open_response_file.
+// Resolve the on-disk path used to serve a file, mirroring the open logic below.
 boost::filesystem::path resolve_response_file_path(const std::string& file_path, bool native_path)
 {
     if (native_path)
@@ -265,24 +138,6 @@ bool is_not_modified(const std::string& if_modified_since, const std::string& if
     return false;
 }
 
-std::string get_file_content_type(const std::string& file_path)
-{
-    std::string lower_path = boost::to_lower_copy(file_path);
-    if (boost::ends_with(lower_path, ".html")) return "text/html";
-    if (boost::ends_with(lower_path, ".css")) return "text/css";
-    if (boost::ends_with(lower_path, ".js")) return "text/javascript";
-    if (boost::ends_with(lower_path, ".png")) return "image/png";
-    if (boost::ends_with(lower_path, ".jpg")) return "image/jpeg";
-    if (boost::ends_with(lower_path, ".gif")) return "image/gif";
-    if (boost::ends_with(lower_path, ".svg")) return "image/svg+xml";
-    if (boost::ends_with(lower_path, ".ttf")) return "application/x-font-ttf";
-    if (boost::ends_with(lower_path, ".json")) return "application/json";
-    if (boost::ends_with(lower_path, ".webp")) return "image/webp";
-    if (boost::ends_with(lower_path, ".woff")) return "font/woff";
-    if (boost::ends_with(lower_path, ".woff2")) return "font/woff2";
-    return "application/octet-stream";
-}
-
 // True if basename matches Flutter web's content-hashed naming (name.<hex-hash>.ext),
 // where <hex-hash> is at least 16 hex characters (Flutter emits 16-char truncated
 // digests). The hash is a content digest, so the URL changes whenever the content
@@ -353,11 +208,6 @@ void write_common_headers(std::stringstream& out, int status_code, const std::st
     out << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
     out << "Access-Control-Allow-Headers: Content-Type, Authorization\r\n";
     out << "Connection: close\r\n";
-}
-
-bool should_report_file_progress(const std::string& url)
-{
-    return url.rfind("/localfile/", 0) == 0 || url.rfind(WCP_DOWNLOAD_PREFIX, 0) == 0;
 }
 
 } // namespace
@@ -518,22 +368,6 @@ void session::read_next_line()
                     const std::string url_str = Http::url_decode(headers.get_url());
                     const auto        resp    = server.server.m_request_handler(url_str);
                     resp->set_conditional_headers(headers.get_header("if-modified-since"), headers.get_header("if-none-match"));
-
-                    HttpServer::FileProgressCallback progress_callback;
-                    if (should_report_file_progress(url_str)) {
-                        progress_callback = [this, self, url_str](const FileProgress& progress) {
-                            FileProgress reported_progress = progress;
-                            reported_progress.url           = url_str;
-                            server.server.notify_file_progress(reported_progress);
-                        };
-                    }
-
-                    auto completion = [this, self](const boost::beast::error_code& e, std::size_t s) {
-                        if (e != boost::asio::error::operation_aborted) std::cout << "done" << std::endl;
-                        server.stop(self);
-                    };
-                    if (resp->write_response(socket, progress_callback, completion)) return;
-
                     std::stringstream ssOut;
                     resp->write_response(ssOut);
                     std::shared_ptr<std::string> str = std::make_shared<std::string>(ssOut.str());
@@ -1008,23 +842,6 @@ void HttpServer::set_request_handler(const std::function<std::shared_ptr<Respons
     this->m_request_handler = request_handler;
 }
 
-void HttpServer::set_file_progress_callback(FileProgressCallback callback)
-{
-    std::lock_guard<std::mutex> lock(m_file_progress_mutex);
-    m_file_progress_callback = std::move(callback);
-}
-
-void HttpServer::notify_file_progress(const FileProgress& progress) const
-{
-    FileProgressCallback callback;
-    {
-        std::lock_guard<std::mutex> lock(m_file_progress_mutex);
-        callback = m_file_progress_callback;
-    }
-
-    if (callback) callback(progress);
-}
-
 std::shared_ptr<HttpServer::Response> HttpServer::bbl_auth_handle_request(const std::string& url)
 {
     BOOST_LOG_TRIVIAL(info) << "thirdparty_login: get_response";
@@ -1280,82 +1097,8 @@ void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
         ssOut << "ETag: " << etag << "\r\n";
         ssOut << "Last-Modified: " << last_modified << "\r\n";
     }
-    ssOut << "\r\n";
+    ssOut << "\r\n";      // 头和主体之间的空行（必须）
     ssOut << fileContent; // 响应体（长度必须与Content-Length一致）
-}
-
-bool HttpServer::Response::write_response(boost::asio::ip::tcp::socket&, const FileProgressCallback&, StreamCompletion) { return false; }
-
-bool HttpServer::ResponseFile::write_response(boost::asio::ip::tcp::socket& socket, const FileProgressCallback& progress_callback,
-                                              StreamCompletion completion)
-{
-    std::ifstream file = open_response_file(file_path, m_native_path);
-    std::uintmax_t content_length  = 0;
-    std::time_t    last_write_time = 0;
-    bool           file_ok         = false;
-
-    if (file) {
-        file.seekg(0, std::ios::end);
-        const std::streamoff end_offset = static_cast<std::streamoff>(file.tellg());
-        file.seekg(0, std::ios::beg);
-        if (end_offset < 0 || !file) {
-            file.clear();
-            file.close();
-        } else {
-            content_length  = static_cast<std::uintmax_t>(end_offset);
-            last_write_time = get_file_last_write_time(file_path, m_native_path);
-            file_ok         = true;
-        }
-    }
-
-    const bool  can_revalidate = file_ok && last_write_time >= 0;
-    std::string last_modified;
-    std::string etag;
-    if (can_revalidate) {
-        last_modified = format_http_date(last_write_time);
-        etag          = make_etag(last_write_time, content_length);
-    }
-
-    std::stringstream header_stream;
-    if (!file_ok) {
-        ResponseNotFound not_found_response;
-        not_found_response.write_response(header_stream);
-        if (progress_callback) {
-            FileProgress progress;
-            progress.bytes_sent  = 0;
-            progress.total_bytes = 0;
-            progress.failed      = true;
-            progress_callback(progress);
-        }
-    } else if (can_revalidate && is_not_modified(m_if_modified_since, m_if_none_match, etag, last_write_time)) {
-        // Client's cached copy is still current: no body, so no FileStreamWriter.
-        write_common_headers(header_stream, 304, "Not Modified");
-        header_stream << "Cache-Control: " << get_cache_control_header(file_path) << "\r\n";
-        header_stream << "ETag: " << etag << "\r\n";
-        header_stream << "Last-Modified: " << last_modified << "\r\n";
-        header_stream << "\r\n";
-        file.close();
-
-        auto str = std::make_shared<std::string>(header_stream.str());
-        boost::asio::async_write(socket, boost::asio::buffer(*str),
-                                 [completion, str](const boost::beast::error_code& ec, std::size_t s) { completion(ec, s); });
-        return true;
-    } else {
-        write_common_headers(header_stream, 200, "OK");
-        header_stream << "Content-Type: " << get_file_content_type(file_path) << "\r\n";
-        header_stream << "Content-Length: " << content_length << "\r\n";
-        header_stream << "Cache-Control: " << get_cache_control_header(file_path) << "\r\n";
-        if (can_revalidate) {
-            header_stream << "ETag: " << etag << "\r\n";
-            header_stream << "Last-Modified: " << last_modified << "\r\n";
-        }
-        header_stream << "\r\n";
-    }
-
-    auto writer = std::make_shared<FileStreamWriter>(socket, std::move(file), header_stream.str(), content_length, progress_callback,
-                                                     std::move(completion));
-    writer->start();
-    return true;
 }
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/HttpServer.cpp
+++ b/src/slic3r/GUI/HttpServer.cpp
@@ -1,17 +1,327 @@
 #include "HttpServer.hpp"
 #include <boost/log/trivial.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/system/errc.hpp>
+#include <algorithm>
+#include <fstream>
+#include <limits>
+#include <vector>
 #include <condition_variable>
 #include "GUI_App.hpp"
 #include "slic3r/Utils/Http.hpp"
 #include "slic3r/Utils/NetworkAgent.hpp"
 #include  "sentry_wrapper/SentryWrapper.hpp"
 #include <boost/beast/core/detail/base64.hpp>
+#include <boost/filesystem.hpp>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
 #ifdef _WIN32
 #include <windows.h>
 #include <io.h>
 #endif
 
 namespace Slic3r { namespace GUI {
+
+std::string utf8_to_filesystem_encoding(const std::string& utf8_str);
+
+std::string http_headers::get_header(const std::string& name) const
+{
+    for (const auto& header : headers) {
+        if (boost::iequals(header.first, name))
+            return boost::trim_copy(header.second);
+    }
+    return "";
+}
+
+namespace {
+
+constexpr std::size_t file_stream_chunk_size = 64 * 1024;
+
+class FileStreamWriter : public std::enable_shared_from_this<FileStreamWriter>
+{
+public:
+    FileStreamWriter(boost::asio::ip::tcp::socket& socket, std::ifstream file, std::string header, std::uintmax_t total_bytes,
+                     HttpServer::FileProgressCallback progress_callback, HttpServer::StreamCompletion completion)
+        : socket_(socket), file_(std::move(file)), header_(std::move(header)), total_bytes_(total_bytes),
+          progress_callback_(std::move(progress_callback)), completion_(std::move(completion))
+    {}
+
+    void start()
+    {
+        auto self = shared_from_this();
+        boost::asio::async_write(socket_, boost::asio::buffer(header_),
+                                 [this, self](const boost::beast::error_code& error, std::size_t bytes_transferred) {
+                                     handle_header_written(error, bytes_transferred);
+                                 });
+    }
+
+private:
+    void handle_header_written(const boost::beast::error_code& error, std::size_t bytes_transferred)
+    {
+        if (error) {
+            finish(error, bytes_transferred);
+            return;
+        }
+
+        if (total_bytes_ == 0) {
+            report_progress(false);
+            finish({}, 0);
+            return;
+        }
+
+        report_progress(false);
+        write_next_chunk();
+    }
+
+    void write_next_chunk()
+    {
+        const std::uintmax_t remaining_bytes = total_bytes_ - bytes_sent_;
+        const std::uintmax_t bytes_to_read   = std::min<std::uintmax_t>(remaining_bytes, file_stream_chunk_size);
+        if (bytes_to_read > static_cast<std::uintmax_t>(std::numeric_limits<std::streamsize>::max())) {
+            finish(boost::system::errc::make_error_code(boost::system::errc::file_too_large), 0);
+            return;
+        }
+
+        buffer_.resize(static_cast<std::size_t>(bytes_to_read));
+        file_.read(buffer_.data(), static_cast<std::streamsize>(bytes_to_read));
+        if (static_cast<std::uintmax_t>(file_.gcount()) != bytes_to_read) {
+            finish(boost::system::errc::make_error_code(boost::system::errc::io_error), 0);
+            return;
+        }
+
+        auto self = shared_from_this();
+        boost::asio::async_write(socket_, boost::asio::buffer(buffer_),
+                                 [this, self](const boost::beast::error_code& error, std::size_t bytes_transferred) {
+                                     handle_chunk_written(error, bytes_transferred);
+                                 });
+    }
+
+    void handle_chunk_written(const boost::beast::error_code& error, std::size_t bytes_transferred)
+    {
+        if (error) {
+            finish(error, bytes_transferred);
+            return;
+        }
+
+        bytes_sent_ += bytes_transferred;
+        if (progress_callback_) {
+            report_progress(false);
+        }
+
+        if (bytes_sent_ == total_bytes_) {
+            finish({}, bytes_transferred);
+            return;
+        }
+
+        write_next_chunk();
+    }
+
+    void finish(const boost::beast::error_code& error, std::size_t bytes_transferred)
+    {
+        if (finished_) return;
+        finished_ = true;
+        if (error && progress_callback_) report_progress(true);
+        completion_(error, bytes_transferred);
+    }
+
+    void report_progress(bool failed)
+    {
+        if (!progress_callback_) return;
+        FileProgress progress;
+        progress.bytes_sent  = bytes_sent_;
+        progress.total_bytes = total_bytes_;
+        progress.failed      = failed;
+        progress_callback_(progress);
+    }
+
+    boost::asio::ip::tcp::socket& socket_;
+    std::ifstream                 file_;
+    std::string                   header_;
+    std::vector<char>             buffer_;
+    std::uintmax_t                total_bytes_;
+    std::uintmax_t                bytes_sent_{0};
+    HttpServer::FileProgressCallback progress_callback_;
+    HttpServer::StreamCompletion     completion_;
+    bool                             finished_{false};
+};
+
+std::ifstream open_response_file(const std::string& file_path, bool native_path)
+{
+    std::ifstream file;
+    if (native_path) {
+        file.open(file_path, std::ios::binary);
+    } else {
+        std::string system_file_path = utf8_to_filesystem_encoding(file_path);
+        file.open(system_file_path, std::ios::binary);
+        if (!file) file.open(file_path, std::ios::binary);
+    }
+    return file;
+}
+
+// Locale-independent month/weekday names (HTTP dates are always English).
+static const char* k_http_month_names[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+static const char* k_http_day_names[]   = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+
+// Resolve the on-disk path used to serve a file, mirroring open_response_file.
+boost::filesystem::path resolve_response_file_path(const std::string& file_path, bool native_path)
+{
+    if (native_path)
+        return boost::filesystem::path(file_path);
+
+    const std::string system_file_path = utf8_to_filesystem_encoding(file_path);
+    boost::filesystem::path p(system_file_path);
+    if (boost::filesystem::exists(p))
+        return p;
+    return boost::filesystem::path(file_path);
+}
+
+std::time_t get_file_last_write_time(const std::string& file_path, bool native_path)
+{
+    boost::system::error_code ec;
+    const std::time_t t = boost::filesystem::last_write_time(resolve_response_file_path(file_path, native_path), ec);
+    return ec ? static_cast<std::time_t>(-1) : t;
+}
+
+// Portable UTC std::tm -> time_t (equivalent to timegm / _mkgmtime).
+std::time_t tm_to_time_t_utc(const std::tm& tm)
+{
+    int y = tm.tm_year + 1900;
+    int m = tm.tm_mon + 1;
+    int d = tm.tm_mday;
+    y -= (m <= 2);
+    const int      era = (y >= 0 ? y : y - 399) / 400;
+    const unsigned yoe = static_cast<unsigned>(y - era * 400);
+    const unsigned doy = (153u * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
+    const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    const long long days = static_cast<long long>(era) * 146097 + static_cast<long long>(doe) - 719468;
+    return static_cast<std::time_t>(days * 86400 + tm.tm_hour * 3600 + tm.tm_min * 60 + tm.tm_sec);
+}
+
+// Format std::time_t as an IMF-fixdate HTTP date (locale-independent).
+std::string format_http_date(std::time_t t)
+{
+    std::tm tm = {};
+#ifdef _WIN32
+    gmtime_s(&tm, &t);
+#else
+    gmtime_r(&t, &tm);
+#endif
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%s, %02d %s %04d %02d:%02d:%02d GMT",
+                  k_http_day_names[tm.tm_wday], tm.tm_mday, k_http_month_names[tm.tm_mon],
+                  tm.tm_year + 1900, tm.tm_hour, tm.tm_min, tm.tm_sec);
+    return std::string(buf);
+}
+
+// Parse an IMF-fixdate HTTP date ("Sun, 06 Nov 1994 08:49:37 GMT"). Returns -1 on failure.
+std::time_t parse_http_date(const std::string& value)
+{
+    char wday[4] = {};
+    char mon[4]  = {};
+    int  day = 0, year = 0, hour = 0, minute = 0, second = 0;
+    if (std::sscanf(value.c_str(), "%3s, %d %3s %d %d:%d:%d", wday, &day, mon, &year, &hour, &minute, &second) != 7)
+        return static_cast<std::time_t>(-1);
+
+    int month = -1;
+    for (int i = 0; i < 12; ++i) {
+        if (std::strcmp(mon, k_http_month_names[i]) == 0) {
+            month = i;
+            break;
+        }
+    }
+    if (month < 0)
+        return static_cast<std::time_t>(-1);
+
+    std::tm tm = {};
+    tm.tm_year = year - 1900;
+    tm.tm_mon  = month;
+    tm.tm_mday = day;
+    tm.tm_hour = hour;
+    tm.tm_min  = minute;
+    tm.tm_sec  = second;
+    return tm_to_time_t_utc(tm);
+}
+
+// ETag derived from mtime + size (the same scheme nginx uses), quoted per RFC 7232.
+std::string make_etag(std::time_t mtime, std::uintmax_t size)
+{
+    return "\"" + std::to_string(static_cast<long long>(mtime)) + "-" +
+           std::to_string(static_cast<unsigned long long>(size)) + "\"";
+}
+
+// True when the request's conditional headers prove the client's cached copy is still current.
+bool is_not_modified(const std::string& if_modified_since, const std::string& if_none_match,
+                     const std::string& etag, std::time_t mtime)
+{
+    if (!if_none_match.empty())
+        return if_none_match == etag || if_none_match == "*";
+
+    if (!if_modified_since.empty()) {
+        const std::time_t since = parse_http_date(if_modified_since);
+        if (since != static_cast<std::time_t>(-1))
+            return mtime <= since;
+    }
+    return false;
+}
+
+std::string get_file_content_type(const std::string& file_path)
+{
+    std::string lower_path = boost::to_lower_copy(file_path);
+    if (boost::ends_with(lower_path, ".html")) return "text/html";
+    if (boost::ends_with(lower_path, ".css")) return "text/css";
+    if (boost::ends_with(lower_path, ".js")) return "text/javascript";
+    if (boost::ends_with(lower_path, ".png")) return "image/png";
+    if (boost::ends_with(lower_path, ".jpg")) return "image/jpeg";
+    if (boost::ends_with(lower_path, ".gif")) return "image/gif";
+    if (boost::ends_with(lower_path, ".svg")) return "image/svg+xml";
+    if (boost::ends_with(lower_path, ".ttf")) return "application/x-font-ttf";
+    if (boost::ends_with(lower_path, ".json")) return "application/json";
+    if (boost::ends_with(lower_path, ".webp")) return "image/webp";
+    if (boost::ends_with(lower_path, ".woff")) return "font/woff";
+    if (boost::ends_with(lower_path, ".woff2")) return "font/woff2";
+    return "application/octet-stream";
+}
+
+// Return a Cache-Control value for a served file.
+// - main.<hash>.js / flutter_bootstrap.<hash>.js are content-hashed, so their URL
+//   changes whenever the content changes → safe to serve immutable.
+// - index.html / version.json / manifest.json must always be fresh.
+// - canvaskit/** / fonts / images / other assets keep fixed names, so they are
+//   revalidated via Last-Modified + ETag (304 when unchanged — the 304 logic is in
+//   ResponseFile::write_response).
+std::string get_cache_control_header(const std::string& file_path)
+{
+    std::string lower = boost::to_lower_copy(file_path);
+
+    std::string basename = lower;
+    std::size_t slash    = lower.find_last_of("/\\");
+    if (slash != std::string::npos)
+        basename = lower.substr(slash + 1);
+
+    // Content-hashed JS: main.<hash>.js and flutter_bootstrap.<hash>.js
+    if ((boost::starts_with(basename, "main.") || boost::starts_with(basename, "flutter_bootstrap.")) &&
+        boost::ends_with(basename, ".js"))
+        return "public, max-age=31536000, immutable";
+
+    // App shell + version probe: always fresh (tiny, re-downloaded each boot)
+    if (boost::ends_with(basename, "index.html") ||
+        boost::ends_with(basename, "version.json") ||
+        boost::ends_with(basename, "version.changelog") ||
+        boost::ends_with(basename, "manifest.json"))
+        return "no-cache, no-store";
+
+    // canvaskit / fonts / images / svgs / other assets: fixed names, so revalidate
+    // via Last-Modified + ETag (304 when unchanged).
+    return "no-cache";
+}
+
+bool should_report_file_progress(const std::string& url)
+{
+    return url.rfind("/localfile/", 0) == 0 || url.rfind(WCP_DOWNLOAD_PREFIX, 0) == 0;
+}
+
+} // namespace
 
 // 检测Windows系统是否支持UTF-8模式
 bool is_windows_utf8_mode()
@@ -171,6 +481,23 @@ void session::read_next_line()
 
                     const std::string url_str = Http::url_decode(headers.get_url());
                     const auto        resp    = server.server.m_request_handler(url_str);
+                    resp->set_conditional_headers(headers.get_header("if-modified-since"), headers.get_header("if-none-match"));
+
+                    HttpServer::FileProgressCallback progress_callback;
+                    if (should_report_file_progress(url_str)) {
+                        progress_callback = [this, self, url_str](const FileProgress& progress) {
+                            FileProgress reported_progress = progress;
+                            reported_progress.url           = url_str;
+                            server.server.notify_file_progress(reported_progress);
+                        };
+                    }
+
+                    auto completion = [this, self](const boost::beast::error_code& e, std::size_t s) {
+                        if (e != boost::asio::error::operation_aborted) std::cout << "done" << std::endl;
+                        server.stop(self);
+                    };
+                    if (resp->write_response(socket, progress_callback, completion)) return;
+
                     std::stringstream ssOut;
                     resp->write_response(ssOut);
                     std::shared_ptr<std::string> str = std::make_shared<std::string>(ssOut.str());
@@ -645,6 +972,23 @@ void HttpServer::set_request_handler(const std::function<std::shared_ptr<Respons
     this->m_request_handler = request_handler;
 }
 
+void HttpServer::set_file_progress_callback(FileProgressCallback callback)
+{
+    std::lock_guard<std::mutex> lock(m_file_progress_mutex);
+    m_file_progress_callback = std::move(callback);
+}
+
+void HttpServer::notify_file_progress(const FileProgress& progress) const
+{
+    FileProgressCallback callback;
+    {
+        std::lock_guard<std::mutex> lock(m_file_progress_mutex);
+        callback = m_file_progress_callback;
+    }
+
+    if (callback) callback(progress);
+}
+
 std::shared_ptr<HttpServer::Response> HttpServer::bbl_auth_handle_request(const std::string& url)
 {
     BOOST_LOG_TRIVIAL(info) << "thirdparty_login: get_response";
@@ -847,6 +1191,24 @@ void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
     std::string fileContent    = fileStream.str();
     size_t      content_length = fileContent.size(); // 字节长度，非字符数
 
+    const std::time_t last_write_time = get_file_last_write_time(file_path, m_native_path);
+    const bool        can_revalidate  = last_write_time >= 0;
+    std::string       last_modified   = can_revalidate ? format_http_date(last_write_time) : "";
+    std::string       etag            = can_revalidate ? make_etag(last_write_time, content_length) : "";
+
+    if (can_revalidate && is_not_modified(m_if_modified_since, m_if_none_match, etag, last_write_time)) {
+        // Client's cached copy is still current: no body.
+        ssOut << "HTTP/1.1 304 Not Modified\r\n";
+        ssOut << "Cache-Control: " << get_cache_control_header(file_path) << "\r\n";
+        ssOut << "ETag: " << etag << "\r\n";
+        ssOut << "Last-Modified: " << last_modified << "\r\n";
+        ssOut << "Access-Control-Allow-Origin: *\r\n";
+        ssOut << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
+        ssOut << "Access-Control-Allow-Headers: Content-Type, Authorization\r\n";
+        ssOut << "\r\n";
+        return;
+    }
+
     // 确定Content-Type（保持原有逻辑）
     std::string content_type = "application/octet-stream";
     if (ends_with(file_path, ".html"))
@@ -882,11 +1244,96 @@ void HttpServer::ResponseFile::write_response(std::stringstream& ssOut)
     ssOut << "HTTP/1.1 200 OK\r\n";
     ssOut << "Content-Type: " << content_type << "\r\n";
     ssOut << "Content-Length: " << content_length << "\r\n"; // 必须与实际内容长度一致
+    ssOut << "Cache-Control: " << get_cache_control_header(file_path) << "\r\n";
+    if (can_revalidate) {
+        ssOut << "ETag: " << etag << "\r\n";
+        ssOut << "Last-Modified: " << last_modified << "\r\n";
+    }
     ssOut << "Access-Control-Allow-Origin: *\r\n";           // CORS头
     ssOut << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
     ssOut << "Access-Control-Allow-Headers: Content-Type, Authorization\r\n";
     ssOut << "\r\n";      // 头和主体之间的空行（必须）
     ssOut << fileContent; // 响应体（长度必须与Content-Length一致）
+}
+
+bool HttpServer::Response::write_response(boost::asio::ip::tcp::socket&, const FileProgressCallback&, StreamCompletion) { return false; }
+
+bool HttpServer::ResponseFile::write_response(boost::asio::ip::tcp::socket& socket, const FileProgressCallback& progress_callback,
+                                              StreamCompletion completion)
+{
+    std::ifstream file = open_response_file(file_path, m_native_path);
+    std::uintmax_t content_length  = 0;
+    std::time_t    last_write_time = 0;
+    bool           file_ok         = false;
+
+    if (file) {
+        file.seekg(0, std::ios::end);
+        const std::streamoff end_offset = static_cast<std::streamoff>(file.tellg());
+        file.seekg(0, std::ios::beg);
+        if (end_offset < 0 || !file) {
+            file.clear();
+            file.close();
+        } else {
+            content_length  = static_cast<std::uintmax_t>(end_offset);
+            last_write_time = get_file_last_write_time(file_path, m_native_path);
+            file_ok         = true;
+        }
+    }
+
+    const bool  can_revalidate = file_ok && last_write_time >= 0;
+    std::string last_modified;
+    std::string etag;
+    if (can_revalidate) {
+        last_modified = format_http_date(last_write_time);
+        etag          = make_etag(last_write_time, content_length);
+    }
+
+    std::stringstream header_stream;
+    if (!file_ok) {
+        ResponseNotFound not_found_response;
+        not_found_response.write_response(header_stream);
+        if (progress_callback) {
+            FileProgress progress;
+            progress.bytes_sent  = 0;
+            progress.total_bytes = 0;
+            progress.failed      = true;
+            progress_callback(progress);
+        }
+    } else if (can_revalidate && is_not_modified(m_if_modified_since, m_if_none_match, etag, last_write_time)) {
+        // Client's cached copy is still current: no body, so no FileStreamWriter.
+        header_stream << "HTTP/1.1 304 Not Modified\r\n";
+        header_stream << "Cache-Control: " << get_cache_control_header(file_path) << "\r\n";
+        header_stream << "ETag: " << etag << "\r\n";
+        header_stream << "Last-Modified: " << last_modified << "\r\n";
+        header_stream << "Access-Control-Allow-Origin: *\r\n";
+        header_stream << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
+        header_stream << "Access-Control-Allow-Headers: Content-Type, Authorization\r\n";
+        header_stream << "\r\n";
+        file.close();
+
+        auto str = std::make_shared<std::string>(header_stream.str());
+        boost::asio::async_write(socket, boost::asio::buffer(*str),
+                                 [completion, str](const boost::beast::error_code& ec, std::size_t s) { completion(ec, s); });
+        return true;
+    } else {
+        header_stream << "HTTP/1.1 200 OK\r\n";
+        header_stream << "Content-Type: " << get_file_content_type(file_path) << "\r\n";
+        header_stream << "Content-Length: " << content_length << "\r\n";
+        header_stream << "Cache-Control: " << get_cache_control_header(file_path) << "\r\n";
+        if (can_revalidate) {
+            header_stream << "ETag: " << etag << "\r\n";
+            header_stream << "Last-Modified: " << last_modified << "\r\n";
+        }
+        header_stream << "Access-Control-Allow-Origin: *\r\n";
+        header_stream << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
+        header_stream << "Access-Control-Allow-Headers: Content-Type, Authorization\r\n";
+        header_stream << "\r\n";
+    }
+
+    auto writer = std::make_shared<FileStreamWriter>(socket, std::move(file), header_stream.str(), content_length, progress_callback,
+                                                     std::move(completion));
+    writer->start();
+    return true;
 }
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/HttpServer.cpp
+++ b/src/slic3r/GUI/HttpServer.cpp
@@ -337,8 +337,8 @@ void session::read_next_line()
         // 构造OPTIONS响应（允许跨域）
         std::stringstream ssOut;
         write_common_headers(ssOut, 200, "OK");
-        ssOut << "Content-Length: 0\r\n"; // 无响应体
-        ssOut << "\r\n";                  // 头和主体之间的空行（必须）
+        ssOut << "Content-Length: 0\r\n"; // no response body
+        ssOut << "\r\n";                  // blank line between headers and body (required)
 
         // 异步发送响应
         async_write(socket, boost::asio::buffer(ssOut.str()), [this, self](const boost::beast::error_code& e, std::size_t s) {

--- a/src/slic3r/GUI/HttpServer.hpp
+++ b/src/slic3r/GUI/HttpServer.hpp
@@ -2,8 +2,12 @@
 #define slic3r_Http_App_hpp_
 
 #include <iostream>
+#include <functional>
 #include <mutex>
 #include <stack>
+#include <cstdint>
+#include <map>
+#include <sstream>
 
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
@@ -23,6 +27,14 @@ namespace Slic3r { namespace GUI {
 
 class session;
 
+struct FileProgress
+{
+    std::string    url;
+    std::uintmax_t bytes_sent;
+    std::uintmax_t total_bytes;
+    bool           failed;
+};
+
 class http_headers
 {
     std::string method;
@@ -34,6 +46,9 @@ class http_headers
     friend class session;
 public:
     std::string get_url() { return url; }
+
+    // Case-insensitive lookup with surrounding whitespace trimmed.
+    std::string get_header(const std::string& name) const;
 
     int content_length()
     {
@@ -80,11 +95,28 @@ class HttpServer
     boost::asio::ip::port_type find_available_port(boost::asio::ip::port_type start_port);
 
 public:
+    using FileProgressCallback = std::function<void(const FileProgress&)>;
+    using StreamCompletion     = std::function<void(const boost::beast::error_code&, std::size_t)>;
+
     class Response
     {
     public:
         virtual ~Response()                                   = default;
         virtual void write_response(std::stringstream& ssOut) = 0;
+        virtual bool write_response(boost::asio::ip::tcp::socket& socket, const FileProgressCallback& progress_callback,
+                                    StreamCompletion completion);
+
+        // Forwarded conditional request headers, used by ResponseFile to implement
+        // 304 Not Modified revalidation (If-Modified-Since / If-None-Match).
+        void set_conditional_headers(const std::string& if_modified_since, const std::string& if_none_match)
+        {
+            m_if_modified_since = if_modified_since;
+            m_if_none_match     = if_none_match;
+        }
+
+    protected:
+        std::string m_if_modified_since;
+        std::string m_if_none_match;
     };
 
     class ResponseNotFound : public Response
@@ -114,6 +146,8 @@ public:
         ~ResponseFile() override = default;
 
         void write_response(std::stringstream& ssOut) override;
+        bool write_response(boost::asio::ip::tcp::socket& socket, const FileProgressCallback& progress_callback,
+                            StreamCompletion completion) override;
 
         bool ends_with(const std::string& str, const std::string& suffix)
         {
@@ -157,6 +191,7 @@ public:
     void stop_restart_check();   // 停止重启检查
     void simulate_crash();       // 模拟服务器崩溃，用于测试重启机制
     void set_request_handler(const std::function<std::shared_ptr<Response>(const std::string&)>& m_request_handler);
+    void set_file_progress_callback(FileProgressCallback callback);
     void setPort(boost::asio::ip::port_type new_port) { 
         if (!start_http_server) {  // 只有在服务器未启动时才允许修改端口
             port = new_port; 
@@ -193,6 +228,10 @@ private:
     std::unique_ptr<IOServer> server_{nullptr};
 
     std::function<std::shared_ptr<Response>(const std::string&)> m_request_handler{&HttpServer::bbl_auth_handle_request};
+    FileProgressCallback m_file_progress_callback;
+    mutable std::mutex  m_file_progress_mutex;
+
+    void notify_file_progress(const FileProgress& progress) const;
 };
 
 class session : public std::enable_shared_from_this<session>

--- a/src/slic3r/GUI/HttpServer.hpp
+++ b/src/slic3r/GUI/HttpServer.hpp
@@ -2,12 +2,8 @@
 #define slic3r_Http_App_hpp_
 
 #include <iostream>
-#include <functional>
 #include <mutex>
 #include <stack>
-#include <cstdint>
-#include <map>
-#include <sstream>
 
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
@@ -26,14 +22,6 @@
 namespace Slic3r { namespace GUI {
 
 class session;
-
-struct FileProgress
-{
-    std::string    url;
-    std::uintmax_t bytes_sent;
-    std::uintmax_t total_bytes;
-    bool           failed;
-};
 
 class http_headers
 {
@@ -95,16 +83,11 @@ class HttpServer
     boost::asio::ip::port_type find_available_port(boost::asio::ip::port_type start_port);
 
 public:
-    using FileProgressCallback = std::function<void(const FileProgress&)>;
-    using StreamCompletion     = std::function<void(const boost::beast::error_code&, std::size_t)>;
-
     class Response
     {
     public:
         virtual ~Response()                                   = default;
         virtual void write_response(std::stringstream& ssOut) = 0;
-        virtual bool write_response(boost::asio::ip::tcp::socket& socket, const FileProgressCallback& progress_callback,
-                                    StreamCompletion completion);
 
         // Forwarded conditional request headers, used by ResponseFile to implement
         // 304 Not Modified revalidation (If-Modified-Since / If-None-Match).
@@ -146,8 +129,6 @@ public:
         ~ResponseFile() override = default;
 
         void write_response(std::stringstream& ssOut) override;
-        bool write_response(boost::asio::ip::tcp::socket& socket, const FileProgressCallback& progress_callback,
-                            StreamCompletion completion) override;
 
         bool ends_with(const std::string& str, const std::string& suffix)
         {
@@ -191,7 +172,6 @@ public:
     void stop_restart_check();   // 停止重启检查
     void simulate_crash();       // 模拟服务器崩溃，用于测试重启机制
     void set_request_handler(const std::function<std::shared_ptr<Response>(const std::string&)>& m_request_handler);
-    void set_file_progress_callback(FileProgressCallback callback);
     void setPort(boost::asio::ip::port_type new_port) { 
         if (!start_http_server) {  // 只有在服务器未启动时才允许修改端口
             port = new_port; 
@@ -228,10 +208,6 @@ private:
     std::unique_ptr<IOServer> server_{nullptr};
 
     std::function<std::shared_ptr<Response>(const std::string&)> m_request_handler{&HttpServer::bbl_auth_handle_request};
-    FileProgressCallback m_file_progress_callback;
-    mutable std::mutex  m_file_progress_mutex;
-
-    void notify_file_progress(const FileProgress& progress) const;
 };
 
 class session : public std::enable_shared_from_this<session>


### PR DESCRIPTION
## Summary
- Add HTTP cache negotiation to the local web server that serves the embedded flutter web homepage:
  - `ETag` (mtime+size) + `Last-Modified` on file responses
  - `304 Not Modified` revalidation via `If-None-Match` / `If-Modified-Since` (If-None-Match takes precedence, per RFC 7232)
  - `Cache-Control` policy: content-hashed assets (`name.<hex-hash>.ext`) served `immutable, max-age=1y`; `index.html`/`version.json`/`manifest.json` served `no-store`; fixed-name assets (canvaskit/fonts) served `no-cache` + 304 revalidation
- Send `Connection: close` on every response path (200/304/302/404/OPTIONS) via a shared `write_common_headers` helper. The server closes each socket after one response; without the explicit header, HTTP/1.1 clients assume keep-alive and race the close -> `ERR_EMPTY_RESPONSE` -> weak-network white screen.

Fixes the weak-network white screen of the embedded flutter web homepage.

## Notes for reviewers
- 3 commits, 2 files (`HttpServer.cpp/.hpp`), +241/-14 vs `main`. The chunked `FileStreamWriter` was added in the first commit and dropped in a later iteration on the source branch; net effect = cache negotiation + `Connection: close` only, file serving keeps the original whole-response write.
- The resulting files are byte-identical to the fork build that was built and verified on Windows (cache headers, 304, and `Connection: close` confirmed via curl against the running app).

## Test plan
- [x] `curl -i /flutter_web/index.html` -> `Cache-Control: no-cache, no-store` + `ETag` + `Last-Modified` + `Connection: close`
- [x] Conditional `If-None-Match` re-request -> `304` with empty body
- [x] Hashed JS (e.g. `main.<hash>.js`) -> `public, max-age=31536000, immutable`
- [ ] CI build