### PR TITLE
fix: unregister shell volumes from LOD sharing map before delete in l…

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -3245,6 +3245,10 @@ void GCodeViewer::load_shells(const Print& print, bool initialized, bool force_p
     while (true) {
         GLVolumePtrs::iterator it = std::find_if(m_shells.volumes.volumes.begin(), m_shells.volumes.volumes.end(), [](GLVolume* volume) { return volume->is_modifier; });
         if (it != m_shells.volumes.volumes.end()) {
+            // Unregister from the LOD sharing map before the pointer becomes
+            // dangling, otherwise a later load_object_volume() with the same
+            // mesh picks up this stale GLVolume* from g_meshVolumesMap.
+            m_shells.volumes.release_volume(*it);
             delete (*it);
             m_shells.volumes.volumes.erase(it);
         }


### PR DESCRIPTION
fix: unregister shell volumes from LOD sharing map before delete in load_shells

GCodeViewer::load_shells() removes modifier volumes with a bare delete,
but those volumes were already registered into the global LOD sharing
map (g_meshVolumesMap) by load_object_volume(). Deleting them without
calling release_volume() leaves dangling GLVolume* entries in the map.

When the same mesh is loaded again (e.g. switching back to a sliced
plate), load_object_volume() picks up the stale pointer as firstVolume
and copies its shared_ptr<GLModel> LOD models, crashing in
shared_ptr::operator= (use-after-free). Reproducible with the
fluffy-letters library model: slice each plate, then switch plates
back and forth.

Fix: call GLVolumeCollection::release_volume() before delete, matching
the existing paths in clear() and the GLCanvas3D reload (P0-2).