### PR TITLE
chore: Bump version to 2.4.0

### DIFF
--- a/installer.nsi
+++ b/installer.nsi
@@ -11,7 +11,7 @@
 !define PRODUCT_INSTALL_KEY "Software\${PRODUCT_PUBLISHER}\${PRODUCT_NAME}"
 
 !ifndef VERSION
-    !define VERSION "2.3.6"
+    !define VERSION "2.4.0"
 !endif
 
 !ifndef SOURCE_DIR

--- a/scripts/flatpak/io.github.Snapmaker.Snapmaker_Orca.metainfo.xml
+++ b/scripts/flatpak/io.github.Snapmaker.Snapmaker_Orca.metainfo.xml
@@ -38,9 +38,9 @@
 	  <color type="primary" scheme_preference="light">#009688</color>
 	</branding>
     <releases>
-	    <release version="2.3.6" date="2026-8-13">
+	    <release version="2.4.0" date="2026-9-3">
             <description>
-                <p>Version 2.3.6 release with improvements and bug fixes.</p>
+                <p>Version 2.4.0 release with improvements and bug fixes.</p>
             </description>
         </release>
     </releases>

--- a/src/common_func/common_func.hpp
+++ b/src/common_func/common_func.hpp
@@ -6,12 +6,12 @@
 #define SLIC3R_APP_NAME "Snapmaker Orca"
 #define SLIC3R_APP_KEY "Snapmaker_Orca"
 #define SLIC3R_VERSION "01.10.01.50"
-#define Snapmaker_VERSION "2.3.6"
+#define Snapmaker_VERSION "2.4.0"
 #define MIN_FIRM_VER "1.6.0"
 #ifndef GIT_COMMIT_HASH
 #define GIT_COMMIT_HASH "0000000" // 0000000 means uninitialized
 #endif
-#define SLIC3R_BUILD_ID "2.3.6"
+#define SLIC3R_BUILD_ID "2.4.0"
 // #define SLIC3R_RC_VERSION "01.10.01.50"
 #define BBL_RELEASE_TO_PUBLIC 1
 #define BBL_INTERNAL_TESTING 0

--- a/version.inc
+++ b/version.inc
@@ -10,7 +10,7 @@ endif()
 if(NOT DEFINED BBL_INTERNAL_TESTING)
 set(BBL_INTERNAL_TESTING "0")
 endif()
-set(Snapmaker_VERSION "2.3.6")
+set(Snapmaker_VERSION "2.4.0")
 set(MIN_FIRM_VER "1.0.0")
 string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)"
        Snapmaker_VERSION_MATCH ${Snapmaker_VERSION})


### PR DESCRIPTION
# Description

Bump the Snapmaker Orca version from 2.3.6 to 2.4.0 for the next release.

Files changed:
- `version.inc`: `Snapmaker_VERSION` 2.3.6 → 2.4.0
- `src/common_func/common_func.hpp`: `Snapmaker_VERSION` and `SLIC3R_BUILD_ID` 2.3.6 → 2.4.0
- `scripts/flatpak/io.github.Snapmaker.Snapmaker_Orca.metainfo.xml`: release entry updated to 2.4.0 (date 2026-9-3)
- `installer.nsi`: `VERSION` 2.3.6 → 2.4.0

Same four files and change pattern as the previous version bump PR (#710, 2.3.5 → 2.3.6). `SLIC3R_VERSION` and `MIN_FIRM_VER` are left untouched, consistent with previous bumps. No functional or breaking changes.

## Tests

No runtime tests required. Verified no leftover `2.3.6` references in the four bumped files, and version constants are consistent across all of them. Branched from the latest `main` (8aca1e04fe).
