### PR TITLE
feat: center of gravity marker for every object

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -219,6 +219,10 @@ void AppConfig::set_defaults()
     if (get("show_3d_navigator").empty())
         set_bool("show_3d_navigator", true);
 
+    // per-object center of gravity markers in the preview
+    if (get("show_objects_cog").empty())
+        set_bool("show_objects_cog", false);
+
 #ifdef _WIN32
 
 //#ifdef SUPPORT_3D_CONNEXION

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -694,6 +694,303 @@ void GCodeViewer::SequentialView::render(const bool has_render_path, float legen
         gcode_window.render(legend_height + 2, std::max(10.f, (float)canvas_height - 40), (float)canvas_width - (float)right_margin, static_cast<uint64_t>(gcode_ids[current.last]));
 }
 
+// the two tones of the standard center of gravity symbol
+static const ColorRGBA Objects_CoG_Dark  = { 0.08f, 0.08f, 0.09f, 1.0f };
+static const ColorRGBA Objects_CoG_Light = { 0.96f, 0.96f, 0.97f, 1.0f };
+// radius of a marker, in pixels, kept constant while zooming
+static const double Objects_CoG_Screen_Radius = 9.0;
+// world radius is clamped to this range, in mm
+static const double Objects_CoG_Min_Radius = 0.6;
+static const double Objects_CoG_Max_Radius = 5.0;
+// default filament density, g/cm3, used when the G-code carries none
+static const double Objects_CoG_Default_Density = 1.24;
+
+// Parts of the standard center of gravity symbol: a flat disc in the local XY plane,
+// facing +Z. Passing a quadrant mask of 0b1111 gives the whole disc, 0b0101 gives one
+// pair of opposite quadrants. Drawing the full disc in black and then the inset pair
+// in white produces the familiar quartered circle with a thin rim.
+static GLModel::Geometry cog_symbol_disc(unsigned int resolution, float radius, unsigned int quadrant_mask)
+{
+    // a multiple of 4, so that no triangle straddles a quadrant boundary
+    const unsigned int sector_count = std::max<unsigned int>(8, (resolution / 4) * 4);
+    const double sector_step = 2.0 * M_PI / double(sector_count);
+    const Vec3f normal(0.0f, 0.0f, 1.0f);
+
+    GLModel::Geometry data;
+    data.format = { GLModel::Geometry::EPrimitiveType::Triangles, GLModel::Geometry::EVertexLayout::P3N3 };
+    data.reserve_vertices(3 * sector_count);
+    data.reserve_indices(3 * sector_count);
+
+    for (unsigned int i = 0; i < sector_count; ++i) {
+        const unsigned int quadrant = (i * 4) / sector_count;
+        if ((quadrant_mask & (1u << quadrant)) == 0)
+            continue;
+
+        const double angle = sector_step * double(i);
+        const double angle_next = sector_step * double(i + 1);
+
+        const unsigned int base = unsigned(data.vertices_count());
+        data.add_vertex(Vec3f(0.0f, 0.0f, 0.0f), normal);
+        data.add_vertex(Vec3f(float(double(radius) * std::cos(angle)), float(double(radius) * std::sin(angle)), 0.0f), normal);
+        data.add_vertex(Vec3f(float(double(radius) * std::cos(angle_next)), float(double(radius) * std::sin(angle_next)), 0.0f), normal);
+        data.add_triangle(base + 0, base + 1, base + 2);
+    }
+
+    return data;
+}
+
+void GCodeViewer::ObjectsCoG::reset()
+{
+    m_regions.clear();
+    m_regions.shrink_to_fit();
+    m_markers.clear();
+    m_markers.shrink_to_fit();
+    m_needs_update = true;
+}
+
+bool GCodeViewer::ObjectsCoG::is_object_extrusion(ExtrusionRole role)
+{
+    switch (role)
+    {
+    // everything which is removed from the part before it is used, plus the
+    // extrusions which do not belong to any object at all
+    case erNone:
+    case erSkirt:
+    case erBrim:
+    case erSupportMaterial:
+    case erSupportMaterialInterface:
+    case erSupportTransition:
+    case erWipeTower:
+    case erCustom:
+    case erMixed:
+    case erCount:
+        return false;
+    default:
+        return true;
+    }
+}
+
+int GCodeViewer::ObjectsCoG::region_at(const Vec3f& position, int hint) const
+{
+    const Point pt = Point::new_scale(double(position.x()), double(position.y()));
+
+    // consecutive moves almost always belong to the same object, so check the previous match first
+    if (hint >= 0 && hint < int(m_regions.size())) {
+        const Region& region = m_regions[hint];
+        if (region.hull_bbox.contains(pt) && region.hull.contains(pt))
+            return hint;
+    }
+
+    int  bbox_match = -1;
+    int  bbox_matches = 0;
+    for (size_t i = 0; i < m_regions.size(); ++i) {
+        const Region& region = m_regions[i];
+        if (!region.hull_bbox.contains(pt))
+            continue;
+        ++bbox_matches;
+        bbox_match = int(i);
+        if (region.hull.contains(pt))
+            return int(i);
+    }
+
+    // the point sits outside every convex hull (this happens for extrusions which
+    // stick out a little, e.g. the object's own brim-like first layer expansion):
+    // accept it only when a single object can claim it
+    return (bbox_matches == 1) ? bbox_match : -1;
+}
+
+void GCodeViewer::ObjectsCoG::load(const GCodeProcessorResult& gcode_result, const Print* print)
+{
+    reset();
+    m_needs_update = false;
+
+    if (gcode_result.moves.size() < 2)
+        return;
+
+    // one region per printable instance on the plate
+    if (print != nullptr) {
+        std::set<const ModelInstance*> processed_instances;
+        for (const PrintObject* print_object : print->objects()) {
+            if (print_object == nullptr)
+                continue;
+            const ModelObject* model_object = print_object->model_object();
+            if (model_object == nullptr)
+                continue;
+            for (const PrintInstance& print_instance : print_object->instances()) {
+                const ModelInstance* model_instance = print_instance.model_instance;
+                if (model_instance == nullptr || !processed_instances.insert(model_instance).second)
+                    continue;
+
+                Region region;
+                region.hull = model_object->convex_hull_2d(model_instance->get_matrix());
+                if (region.hull.size() < 3)
+                    continue;
+                // the hull is only used for point-in-object tests, a coarse one is enough
+                region.hull.douglas_peucker(scale_(0.5));
+                region.hull_bbox = get_extents(region.hull);
+                // small tolerance, the hull is built from the mesh while the toolpath is
+                // half an extrusion width outside of it
+                region.hull_bbox.offset(scale_(1.0));
+
+                region.name = model_object->name;
+                if (model_object->instances.size() > 1) {
+                    const auto it = std::find(model_object->instances.begin(), model_object->instances.end(), model_instance);
+                    if (it != model_object->instances.end())
+                        region.name += " #" + std::to_string(std::distance(model_object->instances.begin(), it) + 1);
+                }
+                m_regions.emplace_back(std::move(region));
+            }
+        }
+    }
+
+    // no print objects (standalone G-code file): fall back to a single marker for the whole plate
+    const bool whole_plate = m_regions.empty();
+    if (whole_plate) {
+        Region region;
+        region.name = _u8L("Whole plate");
+        m_regions.emplace_back(std::move(region));
+    }
+
+    const std::vector<float>& densities = gcode_result.filament_densities;
+    auto density_of = [&densities](size_t extruder_id) {
+        return (extruder_id < densities.size() && densities[extruder_id] > 0.0f) ?
+            double(densities[extruder_id]) : Objects_CoG_Default_Density;
+    };
+
+    int hint = 0;
+    for (size_t i = 1; i < gcode_result.moves.size(); ++i) {
+        const GCodeProcessorResult::MoveVertex& curr = gcode_result.moves[i];
+        if (curr.type != EMoveType::Extrude || curr.width == 0.0f || curr.height == 0.0f ||
+            curr.mm3_per_mm <= 0.0f || !is_object_extrusion(curr.extrusion_role))
+            continue;
+
+        const GCodeProcessorResult::MoveVertex& prev = gcode_result.moves[i - 1];
+        const Vec3f mid = 0.5f * (prev.position + curr.position);
+        const double length = (curr.position - prev.position).cast<double>().norm();
+        if (length <= 0.0)
+            continue;
+
+        // mm3 -> cm3 -> g
+        const double mass = 0.001 * double(curr.mm3_per_mm) * length * density_of(size_t(curr.extruder_id));
+        if (mass <= 0.0)
+            continue;
+
+        const int idx = whole_plate ? 0 : region_at(mid, hint);
+        if (idx < 0)
+            continue;
+        hint = idx;
+
+        Vec3d position = mid.cast<double>();
+        // move.position is the nozzle position, the deposited material sits half a layer below it
+        position.z() -= 0.5 * double(curr.height);
+
+        m_regions[idx].sum += mass * position;
+        m_regions[idx].mass += mass;
+    }
+
+    for (const Region& region : m_regions) {
+        if (region.mass <= 0.0)
+            continue;
+        Marker marker;
+        marker.name = region.name;
+        marker.position = region.sum / region.mass;
+        marker.mass = region.mass;
+        m_markers.emplace_back(std::move(marker));
+    }
+
+    // the hulls are not needed once the markers are computed
+    m_regions.clear();
+    m_regions.shrink_to_fit();
+
+    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": computed %1% per-object center of gravity markers") % m_markers.size();
+}
+
+void GCodeViewer::update_objects_cog()
+{
+    // load() pumps the event loop through its progress dialog, so a paint can land in the
+    // middle of it. It holds the gcode result lock, which is not recursive: stay out
+    if (m_loading)
+        return;
+    if (!m_objects_cog.is_visible() || !m_objects_cog.needs_update())
+        return;
+    if (m_gcode_result == nullptr || m_gcode_result->moves.empty())
+        return;
+
+    // the objects of the plate being previewed, used to tell the extrusions apart.
+    // a standalone G-code file has none, which yields a single marker for the plate
+    const Print* print = nullptr;
+    if (PartPlate* plate = wxGetApp().plater()->get_partplate_list().get_curr_plate()) {
+        PrintBase*   print_base = nullptr;
+        GCodeResult* plate_result = nullptr;
+        plate->get_print(&print_base, &plate_result, nullptr);
+        print = dynamic_cast<const Print*>(print_base);
+    }
+
+    //BBS: add mutex for protection of gcode result
+    m_gcode_result->lock();
+    ScopeGuard unlock_guard([this]() { m_gcode_result->unlock(); });
+    m_objects_cog.load(*m_gcode_result, print);
+}
+
+void GCodeViewer::ObjectsCoG::render()
+{
+    if (!m_visible || m_markers.empty())
+        return;
+
+    if (!m_model_dark.is_initialized()) {
+        // full disc in black, then two opposite quadrants in white, inset so a rim of the
+        // black disc stays visible as an outline against light toolpaths
+        m_model_dark.init_from(cog_symbol_disc(64, 1.0f, 0b1111));
+        m_model_dark.set_color(Objects_CoG_Dark);
+        m_model_light.init_from(cog_symbol_disc(64, 0.90f, 0b0101));
+        m_model_light.set_color(Objects_CoG_Light);
+    }
+
+    GLShaderProgram* shader = wxGetApp().get_shader("gouraud_light");
+    if (shader == nullptr)
+        return;
+
+    const Camera& camera = wxGetApp().plater()->get_camera();
+    const Transform3d& view_matrix = camera.get_view_matrix();
+    const double zoom = camera.get_zoom();
+    const double radius = (zoom > 0.0) ?
+        std::clamp(Objects_CoG_Screen_Radius / zoom, Objects_CoG_Min_Radius, Objects_CoG_Max_Radius) :
+        Objects_CoG_Min_Radius;
+
+    // turn the disc to face the camera, so the symbol reads the same from every angle
+    Transform3d billboard = Transform3d::Identity();
+    {
+        Matrix3d rotation = view_matrix.matrix().block(0, 0, 3, 3);
+        const double scale = rotation.col(0).norm();
+        if (scale > 0.0)
+            rotation /= scale;
+        billboard.linear() = rotation.transpose();
+    }
+
+    // the center of gravity lies inside the object, so the markers are drawn on top of the toolpaths
+    glsafe(::glDisable(GL_DEPTH_TEST));
+
+    shader->start_using();
+    // the disc faces the camera, so lighting is constant across it: this tops the diffuse
+    // term up to 1, which keeps the two tones at their nominal black and white
+    shader->set_uniform("emission_factor", 0.25f);
+    shader->set_uniform("projection_matrix", camera.get_projection_matrix());
+
+    for (const Marker& marker : m_markers) {
+        const Transform3d model_matrix = Geometry::translation_transform(marker.position) * billboard * Geometry::scale_transform(radius);
+        shader->set_uniform("view_model_matrix", view_matrix * model_matrix);
+        const Matrix3d view_normal_matrix = view_matrix.matrix().block(0, 0, 3, 3) * model_matrix.matrix().block(0, 0, 3, 3).inverse().transpose();
+        shader->set_uniform("view_normal_matrix", view_normal_matrix);
+        // the white quadrants must land on top of the black disc
+        m_model_dark.render();
+        m_model_light.render();
+    }
+
+    shader->stop_using();
+
+    glsafe(::glEnable(GL_DEPTH_TEST));
+}
+
 const std::vector<ColorRGBA> GCodeViewer::Extrusion_Role_Colors{ {
     { 0.90f, 0.70f, 0.70f, 1.0f },   // erNone
     { 1.00f, 0.90f, 0.30f, 1.0f },   // erPerimeter
@@ -863,6 +1160,10 @@ void GCodeViewer::init(ConfigOptionMode mode, PresetBundle* preset_bundle)
     update_by_mode(m_user_mode);
 
     m_layers_slider->init_texture();
+
+    // per-object center of gravity markers, off by default
+    if (wxGetApp().app_config != nullptr)
+        m_objects_cog.set_visible(wxGetApp().app_config->get_bool("show_objects_cog"));
 
     m_gl_data_initialized = true;
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": finished");
@@ -1099,6 +1400,11 @@ void GCodeViewer::load(const GCodeProcessorResult& gcode_result, const Print& pr
     m_filament_diameters = gcode_result.filament_diameters;
     m_filament_densities = gcode_result.filament_densities;
     m_sequential_view.m_show_marker = false;
+
+    // per-object center of gravity markers: only drop what was computed for the previous
+    // preview here. Building the new markers is deferred until they are actually shown, so
+    // slicing and the preview load never pay for them
+    m_objects_cog.invalidate();
 
     //BBS: always load shell at preview
     /*if (wxGetApp().is_editor())
@@ -1355,6 +1661,8 @@ void GCodeViewer::reset()
     m_print_statistics.reset();
     m_custom_gcode_per_print_z = std::vector<CustomGCode::Item>();
     m_sequential_view.gcode_window.reset();
+    // per-object center of gravity markers
+    m_objects_cog.reset();
 #if ENABLE_GCODE_VIEWER_STATISTICS
     m_statistics.reset_all();
 #endif // ENABLE_GCODE_VIEWER_STATISTICS
@@ -1377,6 +1685,11 @@ void GCodeViewer::render(int canvas_width, int canvas_height, int right_margin)
         return;
 
     render_toolpaths();
+    // per-object center of gravity markers, drawn on top of the toolpaths. They are
+    // computed here, on the first frame after the user switches them on, rather than
+    // while the preview loads
+    update_objects_cog();
+    m_objects_cog.render();
     float legend_height = 0.0f;
     render_legend(legend_height, canvas_width, canvas_height, right_margin);
 
@@ -4475,6 +4788,7 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         Circle,
         Hexagon,
         Line,
+        CoG,
         None
     };
 
@@ -4530,9 +4844,25 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         case EItemType::Line: {
             draw_list->AddLine({ pos.x + 1, pos.y + icon_size + 2 }, { pos.x + icon_size - 1, pos.y + 4 }, ImGuiWrapper::to_ImU32(color), 3.0f);
             break;
-        case EItemType::None:
+        }
+        case EItemType::CoG: {
+            // the standard center of gravity symbol: a black disc with two opposite
+            // quadrants in white, the same glyph the marker draws in the 3D scene
+            const ImVec2 center(0.5f * (pos.x + pos.x + icon_size), 0.5f * (pos.y + pos.y + icon_size + 5.0f));
+            const float  radius = 0.5f * icon_size;
+            draw_list->AddCircleFilled(center, radius, ImGuiWrapper::to_ImU32(Objects_CoG_Dark), 16);
+            const ImU32 light = ImGuiWrapper::to_ImU32(Objects_CoG_Light);
+            // inset a little, so a rim of the disc stays as an outline
+            const float quadrant_radius = 0.86f * radius;
+            for (int quadrant = 0; quadrant < 4; quadrant += 2) {
+                draw_list->PathLineTo(center);
+                draw_list->PathArcTo(center, quadrant_radius, float(quadrant) * 0.5f * IM_PI, float(quadrant + 1) * 0.5f * IM_PI, 6);
+                draw_list->PathFillConvex(light);
+            }
             break;
         }
+        case EItemType::None:
+            break;
         }
 
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(20.0 * m_scale, 6.0 * m_scale));
@@ -5051,6 +5381,21 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
             append_option_item_with_type(type, Wipe_Color, _u8L("Wipe"), visible);
     };
 
+    // per-object center of gravity markers, offered next to the other preview options.
+    // Unlike those, this one is not backed by a move type buffer, so it needs its own row
+    auto append_cog_item = [this, append_item](const std::vector<float>& offsets) {
+        const bool visible = m_objects_cog.is_visible();
+        // EItemType::CoG draws the symbol itself, so the color argument is unused here
+        const ColorRGBA& color = Objects_CoG_Light;
+        append_item(EItemType::CoG, color, { { _u8L("Center of Gravity"), offsets[0] } },
+            true, offsets.back()/*ORCA checkbox_pos*/, visible, [this, visible]() {
+                m_objects_cog.set_visible(!visible);
+                if (wxGetApp().app_config != nullptr)
+                    wxGetApp().app_config->set_bool("show_objects_cog", !visible);
+                wxGetApp().plater()->get_current_canvas3D()->set_as_dirty();
+            });
+    };
+
     // extrusion paths section -> items
     switch (m_view_type)
     {
@@ -5096,6 +5441,8 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
                     });
             }
         }
+
+        append_cog_item(offsets);
         break;
     }
     case EViewType::Height:         { append_range(m_extrusions.ranges.height, 2); break; }
@@ -5816,6 +6163,7 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
         append_headers({ {_u8L("Options"), offsets[0] }, { _u8L("Display"), offsets[1]} });
         for (auto item : options_items)
             append_option_item(item, offsets);
+        append_cog_item(offsets);
     }
 
     legend_height = ImGui::GetCurrentWindow()->Size.y;

--- a/src/slic3r/GUI/GCodeViewer.hpp
+++ b/src/slic3r/GUI/GCodeViewer.hpp
@@ -2,6 +2,8 @@
 #define slic3r_GCodeViewer_hpp_
 
 #include "3DScene.hpp"
+#include "libslic3r/BoundingBox.hpp"
+#include "libslic3r/Polygon.hpp"
 #include "libslic3r/GCode/GCodeProcessor.hpp"
 #include "libslic3r/GCode/ThumbnailData.hpp"
 #include "IMSlider.hpp"
@@ -709,6 +711,64 @@ public:
         std::vector<bool>  m_tool_visibles;
     };
 
+    // Per-object center of gravity markers shown in the preview.
+    // One marker is placed at the center of gravity of the material actually deposited
+    // inside each printable object instance of the plate. Skirt, brim, support material
+    // and the wipe tower are left out, so a marker matches the part the user takes off
+    // the plate. When no print objects are available (a standalone G-code file loaded in
+    // the viewer) a single marker is computed for the whole plate instead.
+    //
+    // Nothing is computed while the preview loads. The markers are built on the first
+    // frame after the user switches them on, which keeps the pass out of the way of
+    // slicing and off the memory peak that comes with it, and costs nothing at all for
+    // the users who never turn the markers on.
+    class ObjectsCoG
+    {
+    public:
+        struct Marker
+        {
+            std::string name;
+            Vec3d       position{ Vec3d::Zero() }; // world coordinates, mm
+            double      mass{ 0.0 };               // g
+        };
+
+        void reset();
+        // discards the markers computed for a previous preview, without computing new ones
+        void invalidate() { m_markers.clear(); m_markers.shrink_to_fit(); m_needs_update = true; }
+        bool needs_update() const { return m_needs_update; }
+        // print may be null, e.g. for a standalone G-code file
+        void load(const GCodeProcessorResult& gcode_result, const Print* print);
+        void render();
+
+        bool is_visible() const { return m_visible; }
+        void set_visible(bool visible) { m_visible = visible; }
+        const std::vector<Marker>& get_markers() const { return m_markers; }
+
+    private:
+        struct Region
+        {
+            std::string name;
+            Polygon     hull;      // scaled world coordinates
+            BoundingBox hull_bbox; // scaled world coordinates, slightly inflated
+            Vec3d       sum{ Vec3d::Zero() };
+            double      mass{ 0.0 };
+        };
+
+        // extrusions belonging to the object itself (not skirt / brim / support / wipe tower)
+        static bool is_object_extrusion(ExtrusionRole role);
+        // index of the region the given world position falls into, -1 when none or ambiguous.
+        // hint is the region matched by the previous move, tested first.
+        int region_at(const Vec3f& position, int hint) const;
+
+        std::vector<Region> m_regions;
+        std::vector<Marker> m_markers;
+        // the two interleaved octant sets of the center of gravity symbol
+        GLModel             m_model_dark;
+        GLModel             m_model_light;
+        bool                m_visible{ false };
+        bool                m_needs_update{ true };
+    };
+
     enum class EViewType : unsigned char
     {
         FeatureType = 0,
@@ -763,6 +823,8 @@ private:
     std::vector<float> m_filament_densities;
     Extrusions m_extrusions;
     SequentialView m_sequential_view;
+    // per-object center of gravity markers
+    ObjectsCoG m_objects_cog;
     IMSlider* m_moves_slider;
     IMSlider* m_layers_slider;
     Shells m_shells;
@@ -841,6 +903,10 @@ public:
     const SequentialView& get_sequential_view() const { return m_sequential_view; }
     void update_sequential_view_current(unsigned int first, unsigned int last);
 
+    // per-object center of gravity markers
+    bool is_objects_cog_visible() const { return m_objects_cog.is_visible(); }
+    void set_objects_cog_visible(bool visible) { m_objects_cog.set_visible(visible); }
+
     /* BBS IMSlider */
     IMSlider *get_moves_slider() { return m_moves_slider; }
     IMSlider *get_layers_slider() { return m_layers_slider; }
@@ -900,6 +966,8 @@ private:
     void refresh_render_paths(bool keep_sequential_current_first, bool keep_sequential_current_last) const;
     void render_toolpaths();
     void render_shells();
+    // builds the per-object center of gravity markers when they are shown and out of date
+    void update_objects_cog();
 
     //BBS: GUI refactor: add canvas size
     void render_legend(float &legend_height, int canvas_width, int canvas_height, int right_margin);


### PR DESCRIPTION
# Description

Adds a per-object center of gravity marker to the sliced preview, as a preview option in the legend which is hidden by default.

# Screenshots/Recordings/Graphs
<img width="1323" height="693" alt="image" src="https://github.com/user-attachments/assets/6304b0cd-0d7c-46d5-8950-a964e44ac57f" />
<img width="1307" height="803" alt="image" src="https://github.com/user-attachments/assets/958a227e-3e3d-44dd-8128-3e50335759f1" />


## Tests

No unit tests: the change is a rendering pass over an in-memory G-code result
plus a legend row, neither of which is reachable from the libslic3r test suite.

## Verification

- Build: GitHub Actions `Build all` green on windows-2022, macos-14 (arm64),
  ubuntu-24.04 and both Flatpak targets.
- Placement sanity: symmetric cube — marker sits at the XY center of the
  object and near half height. L-shaped part — marker sits toward the heavy leg,
  outside the bounding-box center.
- Infill test: CoG responds to differences in infill density between two otherwise identical objects (white and red cones in screenshot)
- Per object: plate with three objects and a two-instance object — four markers,
  one per printed instance.
- Supports excluded: same object sliced with and without supports — marker does
  not move.
- Toggle: appears in the options list of both Line Type and Filament views;
  off on a fresh config; survives restart via `show_objects_cog`.
- Themes: legend glyph and the 3D marker read correctly in light and dark.