### PR TITLE
feat: migrate query_machine_info to connection gateway via GatewayDevice

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -601,6 +601,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/Frustum.hpp
     Utils/GatewayProtocol.cpp
     Utils/GatewayProtocol.hpp
+    Utils/GatewayDevice.cpp
+    Utils/GatewayDevice.hpp
     Utils/GatewayService.cpp
     Utils/GatewayService.hpp
     Utils/HexFile.cpp

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -5642,7 +5642,7 @@ bool GUI_App::start_gateway_service(bool restart)
         dependencies.websocket = std::make_shared<Gateway::GatewayWebSocketTransport>();
         dependencies.dispatcher = [this](std::function<void()> task) { CallAfter(std::move(task)); };
 
-        m_gateway_service = std::make_unique<Gateway::GatewayService>(Gateway::GatewayService::Config{}, std::move(dependencies));
+        m_gateway_service = std::make_shared<Gateway::GatewayService>(Gateway::GatewayService::Config{}, std::move(dependencies));
         const std::string locale = gateway_locale();
         BOOST_LOG_TRIVIAL(info) << "starting connection gateway with locale " << locale;
         if (!m_gateway_service->start(locale))

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -352,7 +352,7 @@ private:
 
 public:
     HttpServer       m_page_http_server;
-    mutable std::unique_ptr<Gateway::GatewayService> m_gateway_service;
+    mutable std::shared_ptr<Gateway::GatewayService> m_gateway_service;
     
 private:
     bool             m_show_gcode_window{true};
@@ -654,6 +654,7 @@ private:
     Gateway::PreprintStoreResult gateway_store_preprint_context(const std::string& id, const nlohmann::json& payload,
                                                                 int ttl_seconds = 1800) const;
     bool            is_gateway_url(const wxString& url) const;
+    std::shared_ptr<Gateway::GatewayService> gateway_service() const { return m_gateway_service; }
 
     enum class FlutterWebCopyStatus { Ok, UpgradeFailed, InstallFailed, Other };
     /// Copy bundled flutter_web into the user data directory. On failure, records status for deferred user notification.

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -144,6 +144,7 @@
 #include "../Utils/PresetUpdater.hpp"
 #include "../Utils/Process.hpp"
 #include "../Utils/GatewayProtocol.hpp"
+#include "../Utils/GatewayDevice.hpp"
 #include "RemovableDriveManager.hpp"
 #include "InstanceCheck.hpp"
 #include "NotificationManager.hpp"
@@ -2126,7 +2127,14 @@ Sidebar::Sidebar(Plater *parent)
                     hasConnectDevice = true;
             }
 
-            if (!hasConnectDevice)
+            std::string                machine_type = "";
+            std::vector<std::string>   nozzle_diameters;
+            std::string                device_name = "";
+            // Single gateway RPC doubles as the connected-guard: a device answering
+            // machine.system_info is connected (avoids probe + query serial waits).
+            const bool got_machine_info = Gateway::GatewayDevice::query_machine_info(wxGetApp().gateway_service(), machine_type, nozzle_diameters, device_name);
+
+            if (!hasConnectDevice && !got_machine_info)
             {
                 // showdialog tips no connect device
                 wxTheApp->CallAfter([this]() {
@@ -2134,16 +2142,9 @@ Sidebar::Sidebar(Plater *parent)
                                       _L("Printer not connected. Please go to the home page or the device page to connect the printer."),
                                       _L("Note"), wxOK);
                     dlg.ShowModal();
-                    });                
-                return;        
+                    });
+                return;
             }
-
-            std::string                machine_type = "";
-            std::vector<std::string>   nozzle_diameters;
-            std::string                device_name = "";
-            std::shared_ptr<PrintHost> host = nullptr;
-            wxGetApp().get_connect_host(host);
-            const bool got_machine_info = SSWCP::query_machine_info(host, machine_type, nozzle_diameters, device_name);
 
             const auto& sync_nozzle_slots = wxGetApp().preset_bundle->m_connect_machine_info_list;
             if (!sync_nozzle_slots.empty()) {
@@ -9145,7 +9146,14 @@ void Sidebar::show_sync_filament_dialog()
         }
     }
 
-    if (!host && !device_machine) {
+    std::string machine_type;
+    std::string device_name;
+    std::vector<std::string> nozzle_diameters;
+    // Single gateway RPC doubles as the connected-guard: a device answering
+    // machine.system_info is connected (avoids probe + query serial waits).
+    bool got_machine_info = Gateway::GatewayDevice::query_machine_info(wxGetApp().gateway_service(), machine_type, nozzle_diameters, device_name);
+
+    if (!host && !device_machine && !got_machine_info) {
         SyncRichConfirmDialog dlg(this,
             _L("No printer is connected. Please connect your U1 from the Device page before syncing."),
             wxYES_NO);
@@ -9161,14 +9169,6 @@ void Sidebar::show_sync_filament_dialog()
         static const std::set<std::string> white_list_machine_types = {
             "Snapmaker U1"
         };
-        std::string machine_type;
-        std::string device_name;
-        std::vector<std::string> nozzle_diameters;
-        bool got_machine_info = false;
-
-        if (host) {
-            got_machine_info = SSWCP::query_machine_info(host, machine_type, nozzle_diameters, device_name);
-        }
 
         if (!got_machine_info || machine_type.empty()) {
             if (device_machine) {

--- a/src/slic3r/Utils/GatewayDevice.cpp
+++ b/src/slic3r/Utils/GatewayDevice.cpp
@@ -1,0 +1,104 @@
+#include "GatewayDevice.hpp"
+#include "GatewayService.hpp"
+
+#include <boost/log/trivial.hpp>
+
+#include <cmath>
+#include <cstdlib>
+
+namespace Slic3r { namespace Gateway {
+
+namespace {
+
+const nlohmann::json* find_object(const nlohmann::json& parent, const char* key)
+{
+    const auto it = parent.find(key);
+    return it != parent.end() && it->is_object() ? &*it : nullptr;
+}
+
+std::string get_string(const nlohmann::json& parent, const char* key)
+{
+    const auto it = parent.find(key);
+    return it != parent.end() && it->is_string() ? it->get<std::string>() : std::string{};
+}
+
+// Normalize a nozzle diameter into the "0.2"/"0.4"/"0.6"/"0.8" preset labels used by the UI.
+// Diameters outside the supported preset catalog are dropped on purpose — same mapping as the
+// legacy SSWCP::query_machine_info behavior.
+void append_nozzle(const nlohmann::json& value, std::vector<std::string>& out_nozzle_diameters)
+{
+    double diameter = 0.0;
+    if (value.is_number())
+        diameter = value.get<double>();
+    else if (value.is_string())
+        diameter = std::atof(value.get<std::string>().c_str());
+    if (std::fabs(diameter - 0.2) < 1e-6)
+        out_nozzle_diameters.push_back("0.2");
+    else if (std::fabs(diameter - 0.4) < 1e-6)
+        out_nozzle_diameters.push_back("0.4");
+    else if (std::fabs(diameter - 0.6) < 1e-6)
+        out_nozzle_diameters.push_back("0.6");
+    else if (std::fabs(diameter - 0.8) < 1e-6)
+        out_nozzle_diameters.push_back("0.8");
+}
+
+} // namespace
+
+bool GatewayDevice::query_machine_info(const std::shared_ptr<GatewayService>& gateway, std::string& out_model, std::vector<std::string>& out_nozzle_diameters,
+                                        std::string& device_name)
+{
+    if (gateway == nullptr)
+        return false;
+
+    const GatewayService::ApiResult result = gateway->request_sync("machine.system_info", nlohmann::json::object(), std::chrono::milliseconds{5000});
+    if (result.error) {
+        // -32000 not_connected (no device) is an expected answer; anything else is worth a log line.
+        if (result.error.code != GatewayErrorCode::NotConnected && result.error.code != GatewayErrorCode::RpcError)
+            BOOST_LOG_TRIVIAL(warning) << "GatewayDevice::query_machine_info: gateway request failed: " << result.error.message;
+        return false;
+    }
+
+    const nlohmann::json* system_info = find_object(result.value, "system_info");
+    if (system_info == nullptr)
+        return false;
+
+    const nlohmann::json* product_info = find_object(*system_info, "product_info");
+    if (product_info == nullptr)
+        return false;
+
+    std::string              model = get_string(*product_info, "machine_type");
+    std::vector<std::string> nozzles;
+    std::string              name = get_string(*product_info, "device_name");
+    if (product_info->contains("nozzle_diameter")) {
+        const nlohmann::json& nozzle_json = (*product_info)["nozzle_diameter"];
+        if (nozzle_json.is_array()) {
+            for (const auto& nozzle : nozzle_json)
+                append_nozzle(nozzle, nozzles);
+        } else {
+            append_nozzle(nozzle_json, nozzles);
+        }
+    }
+
+    // An answer without a machine type is not usable: callers gate on it (e.g. the
+    // "Snapmaker U1" whitelist), so treat a malformed payload as a failed query.
+    if (model.empty()) {
+        BOOST_LOG_TRIVIAL(warning) << "GatewayDevice::query_machine_info: machine.system_info returned no machine_type";
+        return false;
+    }
+
+    out_model            = std::move(model);
+    out_nozzle_diameters = std::move(nozzles);
+    device_name          = std::move(name);
+
+    return true;
+}
+
+bool GatewayDevice::is_device_connected(const std::shared_ptr<GatewayService>& gateway)
+{
+    std::string              model;
+    std::vector<std::string> nozzles;
+    std::string              name;
+    return query_machine_info(gateway, model, nozzles, name);
+}
+
+}} // namespace Slic3r::Gateway

--- a/src/slic3r/Utils/GatewayDevice.hpp
+++ b/src/slic3r/Utils/GatewayDevice.hpp
@@ -1,0 +1,32 @@
+#ifndef slic3r_Utils_GatewayDevice_hpp_
+#define slic3r_Utils_GatewayDevice_hpp_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Slic3r { namespace Gateway {
+
+class GatewayService;
+
+// Device-facing queries over the connection gateway, written against the
+// snapmaker_connection API contract (WS JSON-RPC / HTTP). One method per
+// legacy SSWCP/MQTT interface as it is migrated; nothing here may call back
+// into the SSWCP/PrintHost stack.
+class GatewayDevice
+{
+public:
+    // Replacement for SSWCP::query_machine_info. Fresh values via the
+    // transparent RPC machine.system_info (result.system_info.product_info).
+    // Returns false when the gateway is down or no device is connected.
+    static bool query_machine_info(const std::shared_ptr<GatewayService>& gateway, std::string& out_model, std::vector<std::string>& out_nozzle_diameters,
+                                    std::string& device_name);
+
+    // True when a device is connected through the gateway. machine.system_info
+    // reaches the device, so a successful call proves a live device channel.
+    static bool is_device_connected(const std::shared_ptr<GatewayService>& gateway);
+};
+
+}} // namespace Slic3r::Gateway
+
+#endif // slic3r_Utils_GatewayDevice_hpp_

--- a/src/slic3r/Utils/GatewayService.cpp
+++ b/src/slic3r/Utils/GatewayService.cpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <deque>
 #include <exception>
+#include <future>
 #include <random>
 #include <stdexcept>
 #include <utility>
@@ -494,6 +495,39 @@ std::int64_t GatewayService::send_request(const std::string& method, const nlohm
     return id;
 }
 
+GatewayService::ApiResult GatewayService::request_sync(const std::string& method, const nlohmann::json& params, std::chrono::milliseconds timeout)
+{
+    ApiResult result;
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        if (stop_requested_ || state_ != ConnectionState::Connected || !websocket_open_) {
+            result.error = {GatewayErrorCode::NotConnected, "gateway websocket is not connected"};
+            return result;
+        }
+    }
+
+    auto               response = std::make_shared<std::promise<ApiResult>>();
+    std::future<ApiResult> future = response->get_future();
+    const std::int64_t     id     = next_request_id();
+    {
+        std::lock_guard<std::mutex> lock(pending_mutex_);
+        pending_requests_.emplace(id, PendingRequest{[response](GatewayError error, const nlohmann::json& value) { response->set_value(ApiResult{error, value}); }, true});
+    }
+    if (!dependencies_.websocket->send(build_jsonrpc_request(id, method, params).dump())) {
+        std::lock_guard<std::mutex> lock(pending_mutex_);
+        pending_requests_.erase(id);
+        result.error = {GatewayErrorCode::TransportError, "failed to queue websocket request"};
+        return result;
+    }
+    if (future.wait_for(timeout) != std::future_status::ready) {
+        std::lock_guard<std::mutex> lock(pending_mutex_);
+        pending_requests_.erase(id);
+        result.error = {GatewayErrorCode::TransportError, "request timed out"};
+        return result;
+    }
+    return future.get();
+}
+
 std::int64_t GatewayService::watch_device(const nlohmann::json& params, RpcCallback callback)
 { return request("action.device.watch", params.is_null() ? nlohmann::json::object() : params, std::move(callback)); }
 
@@ -713,8 +747,12 @@ void GatewayService::complete_pending(std::int64_t id, GatewayError error, const
         request = std::move(pending->second);
         pending_requests_.erase(pending);
     }
-    if (request.callback)
-        dependencies_.dispatcher([callback = std::move(request.callback), error, result]() mutable { callback(error, result); });
+    if (request.callback) {
+        if (request.direct_invoke)
+            request.callback(error, result);
+        else
+            dependencies_.dispatcher([callback = std::move(request.callback), error, result]() mutable { callback(error, result); });
+    }
 }
 
 void GatewayService::fail_pending(const GatewayError& error)
@@ -725,10 +763,13 @@ void GatewayService::fail_pending(const GatewayError& error)
         requests.swap(pending_requests_);
     }
     for (auto& item : requests) {
-        if (item.second.callback) {
+        if (!item.second.callback)
+            continue;
+        if (item.second.direct_invoke)
+            item.second.callback(error, nlohmann::json::object());
+        else
             dependencies_.dispatcher(
                 [callback = std::move(item.second.callback), error]() mutable { callback(error, nlohmann::json::object()); });
-        }
     }
 }
 

--- a/src/slic3r/Utils/GatewayService.hpp
+++ b/src/slic3r/Utils/GatewayService.hpp
@@ -138,6 +138,10 @@ public:
     void clear_notification_handler(const std::string& method);
 
     std::int64_t request(const std::string& method, const nlohmann::json& params, RpcCallback callback);
+    // Synchronous request. The callback is invoked directly on the websocket thread (bypassing
+    // the dispatcher), so this is safe from any thread except the gateway's own websocket I/O
+    // thread: waiting there would block the only thread that can deliver the response.
+    ApiResult    request_sync(const std::string& method, const nlohmann::json& params, std::chrono::milliseconds timeout);
     std::int64_t watch_device(const nlohmann::json& params, RpcCallback callback);
     ApiResult    get_device(const std::optional<std::string>& serial_number = std::nullopt);
     ApiResult    get_account();
@@ -149,6 +153,7 @@ private:
     struct PendingRequest
     {
         RpcCallback callback;
+        bool        direct_invoke{false}; // complete on the websocket thread instead of the dispatcher
     };
 
     void         run(const std::string locale);

--- a/tests/slic3rutils/CMakeLists.txt
+++ b/tests/slic3rutils/CMakeLists.txt
@@ -14,9 +14,11 @@ add_executable(gateway_tests
     ConnectionProcessManager_test.cpp
     GatewayProtocol_test.cpp
     GatewayService_test.cpp
+    GatewayDevice_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/slic3r/Utils/ConnectionProcessManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/slic3r/Utils/GatewayProtocol.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/slic3r/Utils/GatewayService.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/slic3r/Utils/GatewayDevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/slic3r/Utils/Http.cpp
     )
 target_link_libraries(gateway_tests test_common libslic3r boost_libs libcurl OpenSSL::SSL OpenSSL::Crypto)

--- a/tests/slic3rutils/GatewayDevice_test.cpp
+++ b/tests/slic3rutils/GatewayDevice_test.cpp
@@ -1,0 +1,182 @@
+#include <catch2/catch.hpp>
+
+#include "slic3r/Utils/GatewayDevice.hpp"
+#include "slic3r/Utils/GatewayService.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace Slic3r::Gateway;
+
+namespace {
+
+struct DeviceFakeHttp final : public HttpTransport
+{
+    HttpResponse get(const std::string& url) override
+    {
+        if (url.find("/health") != std::string::npos) {
+            return {200,
+                    R"({"status":"ok","cli_version":"1.0","components":{"ipc_server":"ok","web_server":"ok"},)"
+                    R"("server_url":{"base_url":"http://127.0.0.1:8080/","home_page":"/index","device_control":""}})",
+                    {}};
+        }
+        return {404, {}, "not found"};
+    }
+
+    HttpResponse post_json(const std::string& url, const std::string& body) override { return {404, {}, "not found"}; }
+};
+
+// Answers machine.system_info with a canned payload (or a -32000 error frame).
+struct DeviceFakeWebSocket final : public WebSocketTransport
+{
+    Listener          listener;
+    nlohmann::json    system_info_payload{nlohmann::json::object()};
+    bool              answer_with_error{false};
+    std::atomic<bool> machine_info_seen{false};
+
+    void set_listener(Listener value) override { listener = std::move(value); }
+
+    void connect(std::uint16_t port, const std::string& path) override { listener.opened(); }
+
+    bool send(const std::string& message) override
+    {
+        const nlohmann::json request = nlohmann::json::parse(message);
+        if (request.value("method", "") != "machine.system_info")
+            return true;
+        machine_info_seen = true;
+        if (answer_with_error) {
+            listener.message(nlohmann::json{{"jsonrpc", "2.0"}, {"id", request["id"]}, {"error", {{"code", -32000}, {"message", "not_connected"}}}}.dump());
+        } else {
+            listener.message(nlohmann::json{{"jsonrpc", "2.0"}, {"id", request["id"]}, {"result", {{"system_info", system_info_payload}}}}.dump());
+        }
+        return true;
+    }
+
+    void close() override
+    {
+        if (listener.closed)
+            listener.closed("closed");
+    }
+};
+
+bool wait_for_state(const GatewayService& service, ConnectionState expected)
+{
+    for (int i = 0; i < 2000; ++i) {
+        if (service.state() == expected)
+            return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds{1});
+    }
+    return service.state() == expected;
+}
+
+struct ServiceFixture
+{
+    std::shared_ptr<ConnectionProcessManager> process;
+    std::shared_ptr<DeviceFakeWebSocket>      websocket;
+    std::shared_ptr<GatewayService>           service;
+
+    ServiceFixture()
+    {
+        process = std::make_shared<ConnectionProcessManager>(ConnectionProcessManager::Config{boost::filesystem::path{"snapmaker_connection.exe"}},
+                                                             [](const std::vector<std::string>&) {
+                                                                 ConnectionProcessManager::ProcessRunResult result;
+                                                                 result.stdout_data = "PORT:8888\r\n\r\n";
+                                                                 return result;
+                                                             });
+        GatewayService::Dependencies dependencies;
+        dependencies.process_manager = process;
+        dependencies.http            = std::make_shared<DeviceFakeHttp>();
+        websocket                    = std::make_shared<DeviceFakeWebSocket>();
+        dependencies.websocket       = websocket;
+        dependencies.dispatcher      = [](std::function<void()> task) { task(); };
+        service                      = std::make_shared<GatewayService>(GatewayService::Config{}, std::move(dependencies));
+        if (!service->start("zh-CN"))
+            return;
+        wait_for_state(*service, ConnectionState::Connected);
+    }
+
+    ~ServiceFixture() { service->stop(); }
+};
+
+const nlohmann::json valid_system_info{
+    {"system_info", {{"product_info", {{"machine_type", "Snapmaker U1"},
+                                       {"nozzle_diameter", {0.4, 0.4, 0.25, "0.8", 0.6}},
+                                       {"device_name", "qiepian-6"},
+                                       {"serial_number", "SN1"}}}}}};
+
+} // namespace
+
+TEST_CASE("GatewayDevice query_machine_info parses product_info", "[gateway][device]")
+{
+    ServiceFixture fixture;
+    REQUIRE(fixture.service->is_connected());
+    fixture.websocket->system_info_payload = valid_system_info["system_info"];
+
+    std::string              model;
+    std::vector<std::string> nozzles;
+    std::string              name;
+    REQUIRE(GatewayDevice::query_machine_info(fixture.service, model, nozzles, name));
+    REQUIRE(model == "Snapmaker U1");
+    REQUIRE(name == "qiepian-6");
+    // 0.25 is not a supported preset label and is dropped by design; "0.8" as a string is accepted.
+    REQUIRE(nozzles == std::vector<std::string>{"0.4", "0.4", "0.8", "0.6"});
+    REQUIRE(GatewayDevice::is_device_connected(fixture.service));
+}
+
+TEST_CASE("GatewayDevice query_machine_info rejects malformed payloads", "[gateway][device]")
+{
+    ServiceFixture fixture;
+    REQUIRE(fixture.service->is_connected());
+
+    SECTION("empty machine_type")
+    {
+        fixture.websocket->system_info_payload = {{"product_info", {{"machine_type", ""}, {"device_name", "x"}}}};
+    }
+    SECTION("missing product_info")
+    {
+        fixture.websocket->system_info_payload = nlohmann::json::object();
+    }
+    SECTION("missing machine_type key")
+    {
+        fixture.websocket->system_info_payload = {{"product_info", {{"device_name", "x"}}}};
+    }
+
+    std::string              model = "untouched";
+    std::vector<std::string> nozzles{"untouched"};
+    std::string              name  = "untouched";
+    REQUIRE_FALSE(GatewayDevice::query_machine_info(fixture.service, model, nozzles, name));
+    REQUIRE_FALSE(GatewayDevice::is_device_connected(fixture.service));
+    // Outputs are not modified on failure.
+    REQUIRE(model == "untouched");
+    REQUIRE(nozzles == std::vector<std::string>{"untouched"});
+    REQUIRE(name == "untouched");
+}
+
+TEST_CASE("GatewayDevice query_machine_info reports rpc not_connected", "[gateway][device]")
+{
+    ServiceFixture fixture;
+    REQUIRE(fixture.service->is_connected());
+    fixture.websocket->answer_with_error = true;
+
+    std::string              model;
+    std::vector<std::string> nozzles;
+    std::string              name;
+    REQUIRE_FALSE(GatewayDevice::query_machine_info(fixture.service, model, nozzles, name));
+    REQUIRE_FALSE(GatewayDevice::is_device_connected(fixture.service));
+}
+
+TEST_CASE("GatewayDevice tolerates a null gateway", "[gateway][device]")
+{
+    std::string              model;
+    std::vector<std::string> nozzles;
+    std::string              name;
+    REQUIRE_FALSE(GatewayDevice::query_machine_info(nullptr, model, nozzles, name));
+    REQUIRE_FALSE(GatewayDevice::is_device_connected(nullptr));
+}

--- a/tests/slic3rutils/GatewayService_test.cpp
+++ b/tests/slic3rutils/GatewayService_test.cpp
@@ -77,7 +77,10 @@ struct FakeWebSocket final : public WebSocketTransport
         const nlohmann::json request = nlohmann::json::parse(message);
         if (request.value("method", "") == "action.device.watch") {
             listener.message(nlohmann::json{{"jsonrpc", "2.0"}, {"id", request["id"]}, {"result", {{"watching", true}}}}.dump());
+        } else if (request.value("method", "") == "sync.echo") {
+            listener.message(nlohmann::json{{"jsonrpc", "2.0"}, {"id", request["id"]}, {"result", {{"echoed", true}}}}.dump());
         }
+        // "sync.silent" intentionally gets no response (timeout / failure scenarios).
         return true;
     }
 
@@ -240,4 +243,103 @@ TEST_CASE("GatewayService bounded wait fails when the gateway cannot start", "[g
     REQUIRE_FALSE(service.wait_for_connected(std::chrono::milliseconds{20}));
     REQUIRE(service.localfile_url("a.gcode").empty());
     service.stop();
+}
+
+TEST_CASE("request_sync returns the rpc result", "[gateway][service][sync]")
+{
+    std::shared_ptr<ConnectionProcessManager> process;
+    std::shared_ptr<FakeHttp>                 http;
+    std::shared_ptr<FakeWebSocket>            websocket;
+    GatewayService                            service(GatewayService::Config{}, make_dependencies(process, http, websocket));
+
+    REQUIRE(service.start("zh-CN"));
+    REQUIRE(wait_for_state(service, ConnectionState::Connected));
+
+    const auto result = service.request_sync("sync.echo", nlohmann::json::object(), std::chrono::milliseconds{1000});
+    REQUIRE_FALSE(result.error);
+    REQUIRE(result.value.at("echoed") == true);
+
+    service.stop();
+}
+
+TEST_CASE("request_sync times out when nothing answers", "[gateway][service][sync]")
+{
+    std::shared_ptr<ConnectionProcessManager> process;
+    std::shared_ptr<FakeHttp>                 http;
+    std::shared_ptr<FakeWebSocket>            websocket;
+    GatewayService                            service(GatewayService::Config{}, make_dependencies(process, http, websocket));
+
+    REQUIRE(service.start("zh-CN"));
+    REQUIRE(wait_for_state(service, ConnectionState::Connected));
+
+    const auto start  = std::chrono::steady_clock::now();
+    const auto result = service.request_sync("sync.silent", nlohmann::json::object(), std::chrono::milliseconds{200});
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    REQUIRE(result.error);
+    REQUIRE(result.error.code == GatewayErrorCode::TransportError);
+    REQUIRE(result.error.message.find("timed out") != std::string::npos);
+    REQUIRE(elapsed < std::chrono::seconds{2});
+
+    service.stop();
+}
+
+TEST_CASE("request_sync fails fast when the websocket drops while waiting", "[gateway][service][sync]")
+{
+    std::shared_ptr<ConnectionProcessManager> process;
+    std::shared_ptr<FakeHttp>                 http;
+    std::shared_ptr<FakeWebSocket>            websocket;
+    GatewayService                            service(GatewayService::Config{}, make_dependencies(process, http, websocket));
+
+    REQUIRE(service.start("zh-CN"));
+    REQUIRE(wait_for_state(service, ConnectionState::Connected));
+
+    std::atomic<int>          error_code{-1};
+    std::atomic<long long>    elapsed_ms{0};
+    std::thread               caller([&] {
+        const auto start  = std::chrono::steady_clock::now();
+        const auto result = service.request_sync("sync.silent", nlohmann::json::object(), std::chrono::milliseconds{10000});
+        const auto end    = std::chrono::steady_clock::now();
+        elapsed_ms        = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+        if (result.error)
+            error_code = static_cast<int>(result.error.code);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    websocket->close(); // fail_pending must complete the sync request directly, not via the dispatcher
+
+    caller.join();
+    REQUIRE(error_code.load() == static_cast<int>(GatewayErrorCode::NotConnected));
+    REQUIRE(elapsed_ms.load() < 3000); // nowhere near the 10 s timeout
+
+    service.stop();
+}
+
+TEST_CASE("request_sync fails fast when the service stops while waiting", "[gateway][service][sync]")
+{
+    std::shared_ptr<ConnectionProcessManager> process;
+    std::shared_ptr<FakeHttp>                 http;
+    std::shared_ptr<FakeWebSocket>            websocket;
+    GatewayService                            service(GatewayService::Config{}, make_dependencies(process, http, websocket));
+
+    REQUIRE(service.start("zh-CN"));
+    REQUIRE(wait_for_state(service, ConnectionState::Connected));
+
+    std::atomic<int>       error_code{-1};
+    std::atomic<long long> elapsed_ms{0};
+    std::thread            caller([&] {
+        const auto start  = std::chrono::steady_clock::now();
+        const auto result = service.request_sync("sync.silent", nlohmann::json::object(), std::chrono::milliseconds{10000});
+        const auto end    = std::chrono::steady_clock::now();
+        elapsed_ms        = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+        if (result.error)
+            error_code = static_cast<int>(result.error.code);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    service.stop(); // fail_pending must complete the sync request directly, not via the dispatcher
+
+    caller.join();
+    const int code = error_code.load();
+    REQUIRE((code == static_cast<int>(GatewayErrorCode::NotConnected) || code == static_cast<int>(GatewayErrorCode::Cancelled)));
+    REQUIRE(elapsed_ms.load() < 3000); // nowhere near the 10 s timeout
 }


### PR DESCRIPTION
- New Utils/GatewayDevice: device-facing queries per the snapmaker_connection API contract (WS machine.system_info), no SSWCP/PrintHost dependency; home for future interface migrations
- GatewayService: add request_sync() synchronous JSON-RPC whose callback completes on the websocket thread, safe from any thread including the UI thread
- GUI_App: m_gateway_service now shared_ptr, gateway_service() accessor
- Plater: nozzle-sync and filament-sync entry points query machine info via the gateway and accept a gateway-connected device in their guards
- SSWCP untouched: the legacy connect flow keeps SSWCP::query_machine_info
