### PR TITLE
Set Sentry environment to alpha for alpha builds

### DIFF
--- a/src/sentry_wrapper/SentryWrapper.cpp
+++ b/src/sentry_wrapper/SentryWrapper.cpp
@@ -255,7 +255,7 @@ void initSentryEx()
 #endif
 
         //sentry_options_set_environment(options, "develop");
-        sentry_options_set_environment(options, "Release");
+        sentry_options_set_environment(options, "alpha");
 
         sentry_options_set_auto_session_tracking(options, 0);
         sentry_options_set_symbolize_stacktraces(options, 1);


### PR DESCRIPTION
# Description

Set the Sentry `environment` to `alpha` so crash reports and logs from alpha builds can be filtered separately in Sentry. Same change as #833, retargeted to `feat_macos_15` so alpha builds cut from this branch report `environment="alpha"`.

Previously `initSentryEx()` hardcoded `environment="Release"` for every build, so events from alpha builds were indistinguishable from production ones. With this change, builds from branches carrying it report `environment="alpha"`.

Notes:

- `release` is unchanged (`Snapmaker_VERSION`, e.g. `2.4.0`), so symbolication / debug-symbol upload is not affected.
- Custom tags (`snapmaker_version`, `flutter_version`, `machine_id`) are unchanged.
- The commented-out `//sentry_options_set_environment(options, "develop");` hint line is preserved.

# Screenshots/Recordings/Graphs

N/A — no UI changes.

## Tests

- [x] Verified via `git diff` that the only change is the environment value in `initSentryEx()` (`src/sentry_wrapper/SentryWrapper.cpp`).
- [ ] Manual validation: build an alpha package from this branch and confirm events show up under `environment=alpha` in the Sentry UI.
