### PR TITLE
ci: use macos-15 runner image instead of macos-26

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -31,8 +31,8 @@ jobs:
           # - os: ubuntu-20.04
           - os: ubuntu-24.04
           - os: windows-2022
-          # macOS 26 Tahoe (Darwin 25.x). Do not use macos-latest; pin the image.
-          - os: macos-26
+          # macOS 15 Sequoia (Darwin 24.x). Do not use macos-latest; pin the image.
+          - os: macos-15
             arch: arm64
     uses: ./.github/workflows/build_check_cache.yml
     with:

--- a/.github/workflows/build_check_cache.yml
+++ b/.github/workflows/build_check_cache.yml
@@ -31,7 +31,7 @@ jobs:
         id: set_outputs
         env:
           # todo: this is mad! refactor other build scripts to use same name
-          dep-folder-name: ${{ inputs.os == 'windows-2022' && '/OrcaSlicer_dep' || inputs.os == 'macos-26' && '' || inputs.os != 'macos-26' && '/destdir' || '' }}
+          dep-folder-name: ${{ inputs.os == 'windows-2022' && '/OrcaSlicer_dep' || inputs.os == 'macos-15' && '' || inputs.os != 'macos-15' && '/destdir' || '' }}
           output-cmd: ${{ inputs.os == 'windows-2022' && '$env:GITHUB_OUTPUT' || '"$GITHUB_OUTPUT"'}}
         run: |
           echo cache-key=${{ inputs.os }}-cache-orcaslicer_deps-build-${{ hashFiles('deps/**') }} >> ${{ env.output-cmd }}

--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -73,7 +73,7 @@ jobs:
             cd ${{ github.workspace }}/deps/build
 
       - name: Free disk space mac
-        if: inputs.os == 'macos-26'
+        if: inputs.os == 'macos-15'
         run: |
           sudo xcode-select -s /Applications/Xcode.app
           xcodebuild -version
@@ -96,7 +96,7 @@ jobs:
           df -h
 
       - name: Build on Mac ${{ inputs.arch }}
-        if: inputs.os == 'macos-26'
+        if: inputs.os == 'macos-15'
         working-directory: ${{ github.workspace }}
         run: |
             brew install automake texinfo libtool
@@ -139,7 +139,7 @@ jobs:
 
       # Upload Artifacts (commented out to reduce artifact storage usage)
       # - name: Upload Mac ${{ inputs.arch }} artifacts
-      #   if: inputs.os == 'macos-26'
+      #   if: inputs.os == 'macos-15'
       #   uses: actions/upload-artifact@v4
       #   with:
       #     name: OrcaSlicer_dep_mac_${{ env.date }}
@@ -181,6 +181,6 @@ jobs:
     with:
       os: ${{ inputs.os }}
       pdb-artifact-name: PDB
-      dsym-artifact-name: ${{ inputs.os == 'macos-26' && format('dSYM_Mac_{0}', needs.build_orca.outputs.release) || '' }}
+      dsym-artifact-name: ${{ inputs.os == 'macos-15' && format('dSYM_Mac_{0}', needs.build_orca.outputs.release) || '' }}
       release: ${{ needs.build_orca.outputs.release || github.sha }}
     secrets: inherit

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -100,7 +100,7 @@ jobs:
 
 #   Mac
       - name: Install tools mac
-        if: inputs.os == 'macos-26'
+        if: inputs.os == 'macos-15'
         run: |
           sudo xcode-select -s /Applications/Xcode.app
           xcodebuild -version
@@ -110,7 +110,7 @@ jobs:
           mkdir -p ${{ github.workspace }}/deps/build
 
       - name: Free disk space
-        if: inputs.os == 'macos-26'
+        if: inputs.os == 'macos-15'
         run: |
           df -h
           XCODE_DEV="$(xcode-select -p)"
@@ -130,14 +130,14 @@ jobs:
           df -h
 
       - name: Build slicer mac
-        if: inputs.os == 'macos-26'
+        if: inputs.os == 'macos-15'
         working-directory: ${{ github.workspace }}
         run: |
           ./build_release_macos.sh -s -n -x -a universal -t 10.15 -1
 
  # Thanks to RaySajuuk, it's working now
       - name: Sign app and notary
-        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_') || github.ref == 'refs/heads/2.3.0-final') && inputs.os == 'macos-26'
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release_') || github.ref == 'refs/heads/2.3.0-final') && inputs.os == 'macos-15'
         working-directory: ${{ github.workspace }}
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -190,7 +190,7 @@ jobs:
           fi
 
       - name: Create DMG without notary
-        if: github.ref != 'refs/heads/main' && inputs.os == 'macos-26' && github.ref != 'refs/heads/2.3.0-final' && !startsWith(github.ref, 'refs/heads/release_')
+        if: github.ref != 'refs/heads/main' && inputs.os == 'macos-15' && github.ref != 'refs/heads/2.3.0-final' && !startsWith(github.ref, 'refs/heads/release_')
         working-directory: ${{ github.workspace }}
         run: |
           mkdir -p ${{ github.workspace }}/build/universal/Snapmaker_Orca_dmg
@@ -209,14 +209,14 @@ jobs:
           fi
 
       - name: Upload artifacts mac
-        if: inputs.os == 'macos-26'
+        if: inputs.os == 'macos-15'
         uses: actions/upload-artifact@v4
         with:
           name: Snapmaker_Orca_Mac_universal_${{ env.ver }}
           path: ${{ github.workspace }}/Snapmaker_Orca_Mac_universal_${{ env.ver }}.dmg
 
       - name: Upload Snapmaker_Orca_profile_validator DMG mac
-        if: inputs.os == 'macos-26'
+        if: inputs.os == 'macos-15'
         uses: actions/upload-artifact@v4
         with:
           name: Snapmaker_Orca_profile_validator_Mac_universal_DMG_${{ env.ver }}
@@ -224,7 +224,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload dSYM artifacts mac
-        if: inputs.os == 'macos-26'
+        if: inputs.os == 'macos-15'
         uses: actions/upload-artifact@v4
         with:
           name: dSYM_Mac_${{ env.ver }}
@@ -232,7 +232,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Deploy Mac release
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.3.0-final') && inputs.os == 'macos-26'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.3.0-final') && inputs.os == 'macos-15'
         uses: WebFreak001/deploy-nightly@v3.2.0
         with:
           upload_url: https://uploads.github.com/repos/Snapmaker/OrcaSlicer/releases/169912305/assets{?name,label}
@@ -243,7 +243,7 @@ jobs:
           max_releases: 1 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
 
       - name: Check if profile validator DMG exists
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.3.0-final') && inputs.os == 'macos-26'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.3.0-final') && inputs.os == 'macos-15'
         id: check_dmg
         working-directory: ${{ github.workspace }}
         run: |
@@ -257,7 +257,7 @@ jobs:
         shell: bash
 
       - name: Deploy Mac Snapmaker_Orca_profile_validator DMG release
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.3.0-final') && inputs.os == 'macos-26' && steps.check_dmg.outputs.exists == 'true'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.3.0-final') && inputs.os == 'macos-15' && steps.check_dmg.outputs.exists == 'true'
         uses: WebFreak001/deploy-nightly@v3.2.0
         with:
           upload_url: https://uploads.github.com/repos/Snapmaker/OrcaSlicer/releases/169912305/assets{?name,label}

--- a/.github/workflows/sentry_cli.yml
+++ b/.github/workflows/sentry_cli.yml
@@ -6,7 +6,7 @@ on:
       os:
         required: true
         type: string
-        description: "Target OS: windows-2022, macos-26, ubuntu-20.04, ubuntu-24.04"
+        description: "Target OS: windows-2022, macos-15, ubuntu-20.04, ubuntu-24.04"
       pdb-artifact-name:
         required: false
         type: string
@@ -91,7 +91,7 @@ jobs:
 
       # ==================== macOS ====================
       - name: "[macOS] Install sentry-cli"
-        if: inputs.os == 'macos-26'
+        if: inputs.os == 'macos-15'
         run: |
           # Try multiple installation methods for reliability
           # Method 1: Official install script (most reliable)
@@ -124,14 +124,14 @@ jobs:
           fi
 
       - name: "[macOS] Download dSYM artifact"
-        if: inputs.os == 'macos-26'
+        if: inputs.os == 'macos-15'
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.dsym-artifact-name }}
           path: ./symbols
 
       - name: "[macOS] Upload dSYM to Sentry (sentry-cli)"
-        if: inputs.os == 'macos-26'
+        if: inputs.os == 'macos-15'
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_LOG_LEVEL: debug


### PR DESCRIPTION
# Description

Switch the macOS CI runner image from `macos-26` (Tahoe) to `macos-15` (Sequoia, Darwin 24.x, default Xcode 16.x), adapting #822 (dcf8629e) to target macos-15.

- `build_all.yml`: matrix entry + pinned-image comment
- `build_check_cache.yml`: dep cache path expression
- `build_deps.yml`: deps build conditions (incl. `Free disk space mac`) + dSYM artifact-name expression
- `build_orca.yml`: slicer build, sign/notary, DMG, artifact/dSYM upload conditions
- `sentry_cli.yml`: input description + macOS step conditions

Everything else from #822 is kept unchanged: the dynamic disk-space cleanup (keeps the Xcode selected via `xcode-select`, removes unused `Xcode_*.app` copies), the `xcodebuild -version` / `sw_vers` diagnostics, and the AGL CMake workarounds + `MediaPlayCtrl.h` constexpr fix — those are still needed when building against the macOS 26 SDK locally and are harmless on the macos-15 image, whose SDK still ships AGL.

No preset, translation, or dependency changes.

# Screenshots/Recordings/Graphs

CI-only change; no UI.

## Tests

- All 5 workflow YAML files parse cleanly (`yaml.safe_load`).
- `git grep macos-26 -- .github/` → no matches; all 22 references (matrix + conditions + description) now read `macos-15`.
- Full pipeline (deps cache → universal build → sign/notary → dSYM upload) to be verified by the CI run on this PR.