### PR TITLE
Machine Filament combo: create-and-link a proper preset for unmatched entries

### DIFF
--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -629,8 +629,9 @@ static void adjust_dialog_in_screen(DPIDialog* dialog) {
     if (pos_x != dialog_x || pos_y != dialog_y) { dialog->SetPosition(wxPoint(dialog_x, dialog_y)); }
 }
 
-CreateFilamentPresetDialog::CreateFilamentPresetDialog(wxWindow *parent) 
-	: DPIDialog(parent ? parent : nullptr, wxID_ANY, _L("Create Filament"), wxDefaultPosition, wxDefaultSize, wxCAPTION | wxCLOSE_BOX | wxCENTRE)
+CreateFilamentPresetDialog::CreateFilamentPresetDialog(wxWindow *parent)
+	: DPIDialog(parent ? parent : nullptr, wxID_ANY, _L("Create Filament"), wxDefaultPosition, wxDefaultSize,
+	            wxCAPTION | wxCLOSE_BOX | wxCENTRE | wxRESIZE_BORDER)
 {
     m_create_type.base_filament = _L("Create Based on Current Filament");
     m_create_type.base_filament_preset = _L("Copy Current Filament Preset ");
@@ -638,6 +639,7 @@ CreateFilamentPresetDialog::CreateFilamentPresetDialog(wxWindow *parent)
 
 	this->SetBackgroundColour(*wxWHITE);
     this->SetSize(wxSize(FromDIP(600), FromDIP(480)));
+    this->SetMinSize(wxSize(FromDIP(560), FromDIP(420)));
 
     std::string icon_path = (boost::format("%1%/images/Snapmaker_OrcaTitle.ico") % resources_dir()).str();
     SetIcon(wxIcon(encode_path(icon_path.c_str()), wxBITMAP_TYPE_ICO));
@@ -672,14 +674,32 @@ CreateFilamentPresetDialog::CreateFilamentPresetDialog(wxWindow *parent)
     m_filament_preset_text = new wxStaticText(this, wxID_ANY, _L("We could create the filament presets for your following printer:"), wxDefaultPosition, wxDefaultSize);
     m_main_sizer->Add(m_filament_preset_text, 0, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(15));
 
-    m_scrolled_preset_panel = new wxScrolledWindow(this, wxID_ANY);
-    m_scrolled_preset_panel->SetMaxSize(wxSize(-1, FromDIP(350)));
+    // Plain wxPanel, not wxScrolledWindow: with wxRESIZE_BORDER + proportion=1 below, the
+    // dialog itself grows to show all rows — no artificial max height, no internal scrollbar.
+    m_scrolled_preset_panel = new wxPanel(this, wxID_ANY);
     m_scrolled_preset_panel->SetBackgroundColour(*wxWHITE);
-    m_scrolled_preset_panel->SetScrollRate(5, 5);
     m_scrolled_sizer = new wxBoxSizer(wxVERTICAL);
+
+    // "All nozzle" — checks/unchecks every printer/preset entry currently in the grid below,
+    // so there's always an easy way to end up with more than one profile selected at once.
+    wxBoxSizer *selectAllSizer = new wxBoxSizer(wxHORIZONTAL);
+    m_select_all_nozzle_checkbox = new ::CheckBox(m_scrolled_preset_panel);
+    selectAllSizer->Add(m_select_all_nozzle_checkbox, 0, wxALIGN_CENTER_VERTICAL, 0);
+    selectAllSizer->Add(0, 0, 0, wxLEFT, FromDIP(5));
+    wxStaticText *selectAllText = new wxStaticText(m_scrolled_preset_panel, wxID_ANY, _L("All nozzle"));
+    selectAllSizer->Add(selectAllText, 0, wxALIGN_CENTER_VERTICAL, 0);
+    m_scrolled_sizer->Add(selectAllSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(5));
+    m_select_all_nozzle_checkbox->Bind(wxEVT_TOGGLEBUTTON, [this](wxCommandEvent &) {
+        const bool value = m_select_all_nozzle_checkbox->GetValue();
+        for (auto &cb_preset : m_filament_preset) cb_preset.first->SetValue(value);
+        for (auto &cb_preset : m_machint_filament_preset) cb_preset.first->SetValue(value);
+    });
+
     m_scrolled_sizer->Add(create_item(FilamentOptionType::PRESET_FOR_PRINTER), 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(5));
     m_scrolled_sizer->Add(0, 0, 0, wxTOP, FromDIP(5));
-    m_scrolled_preset_panel->SetSizerAndFit(m_scrolled_sizer);
+    // SetSizer (not SetSizerAndFit): the latter would force this panel's actual size to match
+    // its content, defeating the wxEXPAND/proportion=1 growth below.
+    m_scrolled_preset_panel->SetSizer(m_scrolled_sizer);
     m_main_sizer->Add(m_scrolled_preset_panel, 1, wxEXPAND | wxLEFT | wxRIGHT, FromDIP(10));
     m_main_sizer->Add(create_dialog_buttons(), 0, wxEXPAND);
 
@@ -690,6 +710,10 @@ CreateFilamentPresetDialog::CreateFilamentPresetDialog(wxWindow *parent)
 
     Layout();
     Fit();
+    // Fit() can end up smaller than this dialog's SetMinSize() floor, in which case the OS
+    // clamps the window without re-Layout()'ing it — this second pass makes sure the printer
+    // grid panel actually claims that extra height instead of it sitting as a dead gap.
+    Layout();
 
 	wxGetApp().UpdateDlgDarkUI(this);
 }
@@ -707,6 +731,129 @@ CreateFilamentPresetDialog::~CreateFilamentPresetDialog()
 
 void CreateFilamentPresetDialog::on_dpi_changed(const wxRect &suggested_rect) {
     Layout();
+}
+
+bool CreateFilamentPresetDialog::prefill_from_machine_filament(const std::string& vendor,
+                                                                const std::string& type,
+                                                                const std::string& serial_hint,
+                                                                const std::string& preferred_base_public_name,
+                                                                const std::string& current_nozzle_diameter)
+{
+    // --- Vendor ---
+    bool vendor_known = false;
+    for (const std::string& v : filament_vendors) {
+        if (v == vendor) { vendor_known = true; break; }
+    }
+    if (vendor_known) {
+        m_filament_vendor_combobox->SetLabel(from_u8(vendor));
+        m_filament_vendor_combobox->SetLabelColor(*wxBLACK);
+    } else if (!vendor.empty()) {
+        m_can_not_find_vendor_checkbox->SetValue(true);
+        m_filament_vendor_combobox->Hide();
+        m_filament_custom_vendor_input->Show();
+        m_filament_custom_vendor_input->GetTextCtrl()->SetValue(from_u8(vendor));
+    }
+
+    // --- Serial (required free-text field; the machine rarely reports a usable one) ---
+    m_filament_serial_input->GetTextCtrl()->SetValue(from_u8(serial_hint.empty() ? std::string("Basic") : serial_hint));
+
+    // Nothing more to do if the reported type isn't one we know any preset for.
+    if (m_system_filament_types_set.find(type) == m_system_filament_types_set.end())
+        return false;
+
+    // --- Type + base filament family (mirrors the Type combobox's wxEVT_COMBOBOX handler) ---
+    m_filament_type_combobox->SetLabel(from_u8(type));
+    m_filament_type_combobox->SetLabelColor(*wxBLACK);
+    clear_filament_preset_map();
+    wxArrayString filament_preset_choice = get_filament_preset_choices();
+    m_filament_preset_combobox->Set(filament_preset_choice);
+
+    // Pick the closest family to base the new preset on: exact public-name match first, else
+    // the plain "Generic <type>" entry (exact match — NOT the first choice merely *containing*
+    // "Generic", which came from an unordered_map and could just as easily land on "Generic
+    // <type> High Speed"/"Silk"/"CF"/etc. depending on hash order), else the first entry
+    // containing "Generic" as a last resort, else just the first available choice.
+    wxString chosen;
+    const wxString preferred = from_u8(preferred_base_public_name);
+    for (size_t i = 0; i < filament_preset_choice.size(); ++i) {
+        if (filament_preset_choice[i] == preferred) { chosen = filament_preset_choice[i]; break; }
+    }
+    if (chosen.empty()) {
+        const wxString genericPlain = from_u8("Generic " + (type == "PLA-AERO" ? std::string("PLA Aero") : type));
+        for (size_t i = 0; i < filament_preset_choice.size(); ++i) {
+            if (filament_preset_choice[i] == genericPlain) { chosen = filament_preset_choice[i]; break; }
+        }
+    }
+    if (chosen.empty()) {
+        for (size_t i = 0; i < filament_preset_choice.size(); ++i) {
+            if (filament_preset_choice[i].Contains("Generic")) { chosen = filament_preset_choice[i]; break; }
+        }
+    }
+    if (chosen.empty() && !filament_preset_choice.empty())
+        chosen = filament_preset_choice.front();
+
+    if (chosen.empty()) {
+        // No known family for this type after all (shouldn't normally happen since the type
+        // came from m_system_filament_types_set) — leave it for the user to pick.
+        m_filament_preset_combobox->SetLabel(_L("Select Filament Preset"));
+        m_filament_preset_combobox->SetLabelColor(DEFAULT_PROMPT_TEXT_COLOUR);
+        update_dialog_size();
+        return true;
+    }
+
+    m_filament_preset_combobox->SetLabel(chosen);
+    m_filament_preset_combobox->SetLabelColor(*wxBLACK);
+
+    // --- Populate the printer/preset grid for the chosen family (mirrors the Filament Preset
+    //     combobox's wxEVT_COMBOBOX handler) ---
+    auto iter = m_filament_choice_map.find(m_public_name_to_filament_id_map[chosen]);
+    m_scrolled_preset_panel->Freeze();
+    m_filament_presets_sizer->Clear(true);
+    m_filament_preset.clear();
+
+    std::vector<std::pair<std::string, Preset *>> printer_name_to_filament_preset;
+    if (iter != m_filament_choice_map.end()) {
+        std::unordered_map<std::string, float> nozzle_diameter = nozzle_diameter_map;
+        for (Preset* preset : iter->second) {
+            auto compatible_printers = preset->config.option<ConfigOptionStrings>("compatible_printers", true);
+            if (!compatible_printers || compatible_printers->values.empty()) {
+                for (const std::string& visible_printer : m_visible_printers) {
+                    std::string nozzle = get_printer_nozzle_diameter(visible_printer);
+                    if (nozzle_diameter[nozzle] == 0) continue;
+                    printer_name_to_filament_preset.push_back(std::make_pair(visible_printer, preset));
+                }
+                continue;
+            }
+            for (std::string &compatible_printer_name : compatible_printers->values) {
+                if (m_visible_printers.find(compatible_printer_name) == m_visible_printers.end()) continue;
+                std::string nozzle = get_printer_nozzle_diameter(compatible_printer_name);
+                if (nozzle_diameter[nozzle] == 0) continue;
+                printer_name_to_filament_preset.push_back(std::make_pair(compatible_printer_name, preset));
+            }
+        }
+    }
+    sort_printer_by_nozzle(printer_name_to_filament_preset);
+    for (std::pair<std::string, Preset *> printer_to_preset : printer_name_to_filament_preset)
+        m_filament_presets_sizer->Add(create_checkbox(m_filament_preset_panel, printer_to_preset.first, printer_to_preset.second, m_filament_preset), 0,
+                                      wxEXPAND | wxTOP | wxLEFT, FromDIP(5));
+    m_scrolled_preset_panel->Thaw();
+    update_dialog_size();
+
+    // Auto-check the entry matching the printer's current nozzle diameter, so Create() can be
+    // used right away with something that will actually be selectable afterwards; NOTHING is
+    // auto-checked if none match — better to make the user pick explicitly (and see, thanks to
+    // the resizable/larger grid, that only a wrong-nozzle option exists) than to silently create
+    // a preset incompatible with the current printer.
+    if (!current_nozzle_diameter.empty()) {
+        for (auto& cb_preset : m_filament_preset) {
+            if (get_printer_nozzle_diameter(cb_preset.second.first) == current_nozzle_diameter) {
+                cb_preset.first->SetValue(true);
+                break;
+            }
+        }
+    }
+
+    return true;
 }
 
 bool CreateFilamentPresetDialog::is_check_box_selected()
@@ -871,7 +1018,6 @@ wxBoxSizer *CreateFilamentPresetDialog::create_type_item()
         } else if (curr_create_type == m_create_type.base_filament_preset) {
             get_filament_presets_by_machine();
         }
-        m_scrolled_preset_panel->SetSizerAndFit(m_scrolled_sizer);
 
         update_dialog_size();
         e.Skip();
@@ -984,7 +1130,6 @@ wxBoxSizer *CreateFilamentPresetDialog::create_filament_preset_item()
         for (std::pair<std::string, Preset *> printer_to_preset : printer_name_to_filament_preset)
             m_filament_presets_sizer->Add(create_checkbox(m_filament_preset_panel, printer_to_preset.first, printer_to_preset.second, m_filament_preset), 0,
                                           wxEXPAND | wxTOP | wxLEFT, FromDIP(5));
-        m_scrolled_preset_panel->SetSizerAndFit(m_scrolled_sizer);
         m_scrolled_preset_panel->Thaw();
 
         update_dialog_size();
@@ -1177,7 +1322,8 @@ wxWindow *CreateFilamentPresetDialog::create_dialog_buttons()
             }
         }
         preset_bundle->update_compatible(PresetSelectCompatibleType::Always);
-        EndModal(wxID_OK); 
+        m_last_created_filament_name = filament_preset_name;
+        EndModal(wxID_OK);
         });
 
     dlg_btns->GetCANCEL()->Bind(wxEVT_BUTTON, [this](wxCommandEvent &e) { 
@@ -1228,7 +1374,6 @@ wxArrayString CreateFilamentPresetDialog::get_filament_preset_choices()
             }
             preset_name_set.insert(from_u8(cur_preset_name));
         }
-        assert(1 == preset_name_set.size());
         if (preset_name_set.size() > 1) {
             BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " the same filament has different filament(vendor type serial)"; 
         }
@@ -1306,7 +1451,6 @@ void CreateFilamentPresetDialog::select_curr_radiobox(std::vector<std::pair<Radi
                     
                 }
             }
-            m_scrolled_preset_panel->SetSizerAndFit(m_scrolled_sizer);
             this->Thaw();
         } else {
             radiobox_list[i].first->SetValue(false);
@@ -1459,7 +1603,12 @@ void CreateFilamentPresetDialog::get_all_filament_presets()
         auto filament_type = preset.config.option<ConfigOptionStrings>("filament_type");
         if (filament_type && filament_type->values.size())
             m_system_filament_types_set.insert(filament_type->values[0]);
-        if (!preset.is_visible) continue;
+        // NOTE: deliberately NOT filtering on preset.is_visible here. That flag tracks whether
+        // the user has toggled this preset visible in the main filament picker (persisted in
+        // AppConfig) — a brand new system preset (e.g. a nozzle size just added to the vendor
+        // pack) starts out invisible until the user does that manually, even though it's a
+        // perfectly valid template to clone from in *this* dialog. Filtering on it here made
+        // such presets silently vanish from the printer/preset grid below.
         std::string filament_preset_name        = preset.name;
         Preset *filament_preset                 = new Preset(preset);
         m_all_presets_map[filament_preset_name] = filament_preset;
@@ -1477,6 +1626,22 @@ void CreateFilamentPresetDialog::get_all_visible_printer_name()
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << " entry, and visible printer is: " << printer_preset.name;
     }
 
+    // Always include every nozzle-size variant of the printer *model* currently active for the
+    // project ("Snapmaker U1 (0.2 nozzle)", "... (0.4 nozzle)", etc.), even if individual
+    // variants aren't flagged "visible" in the system-preset picker sense (that flag governs
+    // what shows up when *browsing* printers, not what's currently in use) — the user is on
+    // this printer model right now and may want a filament preset for any of its nozzles, not
+    // just the one currently loaded.
+    const std::string& edited_printer_name = preset_bundle->printers.get_edited_preset().name;
+    if (!edited_printer_name.empty()) {
+        m_visible_printers.insert(edited_printer_name);
+        const size_t paren_pos = edited_printer_name.find(" (");
+        const std::string base_model = paren_pos != std::string::npos ? edited_printer_name.substr(0, paren_pos) : edited_printer_name;
+        for (const Preset &printer_preset : preset_bundle->printers.get_presets()) {
+            if (printer_preset.name == base_model || printer_preset.name.rfind(base_model + " (", 0) == 0)
+                m_visible_printers.insert(printer_preset.name);
+        }
+    }
 }
 
 void CreateFilamentPresetDialog::update_dialog_size()
@@ -1485,11 +1650,18 @@ void CreateFilamentPresetDialog::update_dialog_size()
     m_filament_preset_panel->SetSizerAndFit(m_filament_presets_sizer);
     int width      = m_filament_preset_panel->GetSize().GetWidth();
     int height     = m_filament_preset_panel->GetSize().GetHeight();
-    m_scrolled_preset_panel->SetMinSize(wxSize(std::min(1400, width + FromDIP(26)), std::min(600, height + FromDIP(18))));
-    m_scrolled_preset_panel->SetMaxSize(wxSize(std::min(1400, width + FromDIP(26)), std::min(600, height + FromDIP(18))));
-    m_scrolled_preset_panel->SetSize(wxSize(std::min(1500, width + FromDIP(26)), std::min(600, height + FromDIP(18))));
+    // Just a sane cap so a pathologically long list can't blow the dialog past the screen; in
+    // practice this essentially never triggers. No SetMinSize/SetMaxSize on the panel itself —
+    // it's a plain wxPanel, so standard wxEXPAND + proportion=1 in the main sizer sizes it to
+    // its actual content, and the dialog (wxRESIZE_BORDER) grows/shrinks around it normally.
+    if (height + FromDIP(18) > FromDIP(900) || width + FromDIP(26) > FromDIP(1400))
+        m_filament_preset_panel->SetSize(wxSize(std::min(width, FromDIP(1400)), std::min(height, FromDIP(900))));
     Layout();
     Fit();
+    // Fit() can end up smaller than this dialog's SetMinSize() floor, in which case the OS
+    // clamps the window without re-Layout()'ing it — this second pass makes sure the printer
+    // grid panel actually claims that extra height instead of it sitting as a dead gap.
+    Layout();
     Refresh();
     adjust_dialog_in_screen(this);
     this->Thaw();
@@ -1521,7 +1693,6 @@ void CreateFilamentPresetDialog::sort_printer_by_nozzle(std::vector<std::pair<st
                   try {
                       nozzle_a = nozzle_diameter[nozzle_str_a];
                       nozzle_b = nozzle_diameter[nozzle_str_b];
-                      assert(nozzle_a != 0 && nozzle_b != 0);
                   } catch (...) {
                       BOOST_LOG_TRIVIAL(info) << "find nozzle filed, and nozzle is: " << nozzle_str_a << "mm and " << nozzle_str_b << "mm";
                       return a.first < b.first;

--- a/src/slic3r/GUI/CreatePresetsDialog.hpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.hpp
@@ -23,6 +23,23 @@ public:
     CreateFilamentPresetDialog(wxWindow *parent);
     ~CreateFilamentPresetDialog();
 
+    // Pre-fills Basic Information (vendor/type/serial) from a machine-reported filament with no
+    // matching local preset, and — if the reported type is a known system filament type — selects
+    // "Create Based on Current Filament" with the closest-matching filament family and auto-checks
+    // the printer/preset entry matching current_nozzle_diameter (e.g. "0.4"), so Create() can be
+    // used right away — every other compatible printer/nozzle entry is still shown (and can be
+    // checked too) in case the user wants more than one. Call before ShowModal(). Returns false
+    // (nothing pre-filled beyond vendor/type/serial) if the type is unknown.
+    bool prefill_from_machine_filament(const std::string& vendor, const std::string& type,
+                                        const std::string& serial_hint,
+                                        const std::string& preferred_base_public_name,
+                                        const std::string& current_nozzle_diameter);
+
+    // Base name ("Vendor Type Serial", no "@printer nozzle" suffix) of the preset(s) created by
+    // the last successful Create() click, so a caller can remember it (e.g. to link it back to
+    // the machine filament that prompted this dialog). Empty until Create() succeeds.
+    const std::string& get_last_created_filament_name() const { return m_last_created_filament_name; }
+
 protected:
     enum FilamentOptionType { 
         VENDOR = 0,
@@ -84,10 +101,14 @@ private:
     TextInput *                                                      m_filament_custom_vendor_input = nullptr;
     wxGridSizer *                                                    m_filament_presets_sizer       = nullptr;
     wxPanel *                                                        m_filament_preset_panel        = nullptr;
-    wxScrolledWindow *                                               m_scrolled_preset_panel        = nullptr;
+    // Plain wxPanel, not wxScrolledWindow — see the comment where it's constructed.
+    wxPanel *                                                        m_scrolled_preset_panel        = nullptr;
+    // "All nozzle" — checks/unchecks every entry currently in the printer/preset grid at once.
+    ::CheckBox *                                                     m_select_all_nozzle_checkbox   = nullptr;
     TextInput *                                                      m_filament_serial_input        = nullptr;
     wxBoxSizer *                                                     m_scrolled_sizer               = nullptr;
     wxStaticText *                                                   m_filament_preset_text         = nullptr;
+    std::string                                                      m_last_created_filament_name;
 
 };
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -719,6 +719,21 @@ Preset* resolve_filament_preset(PresetBundle* preset_bundle,
     return nullptr;
 }
 
+// Deterministic key identifying a machine-reported filament (by vendor+type only, so it still
+// matches on later scans of the same or a same-vendor/type spool). Stored in AppConfig's
+// "machine_filament_presets" section to explicitly remember which local preset a "Create
+// Filament" wizard run — launched from that exact machine slot — produced, instead of relying
+// purely on reconstructing a name match afterwards. Keep in sync with the identical helper in
+// PresetComboBoxes.cpp (ResolveMachineFilamentPreset's caller), which reads this mapping back.
+std::string machine_filament_signature(const std::string& vendor, const std::string& type)
+{
+    std::string v = boost::algorithm::to_lower_copy(vendor);
+    std::string t = boost::algorithm::to_lower_copy(type);
+    boost::algorithm::trim(v);
+    boost::algorithm::trim(t);
+    return t + "|" + v;
+}
+
 void build_design_filament_list(PresetBundle* preset_bundle, std::vector<FilamentData>& out_list)
 {
     if (!preset_bundle)
@@ -10390,6 +10405,10 @@ struct Plater::priv
     void on_combobox_select(wxCommandEvent&);
     void on_select_bed_type(wxCommandEvent&);
     void on_select_preset(wxCommandEvent&);
+    // Handles picking a "Machine Filament" combo entry that has no exact matching local
+    // preset (shown muted/grey): resolves a sensible fallback preset instead of assigning
+    // the raw machine name as-is, reflects the reported colour, and opens Material settings.
+    void on_select_unmatched_machine_filament(PlaterPresetComboBox* combo, int idx, int selection);
     void on_slicing_update(SlicingStatusEvent&);
     void on_slicing_completed(wxCommandEvent&);
     void on_process_completed(SlicingProcessCompletedEvent&);
@@ -14897,6 +14916,14 @@ void Plater::priv::on_select_preset(wxCommandEvent &evt)
 
     auto idx = combo->get_filament_idx();
 
+    if (preset_type == Preset::TYPE_FILAMENT && combo->IsItemMuted(static_cast<unsigned int>(selection))) {
+        // This entry is a machine-reported filament with no exact local preset match: the
+        // generic GetString()-based lookup below would assign a bogus, non-existent preset
+        // name. Handle it separately instead.
+        on_select_unmatched_machine_filament(combo, idx, selection);
+        return;
+    }
+
     // BBS:Save the plate parameters before switching
     PartPlateList& old_plate_list = this->partplate_list;
     PartPlate* old_plate = old_plate_list.get_selected_plate();
@@ -15016,6 +15043,75 @@ void Plater::priv::on_select_preset(wxCommandEvent &evt)
     auto plate_list = partplate_list.get_plate_list();
     for (auto plate : plate_list) {
          plate->update_slice_result_valid_state(false);
+    }
+}
+
+void Plater::priv::on_select_unmatched_machine_filament(PlaterPresetComboBox* combo, int idx, int selection)
+{
+    PresetBundle* preset_bundle = wxGetApp().preset_bundle;
+    if (!preset_bundle)
+        return;
+
+    // Capture which raw machine slot this entry corresponds to *before* reverting the combo
+    // below — that rebuilds the item list and would invalidate the index.
+    int machine_idx = combo->selected_ams_filament();
+    const auto& machineList = preset_bundle->m_connect_machine_info_list;
+
+    // Nothing was actually applied when this entry was clicked (it has no backing preset) —
+    // snap the combo back to whatever was selected before, so it doesn't keep showing the raw
+    // machine name as if it were the active filament.
+    combo->update();
+
+    if (machine_idx < 0 || static_cast<size_t>(machine_idx) >= machineList.size())
+        return;
+    const ConnectMachineInfo& machineInfo = machineList[machine_idx];
+
+    // The machine builds filament_info as "<vendor> <type>[ <sub_type>]" (see SSWCP.cpp). Split
+    // it back apart using the type we already know, so vendor/serial land in the right fields.
+    std::string vendor, serial;
+    size_t type_pos = machineInfo.filament_type.empty() ? std::string::npos
+                                                          : machineInfo.filament_info.find(machineInfo.filament_type);
+    if (type_pos != std::string::npos) {
+        vendor = machineInfo.filament_info.substr(0, type_pos);
+        serial = machineInfo.filament_info.substr(type_pos + machineInfo.filament_type.size());
+        boost::algorithm::trim(vendor);
+        boost::algorithm::trim(serial);
+    } else {
+        vendor = machineInfo.filament_info;
+    }
+
+    const std::string preferred_base = vendor.empty() ? machineInfo.filament_type : (vendor + " " + machineInfo.filament_type);
+
+    // Same nozzle-diameter formatting as the "Machine Filament" combo's own currentNozzleInfo
+    // (PresetComboBoxes.cpp), so the wizard can auto-check the entry that will actually be
+    // selectable afterwards instead of an arbitrary/wrong-nozzle one.
+    std::string current_nozzle_diameter;
+    if (const auto* nd_opt = preset_bundle->printers.get_edited_preset().config.option<ConfigOptionFloats>("nozzle_diameter");
+        nd_opt && !nd_opt->values.empty()) {
+        current_nozzle_diameter = float_to_string_decimal_point(nd_opt->values.front(), 2);
+        while (!current_nozzle_diameter.empty() && current_nozzle_diameter.back() == '0')
+            current_nozzle_diameter.pop_back();
+        if (!current_nozzle_diameter.empty() && current_nozzle_diameter.back() == '.')
+            current_nozzle_diameter.pop_back();
+    }
+
+    CreateFilamentPresetDialog dlg(wxGetApp().mainframe);
+    dlg.prefill_from_machine_filament(vendor, machineInfo.filament_type, serial, preferred_base, current_nozzle_diameter);
+    if (dlg.ShowModal() == wxID_OK) {
+        // Remember which preset this exact machine slot's "Create Filament" run produced, so
+        // future readings of the same (or same-vendor/type) filament resolve to it directly
+        // instead of depending on the created preset's name still resembling the machine's.
+        if (AppConfig* app_config = wxGetApp().app_config; app_config && !dlg.get_last_created_filament_name().empty()) {
+            app_config->set("machine_filament_presets", machine_filament_signature(vendor, machineInfo.filament_type),
+                             dlg.get_last_created_filament_name());
+            app_config->save();
+        }
+
+        wxGetApp().mainframe->update_side_preset_ui();
+        update_ui_from_settings();
+        sidebar->update_all_preset_comboboxes();
+        CreatePresetSuccessfulDialog success_dlg(wxGetApp().mainframe, SuccessType::FILAMENT);
+        success_dlg.ShowModal();
     }
 }
 

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1479,10 +1479,11 @@ void PlaterPresetComboBox::update()
                 const_cast<Preset&>(*item_iter).is_visible = true;
                 Append(get_preset_name(*item_iter), bmp.ConvertToImage(), &m_first_ams_filament + i);
             } else {
-                // No local preset matched by name (filter disabled) — show it anyway, greyed out
-                // and non-selectable, so it's visible instead of silently missing.
-                int item_id = Append(wxString::FromUTF8(filament_name), bmp.ConvertToImage());
-                set_label_marker(item_id, LABEL_ITEM_DISABLED);
+                // No local preset matched by name (filter disabled) — show it anyway, using the
+                // machine's own filament name. Stays fully clickable (same indexed clientData as
+                // matched entries), just rendered muted/light-grey to flag it as unconfirmed.
+                int item_id = Append(wxString::FromUTF8(filament_name), bmp.ConvertToImage(), &m_first_ams_filament + i);
+                SetItemMuted(item_id, true);
             }
         }
         m_last_ams_filament = GetCount();
@@ -2076,10 +2077,11 @@ void TabPresetComboBox::update()
                 const_cast<Preset&>(*item_iter).is_visible = true;
                 Append(get_preset_name(*item_iter), bmp.ConvertToImage(), &m_first_ams_filament + i);
             } else {
-                // No local preset matched by name (filter disabled) — show it anyway, greyed out
-                // and non-selectable, so it's visible instead of silently missing.
-                int item_id = Append(wxString::FromUTF8(filament_name), bmp.ConvertToImage());
-                set_label_marker(item_id, LABEL_ITEM_DISABLED);
+                // No local preset matched by name (filter disabled) — show it anyway, using the
+                // machine's own filament name. Stays fully clickable (same indexed clientData as
+                // matched entries), just rendered muted/light-grey to flag it as unconfirmed.
+                int item_id = Append(wxString::FromUTF8(filament_name), bmp.ConvertToImage(), &m_first_ams_filament + i);
+                SetItemMuted(item_id, true);
             }
         }
 

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -127,6 +127,127 @@ bool FilamentMatchesPresetName(const FilamentColorInfo& filament, const std::str
     return !filamentName.empty() && filamentName == currentFilamentName;
 }
 
+// Resolves a machine-reported filament to a local preset for the "Machine Filament" combo
+// section. Tries an exact historical name match first (preset literally named after the
+// machine's reported string, optionally with an "@<printer> <nozzle> nozzle" suffix), then
+// falls back to a "<vendor> <type>" prefix match (case-insensitive, ignoring the "@printer"
+// suffix and any filament_type match) — because the free-text "Serial" part of a preset
+// created via the "Create Filament" wizard need not reproduce whatever generic sub-type the
+// machine itself reports (e.g. the user naming it "White" instead of the machine's "Basic").
+//
+// Only ever returns a preset that's actually compatible with the current printer/nozzle: a
+// preset that matches by name/vendor+type but was created for a different nozzle is a dead end
+// (shown but not selectable) rather than a match — so it's treated as no match at all, keeping
+// the combo entry muted/clickable so re-opening "Create Filament" lets the user add the missing
+// nozzle variant instead.
+const Preset* ResolveMachineFilamentPreset(const std::deque<Preset>& filaments,
+                                           const std::string& filamentName,
+                                           const std::string& filamentType,
+                                           const std::string& machineNozzles)
+{
+    bool foundByName = false;
+    for (const auto& f : filaments) {
+        if (f.name == filamentName + " @U1 " + machineNozzles + " nozzle" ||
+            f.name == filamentName + " @U1 " + machineNozzles ||
+            f.name == filamentName + " @U1" ||
+            f.name == filamentName) {
+            if (f.is_compatible)
+                return &f;
+            foundByName = true;
+        }
+    }
+    if (foundByName)
+        return nullptr;
+
+    if (filamentType.empty())
+        return nullptr;
+
+    const size_t typePos = filamentName.find(filamentType);
+    if (typePos == std::string::npos)
+        return nullptr;
+    std::string vendorType = filamentName.substr(0, typePos + filamentType.size());
+    boost::algorithm::trim(vendorType);
+    if (vendorType.empty())
+        return nullptr;
+
+    for (const auto& f : filaments) {
+        const auto* typeOpt = f.config.option<ConfigOptionStrings>("filament_type");
+        if (!typeOpt || typeOpt->values.empty() || typeOpt->values[0] != filamentType)
+            continue;
+        std::string base = f.name;
+        const size_t atPos = base.find(" @");
+        if (atPos != std::string::npos)
+            base = base.substr(0, atPos);
+        if (boost::algorithm::istarts_with(base, vendorType) && f.is_compatible)
+            return &f;
+    }
+    return nullptr;
+}
+
+// Extracts the vendor portion of a machine-reported "<vendor> <type>[ <sub_type>]" string,
+// given the type we already know. Keep in sync with the identical split in Plater.cpp's
+// on_select_unmatched_machine_filament().
+std::string ExtractMachineFilamentVendor(const std::string& filamentInfo, const std::string& filamentType)
+{
+    if (filamentType.empty())
+        return filamentInfo;
+    const size_t pos = filamentInfo.find(filamentType);
+    if (pos == std::string::npos)
+        return filamentInfo;
+    std::string vendor = filamentInfo.substr(0, pos);
+    boost::algorithm::trim(vendor);
+    return vendor;
+}
+
+// Keep in sync with Plater.cpp's machine_filament_signature().
+std::string MachineFilamentSignature(const std::string& vendor, const std::string& type)
+{
+    std::string v = boost::algorithm::to_lower_copy(vendor);
+    std::string t = boost::algorithm::to_lower_copy(type);
+    boost::algorithm::trim(v);
+    boost::algorithm::trim(t);
+    return t + "|" + v;
+}
+
+// Looks up a preset explicitly linked, via AppConfig's "machine_filament_presets" section, to
+// this machine-reported filament by a prior "Create Filament" run launched from this exact
+// slot (see Plater.cpp's on_select_unmatched_machine_filament) — authoritative, since it
+// doesn't depend on the created preset's name still resembling the machine's. Falls back to
+// the heuristic ResolveMachineFilamentPreset() above when no such link is recorded.
+const Preset* ResolveMachineFilamentPresetForSlot(const std::deque<Preset>& filaments,
+                                                   const std::string& filamentName,
+                                                   const std::string& filamentType,
+                                                   const std::string& machineNozzles)
+{
+    const std::string vendor = ExtractMachineFilamentVendor(filamentName, filamentType);
+    const std::string signature = MachineFilamentSignature(vendor, filamentType);
+    if (AppConfig* app_config = wxGetApp().app_config; app_config && app_config->has("machine_filament_presets", signature)) {
+        const std::string mappedName = app_config->get("machine_filament_presets", signature);
+        if (!mappedName.empty()) {
+            bool foundByMapping = false;
+            for (const auto& f : filaments) {
+                std::string base = f.name;
+                const size_t atPos = base.find(" @");
+                if (atPos != std::string::npos)
+                    base = base.substr(0, atPos);
+                if (base == mappedName) {
+                    if (f.is_compatible)
+                        return &f;
+                    foundByMapping = true;
+                }
+            }
+            // A preset was created for this exact machine filament, but not for the current
+            // nozzle — stay muted (don't fall through to the weaker heuristic below, which
+            // could otherwise pick an unrelated compatible preset) so re-clicking reopens
+            // "Create Filament" already scoped to this family, letting the user add the
+            // missing nozzle variant.
+            if (foundByMapping)
+                return nullptr;
+        }
+    }
+    return ResolveMachineFilamentPreset(filaments, filamentName, filamentType, machineNozzles);
+}
+
 wxSize FilamentColorPickerBitmapSize(const wxButton* picker)
 {
     wxSize size = picker != nullptr ? picker->GetSize() : wxSize();
@@ -1424,48 +1545,9 @@ void PlaterPresetComboBox::update()
             if (currentNozzleInfo != machine_nozzles)
                 continue;
 
-            // TEMP (2026-08-31): name-matching filter disabled for testing — it was silently
-            // dropping machine filaments whose reported name didn't exactly match a local preset
-            // name, hiding entries from "Machine Filament" with no feedback. Entries with no
-            // matching preset are now shown greyed out / non-selectable instead of being hidden.
-            // auto item_iter = std::find_if(filaments.begin(), filaments.end(),
-            // [&filament_name, &machine_nozzles, &currentNozzleInfo](auto& f) {
-            //     if (f.name == filament_name + " @U1 " + machine_nozzles + " nozzle")
-            //         if (f.is_compatible)
-            //             return true;
-            //
-            //     if (f.name == filament_name + " @U1 " + machine_nozzles)
-            //         if (f.is_compatible)
-            //             return true;
-            //
-            //     if (f.name == filament_name + " @U1")
-            //         if (f.is_compatible)
-            //             return true;
-            //
-            //     if (f.name == filament_name)
-            //         if (f.is_compatible)
-            //             return true;
-            //
-            //     return false;
-            // });
-            auto item_iter = std::find_if(filaments.begin(), filaments.end(),
-            [&filament_name, &machine_nozzles, &currentNozzleInfo](auto& f) {
-                if (f.name == filament_name + " @U1 " + machine_nozzles + " nozzle")
-                    return true;
-
-                if (f.name == filament_name + " @U1 " + machine_nozzles)
-                    return true;
-
-                if (f.name == filament_name + " @U1")
-                    return true;
-
-                if (f.name == filament_name)
-                    return true;
-
-                return false;
-            });
-
             const ConnectMachineInfo& machineInfo = machine_nozzles_list[i];
+            const Preset* matched = ResolveMachineFilamentPresetForSlot(filaments, filament_name, machineInfo.filament_type, machine_nozzles);
+
             std::vector<std::string> colors = machineInfo.multiColors;
             if (colors.empty() && !machineInfo.color_info.empty())
                 colors.emplace_back(machineInfo.color_info);
@@ -1475,13 +1557,13 @@ void PlaterPresetComboBox::update()
                 icon = get_extruder_color_icon(machineInfo.color_info, name, 24, 16);
             wxBitmap bmp(*icon);
 
-            if (item_iter != filaments.end()) {
-                const_cast<Preset&>(*item_iter).is_visible = true;
-                Append(get_preset_name(*item_iter), bmp.ConvertToImage(), &m_first_ams_filament + i);
+            if (matched) {
+                const_cast<Preset*>(matched)->is_visible = true;
+                Append(get_preset_name(*matched), bmp.ConvertToImage(), &m_first_ams_filament + i);
             } else {
-                // No local preset matched by name (filter disabled) — show it anyway, using the
-                // machine's own filament name. Stays fully clickable (same indexed clientData as
-                // matched entries), just rendered muted/light-grey to flag it as unconfirmed.
+                // No local preset matched — show it anyway, using the machine's own filament
+                // name. Stays fully clickable (same indexed clientData as matched entries),
+                // just rendered muted/light-grey to flag it as unconfirmed.
                 int item_id = Append(wxString::FromUTF8(filament_name), bmp.ConvertToImage(), &m_first_ams_filament + i);
                 SetItemMuted(item_id, true);
             }
@@ -2022,48 +2104,9 @@ void TabPresetComboBox::update()
             if (currentNozzleInfo != machine_nozzles)
                 continue;
 
-            // TEMP (2026-08-31): name-matching filter disabled for testing — it was silently
-            // dropping machine filaments whose reported name didn't exactly match a local preset
-            // name, hiding entries from "Machine Filament" with no feedback. Entries with no
-            // matching preset are now shown greyed out / non-selectable instead of being hidden.
-            // auto item_iter = std::find_if(filaments.begin(), filaments.end(),[&filament_name, &machine_nozzles, &currentNozzleInfo](auto& f) {
-            //
-            //     if (f.name == filament_name + " @U1 " + machine_nozzles + " nozzle")
-            //         if (f.is_compatible)
-            //             return true;
-            //
-            //     if (f.name == filament_name + " @U1 " + machine_nozzles)
-            //         if (f.is_compatible)
-            //             return true;
-            //
-            //     if (f.name == filament_name + " @U1")
-            //         if (f.is_compatible)
-            //             return true;
-            //
-            //     if (f.name == filament_name)
-            //         if (f.is_compatible)
-            //             return true;
-            //
-            //     return false;
-            //     });
-            auto item_iter = std::find_if(filaments.begin(), filaments.end(),[&filament_name, &machine_nozzles, &currentNozzleInfo](auto& f) {
-
-                if (f.name == filament_name + " @U1 " + machine_nozzles + " nozzle")
-                    return true;
-
-                if (f.name == filament_name + " @U1 " + machine_nozzles)
-                    return true;
-
-                if (f.name == filament_name + " @U1")
-                    return true;
-
-                if (f.name == filament_name)
-                    return true;
-
-                return false;
-                });
-
             const ConnectMachineInfo& machineInfo = machine_nozzles_list[i];
+            const Preset* matched = ResolveMachineFilamentPresetForSlot(filaments, filament_name, machineInfo.filament_type, machine_nozzles);
+
             std::vector<std::string> colors = machineInfo.multiColors;
             if (colors.empty() && !machineInfo.color_info.empty())
                 colors.emplace_back(machineInfo.color_info);
@@ -2073,13 +2116,13 @@ void TabPresetComboBox::update()
                 icon = get_extruder_color_icon(machineInfo.color_info, name, 24, 16);
             wxBitmap bmp(*icon);
 
-            if (item_iter != filaments.end()) {
-                const_cast<Preset&>(*item_iter).is_visible = true;
-                Append(get_preset_name(*item_iter), bmp.ConvertToImage(), &m_first_ams_filament + i);
+            if (matched) {
+                const_cast<Preset*>(matched)->is_visible = true;
+                Append(get_preset_name(*matched), bmp.ConvertToImage(), &m_first_ams_filament + i);
             } else {
-                // No local preset matched by name (filter disabled) — show it anyway, using the
-                // machine's own filament name. Stays fully clickable (same indexed clientData as
-                // matched entries), just rendered muted/light-grey to flag it as unconfirmed.
+                // No local preset matched — show it anyway, using the machine's own filament
+                // name. Stays fully clickable (same indexed clientData as matched entries),
+                // just rendered muted/light-grey to flag it as unconfirmed.
                 int item_id = Append(wxString::FromUTF8(filament_name), bmp.ConvertToImage(), &m_first_ams_filament + i);
                 SetItemMuted(item_id, true);
             }

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -1424,39 +1424,65 @@ void PlaterPresetComboBox::update()
             if (currentNozzleInfo != machine_nozzles)
                 continue;
 
+            // TEMP (2026-08-31): name-matching filter disabled for testing — it was silently
+            // dropping machine filaments whose reported name didn't exactly match a local preset
+            // name, hiding entries from "Machine Filament" with no feedback. Entries with no
+            // matching preset are now shown greyed out / non-selectable instead of being hidden.
+            // auto item_iter = std::find_if(filaments.begin(), filaments.end(),
+            // [&filament_name, &machine_nozzles, &currentNozzleInfo](auto& f) {
+            //     if (f.name == filament_name + " @U1 " + machine_nozzles + " nozzle")
+            //         if (f.is_compatible)
+            //             return true;
+            //
+            //     if (f.name == filament_name + " @U1 " + machine_nozzles)
+            //         if (f.is_compatible)
+            //             return true;
+            //
+            //     if (f.name == filament_name + " @U1")
+            //         if (f.is_compatible)
+            //             return true;
+            //
+            //     if (f.name == filament_name)
+            //         if (f.is_compatible)
+            //             return true;
+            //
+            //     return false;
+            // });
             auto item_iter = std::find_if(filaments.begin(), filaments.end(),
             [&filament_name, &machine_nozzles, &currentNozzleInfo](auto& f) {
                 if (f.name == filament_name + " @U1 " + machine_nozzles + " nozzle")
-                    if (f.is_compatible)
-                        return true;
-                
+                    return true;
+
                 if (f.name == filament_name + " @U1 " + machine_nozzles)
-                    if (f.is_compatible)
-                        return true;
+                    return true;
 
                 if (f.name == filament_name + " @U1")
-                    if (f.is_compatible)
-                        return true;
+                    return true;
 
                 if (f.name == filament_name)
-                    if (f.is_compatible)
-                        return true;
+                    return true;
 
                 return false;
             });
 
+            const ConnectMachineInfo& machineInfo = machine_nozzles_list[i];
+            std::vector<std::string> colors = machineInfo.multiColors;
+            if (colors.empty() && !machineInfo.color_info.empty())
+                colors.emplace_back(machineInfo.color_info);
+            const std::string name = std::to_string(i + 1);
+            wxBitmap* icon = FilamentColorUtils::GetFilamentColorIcon(colors, machineInfo.colorMode, name, 24, 16);
+            if (icon == nullptr)
+                icon = get_extruder_color_icon(machineInfo.color_info, name, 24, 16);
+            wxBitmap bmp(*icon);
+
             if (item_iter != filaments.end()) {
                 const_cast<Preset&>(*item_iter).is_visible = true;
-                const ConnectMachineInfo& machineInfo = machine_nozzles_list[i];
-                std::vector<std::string> colors = machineInfo.multiColors;
-                if (colors.empty() && !machineInfo.color_info.empty())
-                    colors.emplace_back(machineInfo.color_info);
-                const std::string name = std::to_string(i + 1);
-                wxBitmap* icon = FilamentColorUtils::GetFilamentColorIcon(colors, machineInfo.colorMode, name, 24, 16);
-                if (icon == nullptr)
-                    icon = get_extruder_color_icon(machineInfo.color_info, name, 24, 16);
-                wxBitmap bmp(*icon);
                 Append(get_preset_name(*item_iter), bmp.ConvertToImage(), &m_first_ams_filament + i);
+            } else {
+                // No local preset matched by name (filter disabled) — show it anyway, greyed out
+                // and non-selectable, so it's visible instead of silently missing.
+                int item_id = Append(wxString::FromUTF8(filament_name), bmp.ConvertToImage());
+                set_label_marker(item_id, LABEL_ITEM_DISABLED);
             }
         }
         m_last_ams_filament = GetCount();
@@ -1995,39 +2021,65 @@ void TabPresetComboBox::update()
             if (currentNozzleInfo != machine_nozzles)
                 continue;
 
-            auto item_iter = std::find_if(filaments.begin(), filaments.end(),[&filament_name, &machine_nozzles, &currentNozzleInfo](auto& f) {               
+            // TEMP (2026-08-31): name-matching filter disabled for testing — it was silently
+            // dropping machine filaments whose reported name didn't exactly match a local preset
+            // name, hiding entries from "Machine Filament" with no feedback. Entries with no
+            // matching preset are now shown greyed out / non-selectable instead of being hidden.
+            // auto item_iter = std::find_if(filaments.begin(), filaments.end(),[&filament_name, &machine_nozzles, &currentNozzleInfo](auto& f) {
+            //
+            //     if (f.name == filament_name + " @U1 " + machine_nozzles + " nozzle")
+            //         if (f.is_compatible)
+            //             return true;
+            //
+            //     if (f.name == filament_name + " @U1 " + machine_nozzles)
+            //         if (f.is_compatible)
+            //             return true;
+            //
+            //     if (f.name == filament_name + " @U1")
+            //         if (f.is_compatible)
+            //             return true;
+            //
+            //     if (f.name == filament_name)
+            //         if (f.is_compatible)
+            //             return true;
+            //
+            //     return false;
+            //     });
+            auto item_iter = std::find_if(filaments.begin(), filaments.end(),[&filament_name, &machine_nozzles, &currentNozzleInfo](auto& f) {
 
                 if (f.name == filament_name + " @U1 " + machine_nozzles + " nozzle")
-                    if (f.is_compatible)
-                        return true;
-                
+                    return true;
+
                 if (f.name == filament_name + " @U1 " + machine_nozzles)
-                    if (f.is_compatible)
-                        return true;
-                
+                    return true;
+
                 if (f.name == filament_name + " @U1")
-                    if (f.is_compatible)
-                        return true;
+                    return true;
 
                 if (f.name == filament_name)
-                    if (f.is_compatible)
-                        return true;
+                    return true;
 
-                return false;                
+                return false;
                 });
+
+            const ConnectMachineInfo& machineInfo = machine_nozzles_list[i];
+            std::vector<std::string> colors = machineInfo.multiColors;
+            if (colors.empty() && !machineInfo.color_info.empty())
+                colors.emplace_back(machineInfo.color_info);
+            const std::string name = std::to_string(i + 1);
+            wxBitmap* icon = FilamentColorUtils::GetFilamentColorIcon(colors, machineInfo.colorMode, name, 24, 16);
+            if (icon == nullptr)
+                icon = get_extruder_color_icon(machineInfo.color_info, name, 24, 16);
+            wxBitmap bmp(*icon);
 
             if (item_iter != filaments.end()) {
                 const_cast<Preset&>(*item_iter).is_visible = true;
-                const ConnectMachineInfo& machineInfo = machine_nozzles_list[i];
-                std::vector<std::string> colors = machineInfo.multiColors;
-                if (colors.empty() && !machineInfo.color_info.empty())
-                    colors.emplace_back(machineInfo.color_info);
-                const std::string name = std::to_string(i + 1);
-                wxBitmap* icon = FilamentColorUtils::GetFilamentColorIcon(colors, machineInfo.colorMode, name, 24, 16);
-                if (icon == nullptr)
-                    icon = get_extruder_color_icon(machineInfo.color_info, name, 24, 16);
-                wxBitmap bmp(*icon);
                 Append(get_preset_name(*item_iter), bmp.ConvertToImage(), &m_first_ams_filament + i);
+            } else {
+                // No local preset matched by name (filter disabled) — show it anyway, greyed out
+                // and non-selectable, so it's visible instead of silently missing.
+                int item_id = Append(wxString::FromUTF8(filament_name), bmp.ConvertToImage());
+                set_label_marker(item_id, LABEL_ITEM_DISABLED);
             }
         }
 

--- a/src/slic3r/GUI/Widgets/ComboBox.cpp
+++ b/src/slic3r/GUI/Widgets/ComboBox.cpp
@@ -39,7 +39,7 @@ ComboBox::ComboBox(wxWindow *parent,
                    int             n,
                    const wxString  choices[],
                    long            style)
-    : drop(texts, tips, icons)
+    : drop(texts, tips, icons, muted)
 {
     if (style & wxCB_READONLY)
         style |= wxRIGHT;
@@ -160,6 +160,7 @@ int ComboBox::Append(const wxString &item,
     icons.push_back(bitmap);
     datas.push_back(clientData);
     types.push_back(wxClientData_None);
+    muted.push_back(false);
     drop.Invalidate();
     return texts.size() - 1;
 }
@@ -172,6 +173,7 @@ void ComboBox::DoClear()
     icons.clear();
     datas.clear();
     types.clear();
+    muted.clear();
     drop.Invalidate(true);
 }
 
@@ -183,7 +185,15 @@ void ComboBox::DoDeleteOneItem(unsigned int pos)
     icons.erase(icons.begin() + pos);
     datas.erase(datas.begin() + pos);
     types.erase(types.begin() + pos);
+    muted.erase(muted.begin() + pos);
     drop.Invalidate(true);
+}
+
+void ComboBox::SetItemMuted(unsigned int n, bool value)
+{
+    if (n >= muted.size()) return;
+    muted[n] = value;
+    drop.Invalidate();
 }
 
 unsigned int ComboBox::GetCount() const { return texts.size(); }
@@ -234,6 +244,7 @@ int ComboBox::DoInsertItems(const wxArrayStringsAdapter &items,
         icons.insert(icons.begin() + pos, wxNullBitmap);
         datas.insert(datas.begin() + pos, clientData ? clientData[i] : NULL);
         types.insert(types.begin() + pos, type);
+        muted.insert(muted.begin() + pos, false);
         ++pos;
     }
     drop.Invalidate(true);

--- a/src/slic3r/GUI/Widgets/ComboBox.hpp
+++ b/src/slic3r/GUI/Widgets/ComboBox.hpp
@@ -14,6 +14,7 @@ class ComboBox : public wxWindowWithItems<TextInput, wxItemContainer>
     std::vector<wxBitmap>         icons;
     std::vector<void *>           datas;
     std::vector<wxClientDataType> types;
+    std::vector<bool>             muted;
 
     DropDown               drop;
     bool     drop_down = false;
@@ -65,6 +66,13 @@ public:
 
     wxBitmap GetItemBitmap(unsigned int n);
     void     SetItemBitmap(unsigned int n, wxBitmap const &bitmap);
+
+    // Marks an item to be rendered in a muted/light-grey text colour while remaining fully
+    // clickable/selectable — used e.g. for "Machine Filament" entries reported by a remote
+    // printer that have no matching local preset.
+    void SetItemMuted(unsigned int n, bool value = true);
+    bool IsItemMuted(unsigned int n) const { return n < muted.size() && muted[n]; }
+
     bool     is_drop_down(){return drop_down;}
     void     DeleteOneItem(unsigned int pos) { DoDeleteOneItem(pos); }
 protected:

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -32,10 +32,12 @@ END_EVENT_TABLE()
 
 DropDown::DropDown(std::vector<wxString> &texts,
                    std::vector<wxString> &tips,
-                   std::vector<wxBitmap> &icons)
+                   std::vector<wxBitmap> &icons,
+                   std::vector<bool>     &muted)
     : texts(texts)
     , tips(tips)
     , icons(icons)
+    , muted(muted)
     , state_handler(this)
     , border_color(0xDBDBDB)
     , text_color(0x363636)
@@ -50,8 +52,9 @@ DropDown::DropDown(wxWindow *             parent,
                    std::vector<wxString> &texts,
                    std::vector<wxString> &tips,
                    std::vector<wxBitmap> &icons,
+                   std::vector<bool>     &muted,
                    long           style)
-    : DropDown(texts, tips, icons)
+    : DropDown(texts, tips, icons, muted)
 {
     Create(parent, style);
 }
@@ -282,13 +285,16 @@ void DropDown::render(wxDC &dc)
         rcContent.width -= szBmp.x + 5;
     }
     // draw texts & icons
-    dc.SetTextForeground(text_color.colorForStates(states));
+    const wxColour normalTextColor = text_color.colorForStates(states);
+    const wxColour mutedTextColor  = StateColor::darkModeColorFor(wxColour(0xB2, 0xB2, 0xB2));
+    dc.SetTextForeground(normalTextColor);
     for (int i = 0; i < texts.size(); ++i) {
         if (rcContent.GetBottom() < 0) {
             rcContent.y += rowSize.y;
             continue;
         }
         if (rcContent.y > size.y) break;
+        dc.SetTextForeground(i < (int) muted.size() && muted[i] ? mutedTextColor : normalTextColor);
         wxPoint pt   = rcContent.GetLeftTop();
         auto & icon = icons[i];
         auto size2 = GetBmpSize(icon);

--- a/src/slic3r/GUI/Widgets/DropDown.hpp
+++ b/src/slic3r/GUI/Widgets/DropDown.hpp
@@ -18,6 +18,7 @@ class DropDown : public PopupWindow
     std::vector<wxString> &       texts;
     std::vector<wxString> &       tips;
     std::vector<wxBitmap> &     icons;
+    std::vector<bool>     &     muted;
     bool                          need_sync  = false;
     int                         selection = -1;
     int                         hover_item = -1;
@@ -47,12 +48,14 @@ class DropDown : public PopupWindow
 public:
     DropDown(std::vector<wxString> &texts,
              std::vector<wxString> &tips,
-             std::vector<wxBitmap> &icons);
-    
+             std::vector<wxBitmap> &icons,
+             std::vector<bool>     &muted);
+
     DropDown(wxWindow *     parent,
              std::vector<wxString> &texts,
              std::vector<wxString> &tips,
              std::vector<wxBitmap> &icons,
+             std::vector<bool>     &muted,
              long           style     = 0);
     
     void Create(wxWindow *     parent,


### PR DESCRIPTION
## What
When the remote printer reports a filament for which no local preset matches by name, the "Machine Filament" combo used to either silently hide the entry, or (in an earlier iteration of this work) show it greyed-out but load a wrong/guessed preset when clicked. This PR makes that click actually useful:

- Clicking a muted "Machine Filament" entry now opens the "Create Filament" wizard, pre-filled with vendor/type/serial parsed from the machine's reported string and the closest known filament family — instead of silently applying a wrong preset.
- Matching a machine-reported filament to a local preset now goes through an explicit persisted link (recorded when the wizard successfully creates a preset from that exact machine reading) before falling back to name-based heuristics, and only ever returns a preset that's actually compatible with the current printer/nozzle.
- Unmatched entries are shown muted (light grey) but remain fully clickable, instead of being hidden or disabled outright.

## Commits
1. `Machine Filament combo: disable name-match filter, show unmatched entries greyed out` — stop silently dropping machine filaments whose reported name doesn't exactly match a local preset; show them muted instead.
2. `Machine Filament combo: make unmatched entries clickable, muted grey` — add a per-item muted/light-grey rendering to the ComboBox/DropDown widgets, keep unmatched entries clickable.
3. `Machine Filament combo: create-and-link a proper preset for unmatched entries` — clicking an unmatched entry opens "Create Filament" pre-filled from the machine reading; successful creation is persisted as an explicit machine→preset link; matching is nozzle/printer-compatibility aware.

## Testing
Built and manually tested against a Snapmaker U1 printer reporting filaments with no matching local preset, across several rounds of iteration (vendor/type/serial prefill, nozzle-diameter matching, family selection, printer visibility).