### PR TITLE
fix(gui): encode Flutter web version parameter

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -5412,17 +5412,11 @@ void GUI_App::no_new_version()
 }
 
 std::string GUI_App::version_display = "";
-wxString GUI_App::flutter_web_base_url(const wxString& path)
-{
-    return wxString::FromUTF8(LOCALHOST_URL + std::to_string(get_page_http_port()) +
-                              "/web/flutter_web/index.html?path=" + std::string(path.utf8_str()));
-}
-
-// Full launch url: base plus &version= of the embedding desktop client, so the
-// flutter side can identify which app build it is talking to.
 wxString GUI_App::build_flutter_web_url(const wxString& path)
 {
-    return flutter_web_base_url(path) + wxString::Format("&version=%s", Snapmaker_VERSION);
+    return wxString::FromUTF8(LOCALHOST_URL + std::to_string(get_page_http_port()) +
+                              "/web/flutter_web/index.html?path=" + std::string(path.utf8_str()) +
+                              "&version=" + Snapmaker_VERSION);
 }
 
 std::string GUI_App::format_display_version()

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -539,7 +539,6 @@ private:
     bool            is_user_login();
 
     wxString get_international_url(const wxString& origin_url);
-    wxString flutter_web_base_url(const wxString& path);
     wxString build_flutter_web_url(const wxString& path);
 
     // SM


### PR DESCRIPTION
Keep the desktop build version in the Flutter launch URL, but concatenate it with the other UTF-8 query fields before converting the full URL to wxString.
