### PR TITLE
fix(gui): remember auto-gradient choice per project

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -322,6 +322,10 @@ void AppConfig::set_defaults()
         set_bool("auto_generate_gradients", false);
     }
 
+    if (get("auto_generate_gradients_without_confirmation").empty()) {
+        set_bool("auto_generate_gradients_without_confirmation", false);
+    }
+
     if (get("show_home_page").empty()) {
         set_bool("show_home_page", true);
     }

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -322,10 +322,6 @@ void AppConfig::set_defaults()
         set_bool("auto_generate_gradients", false);
     }
 
-    if (get("auto_generate_gradients_without_confirmation").empty()) {
-        set_bool("auto_generate_gradients_without_confirmation", false);
-    }
-
     if (get("show_home_page").empty()) {
         set_bool("show_home_page", true);
     }

--- a/src/libslic3r/MixedFilament.hpp
+++ b/src/libslic3r/MixedFilament.hpp
@@ -16,6 +16,19 @@ class PrintObject;
 
 std::vector<int> fill_continuous_layer_range(const std::vector<int> &sorted_layers);
 
+enum class MixedFilamentAutoGradientAction : uint8_t { Disable, Generate, Confirm };
+
+constexpr MixedFilamentAutoGradientAction mixed_filament_auto_gradient_action(bool   auto_generate_enabled,
+                                                                              bool   without_confirmation,
+                                                                              size_t num_physical)
+{
+    if (!auto_generate_enabled)
+        return MixedFilamentAutoGradientAction::Disable;
+    if (without_confirmation || num_physical <= 4)
+        return MixedFilamentAutoGradientAction::Generate;
+    return MixedFilamentAutoGradientAction::Confirm;
+}
+
 // Represents a virtual "mixed" filament created from physical filaments
 // (layer cadence and/or same-layer interleaved stripe distribution). Display
 // colour blending uses FilamentMixer  so pair previews better

--- a/src/libslic3r/MixedFilament.hpp
+++ b/src/libslic3r/MixedFilament.hpp
@@ -17,15 +17,23 @@ class PrintObject;
 std::vector<int> fill_continuous_layer_range(const std::vector<int> &sorted_layers);
 
 enum class MixedFilamentAutoGradientAction : uint8_t { Disable, Generate, Confirm };
+enum class MixedFilamentAutoGradientChoice : int8_t { Ask = -1, DoNotGenerate = 0, Generate = 1 };
 
 constexpr MixedFilamentAutoGradientAction mixed_filament_auto_gradient_action(bool   auto_generate_enabled,
-                                                                              bool   without_confirmation,
+                                                                              MixedFilamentAutoGradientChoice remembered_choice,
+                                                                              size_t remembered_physical_count,
                                                                               size_t num_physical)
 {
     if (!auto_generate_enabled)
         return MixedFilamentAutoGradientAction::Disable;
-    if (without_confirmation || num_physical <= 4)
+    if (num_physical <= 4)
         return MixedFilamentAutoGradientAction::Generate;
+    if (remembered_physical_count == num_physical) {
+        if (remembered_choice == MixedFilamentAutoGradientChoice::Generate)
+            return MixedFilamentAutoGradientAction::Generate;
+        if (remembered_choice == MixedFilamentAutoGradientChoice::DoNotGenerate)
+            return MixedFilamentAutoGradientAction::Disable;
+    }
     return MixedFilamentAutoGradientAction::Confirm;
 }
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -3017,7 +3017,12 @@ inline t_config_option_keys deep_diff(const ConfigBase &config_this, const Confi
 
 static constexpr const std::initializer_list<const char*> optional_keys { "compatible_prints", "compatible_printers" };
 //BBS: skip these keys for dirty check
-static std::set<std::string> skipped_in_dirty = {"printer_settings_id", "print_settings_id", "filament_settings_id", "mixed_filament_definitions"};
+static std::set<std::string> skipped_in_dirty = {"printer_settings_id",
+                                                 "print_settings_id",
+                                                 "filament_settings_id",
+                                                 "mixed_filament_definitions",
+                                                 "mixed_filament_auto_gradient_choice",
+                                                 "mixed_filament_auto_gradient_physical_count"};
 
 bool PresetCollection::is_dirty(const Preset *edited, const Preset *reference)
 {

--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -223,6 +223,8 @@ static std::vector<std::string> s_project_options {
     "mixed_filament_surface_indentation",
     "mixed_filament_region_collapse",
     "mixed_filament_definitions",
+    "mixed_filament_auto_gradient_choice",
+    "mixed_filament_auto_gradient_physical_count",
     "mixed_color_layer_height_a",
     "mixed_color_layer_height_b",
     "dithering_z_step_size",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4421,6 +4421,24 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionString(""));
 
+    def = this->add("mixed_filament_auto_gradient_choice", coInt);
+    def->label = L("Remembered auto-gradient choice");
+    def->tooltip = L("Project-specific remembered response to the large auto-gradient confirmation.");
+    def->gui_flags = "serialized";
+    def->min = -1;
+    def->max = 1;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionInt(-1));
+
+    def = this->add("mixed_filament_auto_gradient_physical_count", coInt);
+    def->label = L("Remembered auto-gradient physical filament count");
+    def->tooltip = L("Physical filament count for which the project-specific auto-gradient response was remembered.");
+    def->gui_flags = "serialized";
+    def->min = 0;
+    def->max = MAXIMUM_FILAMENT_NUMBER;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionInt(0));
+
     def = this->add("dithering_z_step_size", coFloat);
     def->label = L("Dithering Z step size");
     def->category = L("Others");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1438,6 +1438,8 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloat,              mixed_filament_surface_indentation))
     ((ConfigOptionBool,               mixed_filament_region_collapse))
     ((ConfigOptionString,             mixed_filament_definitions))
+    ((ConfigOptionInt,                mixed_filament_auto_gradient_choice))
+    ((ConfigOptionInt,                mixed_filament_auto_gradient_physical_count))
     ((ConfigOptionFloat,              dithering_z_step_size))
     ((ConfigOptionBool,               dithering_local_z_mode))
     ((ConfigOptionBool,               dithering_local_z_whole_objects))

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -6628,7 +6628,9 @@ void GUI_App::load_current_presets(bool active_preset_combox/*= false*/, bool ch
             "dithering_step_painted_zones_only",
             "mixed_filament_pointillism_pixel_size",
             "mixed_filament_pointillism_line_gap",
-            "mixed_filament_definitions"
+            "mixed_filament_definitions",
+            "mixed_filament_auto_gradient_choice",
+            "mixed_filament_auto_gradient_physical_count"
         };
 
         // Keep the Mixed Filaments sidebar state in sync when presets are reloaded

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -15850,15 +15850,18 @@ bool Plater::priv::confirm_auto_generated_gradients(wxWindow *parent, size_t num
     if (app_config == nullptr)
         return MixedFilamentManager::auto_generate_enabled();
 
-    const bool pref_enabled = app_config->get_bool("auto_generate_gradients");
-    if (!pref_enabled) {
+    const bool auto_generate_enabled = app_config->get_bool("auto_generate_gradients");
+    const bool without_confirmation  = app_config->get_bool("auto_generate_gradients_without_confirmation");
+    const MixedFilamentAutoGradientAction action =
+        mixed_filament_auto_gradient_action(auto_generate_enabled, without_confirmation, num_physical);
+    if (action == MixedFilamentAutoGradientAction::Disable) {
         m_last_auto_gradient_prompt_physical_count = 0;
         m_last_auto_gradient_prompt_accepted = false;
         MixedFilamentManager::set_auto_generate_enabled(false);
         return false;
     }
 
-    if (num_physical <= 4) {
+    if (action == MixedFilamentAutoGradientAction::Generate) {
         m_last_auto_gradient_prompt_physical_count = 0;
         m_last_auto_gradient_prompt_accepted = false;
         MixedFilamentManager::set_auto_generate_enabled(true);
@@ -15882,12 +15885,15 @@ bool Plater::priv::confirm_auto_generated_gradients(wxWindow *parent, size_t num
         _L("Using %d physical filaments will create %d auto-generated gradients.\nDo you want to create them now?"),
         int(num_physical),
         int(auto_gradient_count));
-    const int result = MessageDialog(parent,
-                                     message,
-                                     wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Auto gradients"),
-                                     wxYES_NO | wxYES_DEFAULT | wxCENTRE | wxICON_QUESTION)
-                           .ShowModal();
+    MessageDialog dialog(parent, message, wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Auto gradients"),
+                         wxYES_NO | wxYES_DEFAULT | wxCENTRE | wxICON_QUESTION);
+    dialog.show_dsa_button(_L("Always create auto-generated gradients without asking"));
+    const int  result   = dialog.ShowModal();
     const bool accepted = result == wxID_YES;
+    if (accepted && dialog.get_checkbox_state()) {
+        app_config->set_bool("auto_generate_gradients_without_confirmation", true);
+        app_config->save();
+    }
     m_last_auto_gradient_prompt_physical_count = num_physical;
     m_last_auto_gradient_prompt_accepted = accepted;
     MixedFilamentManager::set_auto_generate_enabled(accepted);
@@ -24668,5 +24674,4 @@ SuppressBackgroundProcessingUpdate::~SuppressBackgroundProcessingUpdate()
 }
 
 }}    // namespace Slic3r::GUI
-
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10151,6 +10151,7 @@ struct Plater::priv
     bool m_is_dark = false;
     size_t m_last_auto_gradient_prompt_physical_count = 0;
     bool   m_last_auto_gradient_prompt_accepted = false;
+    bool   m_auto_gradient_project_choice_changed_during_load = false;
 
     priv(Plater *q, MainFrame *main_frame);
     ~priv();
@@ -15851,9 +15852,24 @@ bool Plater::priv::confirm_auto_generated_gradients(wxWindow *parent, size_t num
         return MixedFilamentManager::auto_generate_enabled();
 
     const bool auto_generate_enabled = app_config->get_bool("auto_generate_gradients");
-    const bool without_confirmation  = app_config->get_bool("auto_generate_gradients_without_confirmation");
+    MixedFilamentAutoGradientChoice remembered_choice = MixedFilamentAutoGradientChoice::Ask;
+    size_t remembered_physical_count = 0;
+    PresetBundle *preset_bundle = wxGetApp().preset_bundle;
+    if (preset_bundle != nullptr) {
+        const DynamicPrintConfig &project_config = preset_bundle->project_config;
+        if (const ConfigOptionInt *choice_opt = project_config.option<ConfigOptionInt>("mixed_filament_auto_gradient_choice")) {
+            if (choice_opt->value == int(MixedFilamentAutoGradientChoice::Generate))
+                remembered_choice = MixedFilamentAutoGradientChoice::Generate;
+            else if (choice_opt->value == int(MixedFilamentAutoGradientChoice::DoNotGenerate))
+                remembered_choice = MixedFilamentAutoGradientChoice::DoNotGenerate;
+        }
+        if (const ConfigOptionInt *count_opt = project_config.option<ConfigOptionInt>("mixed_filament_auto_gradient_physical_count");
+            count_opt != nullptr && count_opt->value > 0) {
+            remembered_physical_count = size_t(count_opt->value);
+        }
+    }
     const MixedFilamentAutoGradientAction action =
-        mixed_filament_auto_gradient_action(auto_generate_enabled, without_confirmation, num_physical);
+        mixed_filament_auto_gradient_action(auto_generate_enabled, remembered_choice, remembered_physical_count, num_physical);
     if (action == MixedFilamentAutoGradientAction::Disable) {
         m_last_auto_gradient_prompt_physical_count = 0;
         m_last_auto_gradient_prompt_accepted = false;
@@ -15887,12 +15903,18 @@ bool Plater::priv::confirm_auto_generated_gradients(wxWindow *parent, size_t num
         int(auto_gradient_count));
     MessageDialog dialog(parent, message, wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Auto gradients"),
                          wxYES_NO | wxYES_DEFAULT | wxCENTRE | wxICON_QUESTION);
-    dialog.show_dsa_button(_L("Always create auto-generated gradients without asking"));
+    dialog.show_dsa_button(_L("Remember this choice for this project"));
     const int  result   = dialog.ShowModal();
     const bool accepted = result == wxID_YES;
-    if (accepted && dialog.get_checkbox_state()) {
-        app_config->set_bool("auto_generate_gradients_without_confirmation", true);
-        app_config->save();
+    if (dialog.get_checkbox_state() && preset_bundle != nullptr) {
+        DynamicPrintConfig &project_config = preset_bundle->project_config;
+        project_config.option<ConfigOptionInt>("mixed_filament_auto_gradient_choice", true)->value =
+            int(accepted ? MixedFilamentAutoGradientChoice::Generate : MixedFilamentAutoGradientChoice::DoNotGenerate);
+        project_config.option<ConfigOptionInt>("mixed_filament_auto_gradient_physical_count", true)->value = int(num_physical);
+        if (q->is_loading_project())
+            m_auto_gradient_project_choice_changed_during_load = true;
+        else
+            q->update_project_dirty_from_presets();
     }
     m_last_auto_gradient_prompt_physical_count = num_physical;
     m_last_auto_gradient_prompt_accepted = accepted;
@@ -17570,6 +17592,9 @@ void Plater::load_project(wxString const& filename2,
     }
     else
         m_loading_project = true;
+    p->m_last_auto_gradient_prompt_physical_count = 0;
+    p->m_last_auto_gradient_prompt_accepted = false;
+    p->m_auto_gradient_project_choice_changed_during_load = false;
 
     m_only_gcode = false;
     m_exported_file = false;
@@ -17658,6 +17683,11 @@ void Plater::load_project(wxString const& filename2,
     up_to_date(true, true);
 
     wxGetApp().params_panel()->switch_to_object_if_has_object_configs();
+
+    if (p->m_auto_gradient_project_choice_changed_during_load) {
+        p->m_auto_gradient_project_choice_changed_during_load = false;
+        p->set_plater_dirty(true);
+    }
 
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << __LINE__ << " load project done";
     m_loading_project = false;
@@ -24674,4 +24704,3 @@ SuppressBackgroundProcessingUpdate::~SuppressBackgroundProcessingUpdate()
 }
 
 }}    // namespace Slic3r::GUI
-

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -17592,8 +17592,6 @@ void Plater::load_project(wxString const& filename2,
     }
     else
         m_loading_project = true;
-    p->m_last_auto_gradient_prompt_physical_count = 0;
-    p->m_last_auto_gradient_prompt_accepted = false;
     p->m_auto_gradient_project_choice_changed_during_load = false;
 
     m_only_gcode = false;
@@ -17624,6 +17622,10 @@ void Plater::load_project(wxString const& filename2,
         }
     }
     bool load_restore = strategy & LoadStrategy::Restore;
+    if (strategy & LoadStrategy::LoadConfig) {
+        p->m_last_auto_gradient_prompt_physical_count = 0;
+        p->m_last_auto_gradient_prompt_accepted = false;
+    }
 
     // Take the Undo / Redo snapshot.
     reset();

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -3,6 +3,7 @@
 #include "test_utils.hpp"
 #include "libslic3r/ExtrusionEntity.hpp"
 #include "libslic3r/FilamentColorLibrary.hpp"
+#include "libslic3r/MixedFilament.hpp"
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/Print.hpp"
 #include "libslic3r/GCode/ToolOrdering.hpp"
@@ -409,6 +410,27 @@ TEST_CASE("Mixed filament auto generation can be disabled without dropping custo
     MixedFilamentManager loaded;
     loaded.load_custom_entries(serialized_auto_rows, colors);
     CHECK(loaded.mixed_filaments().empty());
+}
+
+TEST_CASE("Auto-gradient policy disables generation when the feature is off", "[MixedFilament][AutoGradientPolicy]")
+{
+    CHECK(mixed_filament_auto_gradient_action(false, false, 7) == MixedFilamentAutoGradientAction::Disable);
+    CHECK(mixed_filament_auto_gradient_action(false, true, 7) == MixedFilamentAutoGradientAction::Disable);
+}
+
+TEST_CASE("Auto-gradient policy generates small sets without confirmation", "[MixedFilament][AutoGradientPolicy]")
+{
+    CHECK(mixed_filament_auto_gradient_action(true, false, 4) == MixedFilamentAutoGradientAction::Generate);
+}
+
+TEST_CASE("Auto-gradient policy asks before generating a large set by default", "[MixedFilament][AutoGradientPolicy]")
+{
+    CHECK(mixed_filament_auto_gradient_action(true, false, 5) == MixedFilamentAutoGradientAction::Confirm);
+}
+
+TEST_CASE("Auto-gradient policy honors the persistent confirmation opt-out", "[MixedFilament][AutoGradientPolicy]")
+{
+    CHECK(mixed_filament_auto_gradient_action(true, true, 7) == MixedFilamentAutoGradientAction::Generate);
 }
 
 TEST_CASE("Mixed filament perimeter resolver uses grouped manual patterns by inset", "[MixedFilament]")

--- a/tests/libslic3r/test_mixed_filament.cpp
+++ b/tests/libslic3r/test_mixed_filament.cpp
@@ -414,23 +414,60 @@ TEST_CASE("Mixed filament auto generation can be disabled without dropping custo
 
 TEST_CASE("Auto-gradient policy disables generation when the feature is off", "[MixedFilament][AutoGradientPolicy]")
 {
-    CHECK(mixed_filament_auto_gradient_action(false, false, 7) == MixedFilamentAutoGradientAction::Disable);
-    CHECK(mixed_filament_auto_gradient_action(false, true, 7) == MixedFilamentAutoGradientAction::Disable);
+    CHECK(mixed_filament_auto_gradient_action(false, MixedFilamentAutoGradientChoice::Ask, 0, 7) ==
+          MixedFilamentAutoGradientAction::Disable);
+    CHECK(mixed_filament_auto_gradient_action(false, MixedFilamentAutoGradientChoice::Generate, 7, 7) ==
+          MixedFilamentAutoGradientAction::Disable);
 }
 
 TEST_CASE("Auto-gradient policy generates small sets without confirmation", "[MixedFilament][AutoGradientPolicy]")
 {
-    CHECK(mixed_filament_auto_gradient_action(true, false, 4) == MixedFilamentAutoGradientAction::Generate);
+    CHECK(mixed_filament_auto_gradient_action(true, MixedFilamentAutoGradientChoice::Ask, 0, 4) ==
+          MixedFilamentAutoGradientAction::Generate);
 }
 
 TEST_CASE("Auto-gradient policy asks before generating a large set by default", "[MixedFilament][AutoGradientPolicy]")
 {
-    CHECK(mixed_filament_auto_gradient_action(true, false, 5) == MixedFilamentAutoGradientAction::Confirm);
+    CHECK(mixed_filament_auto_gradient_action(true, MixedFilamentAutoGradientChoice::Ask, 0, 5) ==
+          MixedFilamentAutoGradientAction::Confirm);
 }
 
-TEST_CASE("Auto-gradient policy honors the persistent confirmation opt-out", "[MixedFilament][AutoGradientPolicy]")
+TEST_CASE("Auto-gradient policy remembers an accepted choice for the same project filament count", "[MixedFilament][AutoGradientPolicy]")
 {
-    CHECK(mixed_filament_auto_gradient_action(true, true, 7) == MixedFilamentAutoGradientAction::Generate);
+    CHECK(mixed_filament_auto_gradient_action(true, MixedFilamentAutoGradientChoice::Generate, 7, 7) ==
+          MixedFilamentAutoGradientAction::Generate);
+}
+
+TEST_CASE("Auto-gradient policy remembers a declined choice for the same project filament count", "[MixedFilament][AutoGradientPolicy]")
+{
+    CHECK(mixed_filament_auto_gradient_action(true, MixedFilamentAutoGradientChoice::DoNotGenerate, 7, 7) ==
+          MixedFilamentAutoGradientAction::Disable);
+}
+
+TEST_CASE("Auto-gradient policy asks again when the project filament count changes", "[MixedFilament][AutoGradientPolicy]")
+{
+    CHECK(mixed_filament_auto_gradient_action(true, MixedFilamentAutoGradientChoice::Generate, 7, 8) ==
+          MixedFilamentAutoGradientAction::Confirm);
+    CHECK(mixed_filament_auto_gradient_action(true, MixedFilamentAutoGradientChoice::DoNotGenerate, 7, 8) ==
+          MixedFilamentAutoGradientAction::Confirm);
+}
+
+TEST_CASE("Auto-gradient remembered choice is stored in project configuration", "[MixedFilament][AutoGradientPolicy][Config]")
+{
+    PresetBundle bundle;
+    REQUIRE(bundle.project_config.has("mixed_filament_auto_gradient_choice"));
+    REQUIRE(bundle.project_config.has("mixed_filament_auto_gradient_physical_count"));
+    CHECK(bundle.project_config.opt_int("mixed_filament_auto_gradient_choice") == int(MixedFilamentAutoGradientChoice::Ask));
+    CHECK(bundle.project_config.opt_int("mixed_filament_auto_gradient_physical_count") == 0);
+
+    bundle.project_config.set_key_value(
+        "mixed_filament_auto_gradient_choice", new ConfigOptionInt(int(MixedFilamentAutoGradientChoice::Generate)));
+    bundle.project_config.set_key_value("mixed_filament_auto_gradient_physical_count", new ConfigOptionInt(7));
+
+    DynamicPrintConfig full_config = DynamicPrintConfig::full_print_config();
+    full_config.apply(bundle.project_config);
+    CHECK(full_config.opt_int("mixed_filament_auto_gradient_choice") == int(MixedFilamentAutoGradientChoice::Generate));
+    CHECK(full_config.opt_int("mixed_filament_auto_gradient_physical_count") == 7);
 }
 
 TEST_CASE("Mixed filament perimeter resolver uses grouped manual patterns by inset", "[MixedFilament]")
@@ -2949,6 +2986,18 @@ TEST_CASE("mixed_filament_definitions skipped in dirty check", "[MixedFilament][
     // Simulate what happens after 3MF load: mixed_filament_definitions exists
     // in edited (from the loaded config) but not in the system preset reference.
     edited.config.set_key_value("mixed_filament_definitions", new ConfigOptionString("0,1;1,0"));
+
+    CHECK_FALSE(PresetCollection::is_dirty(&edited, &reference));
+}
+
+TEST_CASE("Auto-gradient project choice is skipped in print preset dirty check", "[MixedFilament][AutoGradientPolicy][Config]")
+{
+    Preset edited(Preset::TYPE_PRINT, "test_edited", false);
+    Preset reference(Preset::TYPE_PRINT, "test_reference", false);
+
+    edited.config.set_key_value(
+        "mixed_filament_auto_gradient_choice", new ConfigOptionInt(int(MixedFilamentAutoGradientChoice::Generate)));
+    edited.config.set_key_value("mixed_filament_auto_gradient_physical_count", new ConfigOptionInt(7));
 
     CHECK_FALSE(PresetCollection::is_dirty(&edited, &reference));
 }


### PR DESCRIPTION
# Description

## Overview - [#826](https://github.com/Snapmaker/OrcaSlicer/issues/826)

Closes #826.

The confirmation above four physical filaments is an intentional safeguard: pairwise gradients grow as `n × (n - 1) / 2`. This change keeps that safeguard and adds an explicit way to remember the answer for one project, instead of bypassing confirmation application-wide.

## Changes Made

- Add **Remember this choice for this project** to the existing Yes/No dialog.
- Store both Yes and No in project configuration together with the matching physical-filament count.
- Reuse the answer only when reopening that saved project with the same count; ask again after the count changes.
- Mark the project dirty when a choice is remembered so the user can persist it in the `.3mf`.
- Keep project-only metadata out of print-preset dirty checks.
- Reset the legacy in-session answer cache when another project is loaded, preventing one file from affecting another file with the same count.

## Preserved Safety Behavior

| Auto-generate | Physical filaments | Matching project choice | Result |
|---|---:|---|---|
| Off | Any | Any | Do not generate |
| On | 0–4 | Any | Generate without prompting |
| On | 5+ | None or different count | Ask |
| On | 5+ | Yes, same count | Generate |
| On | 5+ | No, same count | Do not generate |

# Screenshots/Recordings/Graphs

![Project-scoped auto-gradient choice](https://raw.githubusercontent.com/MoraesGil/OrcaSlicer/55d61ce1941b809f5d7ce323a5f38a280527b4a5/docs/evidence/pr-827/orca-project-auto-gradient-evidence.gif)

The recording uses an isolated macOS arm64 build and a seven-filament fixture. It shows the 7 → 21 safeguard, remembers **Yes** in the project, reopens the saved `.3mf` without prompting, then changes the physical count so the safeguard asks again for 8 → 28 gradients.

## Verification

- Focused Catch2 suite: 8 test cases, 15 assertions — passed.
- Standalone C++17 policy contract with `-Wall -Wextra -Werror` — passed, including unchanged default behavior for counts 0–32.
- macOS arm64 Release target — built successfully from the final diff.
- `git diff --check` — passed.
- Project round-trip — the saved `.3mf` contains `choice = 1` and `physical_count = 7`.
- CUA — read the checkbox back as selected before Yes, observed no Auto gradients window after reopening the saved project, then observed the exact 8 → 28 prompt after adding an eighth physical filament.
- Runtime isolation — used a temporary app bundle, isolated app data, and loopback-only networking; the installed Snapmaker Orca app was not modified.

The wider local `[MixedFilament]` run reaches an existing assertion in `PrintRegion.cpp` (`wall_filament <= num_extruders`) after 22 test cases / 142 assertions; that test and code path are unchanged by this PR. The repository's Ubuntu workflow also has a pre-existing Catch2 v2 include failure reproduced on the [exact base commit](https://github.com/MoraesGil/OrcaSlicer/actions/runs/33907671815).
