### PR TITLE
Fix crash on MQTT disconnect (heap corruption / use-after-free)

### DIFF
--- a/src/slic3r/GUI/HttpServer.cpp
+++ b/src/slic3r/GUI/HttpServer.cpp
@@ -543,13 +543,19 @@ void HttpServer::stop()
     
     // 重启检查已集成到健康检查中，无需单独停止
     
+    // the io thread was still dispatching handlers, and handlers themselves
+    // call IOServer::stop(session) — mutating the same sessions set from two
+    // threads at once, which crashed with EXC_BAD_ACCESS / heap corruption.
+    std::lock_guard<std::mutex> lock(m_server_mtx);
     if (server_) {
-        server_->acceptor.close();
-        server_->stop_all();
+        boost::system::error_code ignored_ec;
+        server_->acceptor.close(ignored_ec);
         server_->io_service.stop();
     }
     if (m_http_server_thread.joinable())
         m_http_server_thread.join();
+    if (server_)
+        server_->stop_all();
     server_.reset();
 }
 
@@ -561,13 +567,19 @@ void HttpServer::restart()
     // 只停止HTTP服务器，不停止健康检查和重启检查线程
     start_http_server = false;
     
+    // Hold the lock across teardown AND start(): if is_healthy() ran in the
+    // gap between the two it would see server_ == nullptr and trigger another
+    // restart on top of this one.
+    std::lock_guard<std::mutex> lock(m_server_mtx);
     if (server_) {
-        server_->acceptor.close();
-        server_->stop_all();
+        boost::system::error_code ignored_ec;
+        server_->acceptor.close(ignored_ec);
         server_->io_service.stop();
     }
     if (m_http_server_thread.joinable())
         m_http_server_thread.join();
+    if (server_)
+        server_->stop_all();
     server_.reset();
     
     BOOST_LOG_TRIVIAL(debug) << "Waiting for resources to be released...";
@@ -581,6 +593,8 @@ void HttpServer::restart()
 
 bool HttpServer::is_healthy()
 {
+    // May run on the health-check thread concurrently with stop()/restart().
+    std::lock_guard<std::mutex> lock(m_server_mtx);
     if (!start_http_server || !server_) {
         BOOST_LOG_TRIVIAL(fatal) << "Health check failed: server not started or server object is null";
         return false;

--- a/src/slic3r/GUI/HttpServer.hpp
+++ b/src/slic3r/GUI/HttpServer.hpp
@@ -205,6 +205,12 @@ private:
     };
     friend class session;
 
+    // Serializes server_ / m_http_server_thread lifecycle between stop(),
+    // restart() and is_healthy() (the latter runs on the health-check thread).
+    // The io thread never takes this lock; it only touches the IOServer, whose
+    // sessions set is joined before teardown (see HttpServer::stop).
+    std::mutex m_server_mtx;
+
     std::unique_ptr<IOServer> server_{nullptr};
 
     std::function<std::shared_ptr<Response>(const std::string&)> m_request_handler{&HttpServer::bbl_auth_handle_request};

--- a/src/slic3r/Utils/MQTT.cpp
+++ b/src/slic3r/Utils/MQTT.cpp
@@ -376,12 +376,14 @@ bool MqttClient::Publish(const std::string& topic, const std::string& payload, i
 // @param callback: Function to be called when a message arrives
 void MqttClient::SetMessageCallback(std::function<void(const std::string& topic, const std::string& payload)> callback)
 {
+    std::lock_guard<std::mutex> lock(cb_mtx_);
     message_callback1_ = nullptr;
     message_callback_ = callback;
 }
 
 void MqttClient::SetMessageCallback(std::function<void(const std::string& topic, const std::string& payload, void* this_)> callback)
 {
+    std::lock_guard<std::mutex> lock(cb_mtx_);
     message_callback_  = nullptr;
     message_callback1_ = callback;
 }
@@ -439,8 +441,13 @@ void MqttClient::connection_lost(const std::string& cause)
         
     if (!ever_connected_.load(std::memory_order_acquire)) {
         BOOST_LOG_TRIVIAL(error) << "The first connection failed. Since no successful connection has been made before, automatic reconnection remains disabled";
-        if (connection_failure_callback_) {
-            connection_failure_callback_();
+        std::function<void()> failure_cb;
+        {
+            std::lock_guard<std::mutex> lock(cb_mtx_);
+            failure_cb = connection_failure_callback_;
+        }
+        if (failure_cb) {
+            failure_cb();
         }
         return;
     }
@@ -469,8 +476,13 @@ void MqttClient::connection_lost(const std::string& cause)
                                 BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] MQTT connection not restored after 20 seconds";
                                 std::string dc_msg = "";
                                 self->Disconnect(dc_msg);
-                                if (self->connection_failure_callback_) {
-                                    self->connection_failure_callback_();
+                                std::function<void()> failure_cb;
+                                {
+                                    std::lock_guard<std::mutex> lock(self->cb_mtx_);
+                                    failure_cb = self->connection_failure_callback_;
+                                }
+                                if (failure_cb) {
+                                    failure_cb();
                                 }
                             }
                             
@@ -491,12 +503,22 @@ void MqttClient::connection_lost(const std::string& cause)
 // @param msg: Pointer to the received message
 void MqttClient::message_arrived(mqtt::const_message_ptr msg)
 {
-    if (message_callback_) {
-        message_callback_(msg->get_topic(), msg->to_string());
+    // Copy the callbacks under the lock and invoke the copies outside it:
+    // the setters (and ~MqttClient) may run concurrently on another thread.
+    std::function<void(const std::string&, const std::string&)> cb;
+    std::function<void(const std::string&, const std::string&, void*)> cb1;
+    {
+        std::lock_guard<std::mutex> lock(cb_mtx_);
+        cb  = message_callback_;
+        cb1 = message_callback1_;
     }
 
-    if (message_callback1_) {
-        message_callback1_(msg->get_topic(), msg->to_string(), this);
+    if (cb) {
+        cb(msg->get_topic(), msg->to_string());
+    }
+
+    if (cb1) {
+        cb1(msg->get_topic(), msg->to_string(), this);
     }
 }
 
@@ -522,10 +544,15 @@ void MqttClient::on_failure(const mqtt::token& tok)
         
         connected_.store(false, std::memory_order_release);
                 
-        if (connection_failure_callback_) {
-            connection_failure_callback_();
+        std::function<void()> failure_cb;
+        {
+            std::lock_guard<std::mutex> lock(cb_mtx_);
+            failure_cb = connection_failure_callback_;
         }
-    } else {        
+        if (failure_cb) {
+            failure_cb();
+        }
+    } else {
         BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] Operation failed for token: " << tok.get_message_id();
         if (tok.get_reason_code() != 0) {
             BOOST_LOG_TRIVIAL(error) << "[MQTT_INFO] Reason code: " << tok.get_reason_code();
@@ -557,11 +584,22 @@ void MqttClient::connected(const std::string& cause)
 }
 
 void MqttClient::resubscribe_topics() {
-    if (topics_to_resubscribe_.empty() || !client_) {
+    if (!client_) {
         return;
     }
 
-    for (const auto& topic_pair : topics_to_resubscribe_) {
+    // Snapshot the map: subscribing can block for seconds per topic, so the
+    // lock must not be held while waiting on the broker.
+    std::map<std::string, int> topics;
+    {
+        std::lock_guard<std::mutex> lock(topics_mtx_);
+        topics = topics_to_resubscribe_;
+    }
+    if (topics.empty()) {
+        return;
+    }
+
+    for (const auto& topic_pair : topics) {
         try {
             auto tok = client_->subscribe(topic_pair.first, topic_pair.second, nullptr,  subListener_);
             if (!tok->wait_for(std::chrono::seconds(5))) {
@@ -578,11 +616,13 @@ void MqttClient::resubscribe_topics() {
 }
 
 void MqttClient::add_topic_to_resubscribe(const std::string& topic, int qos) {
+    std::lock_guard<std::mutex> lock(topics_mtx_);
     topics_to_resubscribe_[topic] = qos;
     BOOST_LOG_TRIVIAL(debug) << "[MQTT_INFO] Added topic to resubscribe list: " << topic;
 }
 
 void MqttClient::remove_topic_from_resubscribe(const std::string& topic) {
+    std::lock_guard<std::mutex> lock(topics_mtx_);
     auto it = topics_to_resubscribe_.find(topic);
     if (it != topics_to_resubscribe_.end()) {
         topics_to_resubscribe_.erase(it);
@@ -592,38 +632,54 @@ void MqttClient::remove_topic_from_resubscribe(const std::string& topic) {
 
 MqttClient::~MqttClient()
 {
-    {        
-        connected_.store(false, std::memory_order_release);
-        is_reconnecting.store(false, std::memory_order_release);
-                
-        int timeout_count = 0;
-        const int max_timeout = 20; // max 5s (50 * 100ms)
-        while (pending_reconnect_checks.load(std::memory_order_acquire) > 0 && timeout_count < max_timeout) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            timeout_count++;
-        }
-        
-        if (timeout_count >= max_timeout) {
-            BOOST_LOG_TRIVIAL(warning) << "[MQTT_INFO] timeout waiting for reconnect checks, forcing destruction";
-        }
-                
-        if (client_) {
-            // Reuse Disconnect: soft-catches already-disconnected and clears shouldBeConnected.
-            std::string dc_msg;
-            Disconnect(dc_msg);
-        }
-     
-        topics_to_resubscribe_.clear();             
-        message_callback_ = nullptr;
+    // 1. Null the callbacks FIRST so any Paho callback that is still in flight
+    //    (or fires during teardown below) becomes a no-op instead of touching
+    //    members being destroyed. Without this, message_arrived() could run on
+    //    the Paho receive thread while these std::function members are being
+    //    torn apart — one of the sources of STATUS_HEAP_CORRUPTION crashes.
+    {
+        std::lock_guard<std::mutex> lock(cb_mtx_);
+        message_callback_            = nullptr;
         message_callback1_           = nullptr;
         connection_failure_callback_ = nullptr;
-
-        if (client_)
-            client_.reset();             
-
-        cleanup_temp_files();        
-        BOOST_LOG_TRIVIAL(info) << "[MQTT_INFO] MQTT client resources freed";
     }
+
+    connected_.store(false, std::memory_order_release);
+    is_reconnecting.store(false, std::memory_order_release);
+
+    // 2. Wait briefly for the detached reconnect-check threads to finish so
+    //    they do not call Disconnect() on a client being destroyed.
+    int timeout_count = 0;
+    const int max_timeout = 20; // max 2s (20 * 100ms)
+    while (pending_reconnect_checks.load(std::memory_order_acquire) > 0 && timeout_count < max_timeout) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        timeout_count++;
+    }
+
+    if (timeout_count >= max_timeout) {
+        BOOST_LOG_TRIVIAL(warning) << "[MQTT_INFO] timeout waiting for reconnect checks, forcing destruction";
+    }
+
+    // 3. Disconnect: clears shouldBeConnected in the C lib, stopping the
+    //    auto-reconnect cycle before the client is destroyed.
+    if (client_) {
+        // Reuse Disconnect: soft-catches already-disconnected and clears shouldBeConnected.
+        std::string dc_msg;
+        Disconnect(dc_msg);
+    }
+
+    // 4. Destroy the async client. ~async_client calls MQTTAsync_destroy(),
+    //    which stops the Paho send/receive threads; doing this BEFORE our own
+    //    members are destroyed (end of destructor) closes the window in which
+    //    a Paho thread could call back into this object after teardown.
+    client_.reset();
+
+    {
+        std::lock_guard<std::mutex> lock(topics_mtx_);
+        topics_to_resubscribe_.clear();
+    }
+
+    cleanup_temp_files();
 }
 
 void MqttClient::cleanup_temp_files()

--- a/src/slic3r/Utils/MQTT.hpp
+++ b/src/slic3r/Utils/MQTT.hpp
@@ -8,6 +8,7 @@
 #include <boost/log/trivial.hpp>
 #include <memory>
 #include <atomic>
+#include <mutex>
 #include <boost/filesystem.hpp>
 
 // Number of retries for connection and subscription attempts
@@ -91,9 +92,16 @@ public:
     // Set callback for handling incoming messages
     void SetMessageCallback(std::function<void(const std::string& topic, const std::string& payload)> callback);
     void SetMessageCallback(std::function<void(const std::string& topic, const std::string& payload, void* this_)> callback);
+    // Resolves ambiguity of SetMessageCallback(nullptr) between the two overloads above
+    void SetMessageCallback(std::nullptr_t) {
+        std::lock_guard<std::mutex> lock(cb_mtx_);
+        message_callback_  = nullptr;
+        message_callback1_ = nullptr;
+    }
 
     //  add set connect callback
     void SetConnectionFailureCallback(std::function<void()> callback) {
+        std::lock_guard<std::mutex> lock(cb_mtx_);
         connection_failure_callback_ = callback;
     }
 
@@ -115,11 +123,16 @@ private:
     std::string server_address_;     // MQTT broker address
     std::string client_id_;          // Unique client identifier
     std::unique_ptr<mqtt::async_client> client_;      // Async MQTT client instance
+    // Guards message_callback_ / message_callback1_ / connection_failure_callback_,
+    // which are read on the Paho callback threads and written from owner threads
+    // (including being nulled at the start of ~MqttClient).
+    mutable std::mutex cb_mtx_;
     std::function<void(const std::string& topic, const std::string& payload)> message_callback_;  // Message handler
     std::function<void(const std::string& topic, const std::string& payload, void* this_)> message_callback1_;  // Message handler
 
     mqtt::connect_options connOpts_; // Connection options
     std::atomic<bool> connected_;    // Connection status flag
+    mutable std::mutex topics_mtx_;  // Guards topics_to_resubscribe_
     std::map<std::string, int> topics_to_resubscribe_;  // Topics to resubscribe after reconnection
     action_listener subListener_;    // Subscription listener
     int connect_retry_time_;         // Connection retry counter

--- a/src/slic3r/Utils/MoonRaker.cpp
+++ b/src/slic3r/Utils/MoonRaker.cpp
@@ -853,6 +853,20 @@ std::string Moonraker_Mqtt::m_notification_topic = "/notification";
 std::string Moonraker_Mqtt::m_request_topic = "/request";
 std::string Moonraker_Mqtt::m_sn = "";
 std::mutex Moonraker_Mqtt::m_sn_mtx;
+std::mutex Moonraker_Mqtt::m_client_mtx;
+std::mutex Moonraker_Mqtt::m_cbs_mtx;
+
+std::shared_ptr<MqttClient> Moonraker_Mqtt::get_mqtt_client()
+{
+    std::lock_guard<std::mutex> lock(m_client_mtx);
+    return m_mqtt_client;
+}
+
+std::shared_ptr<MqttClient> Moonraker_Mqtt::get_mqtt_client_tls()
+{
+    std::lock_guard<std::mutex> lock(m_client_mtx);
+    return m_mqtt_client_tls;
+}
 std::string Moonraker_Mqtt::m_auth_topic = "/config/response";
 std::string Moonraker_Mqtt::m_auth_req_topic = "/config/request";
 nlohmann::json Moonraker_Mqtt::m_auth_info = nlohmann::json::object();
@@ -921,6 +935,8 @@ Moonraker_Mqtt::Moonraker_Mqtt(DynamicPrintConfig* config, bool change_engine) :
             BOOST_LOG_TRIVIAL(error) << "Error getting local IP: " << e.what();
             local_ip = "0.0.0.0"; 
         }
+
+        std::lock_guard<std::mutex> lock(m_client_mtx);
         try {
             m_mqtt_client.reset(new MqttClient("mqtt://" + host_info, local_ip, "", "", true));
         } catch (const std::exception& e) {
@@ -969,12 +985,22 @@ bool Moonraker_Mqtt::set_engine(const std::shared_ptr<MqttClient>& engine, std::
     }
     BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] new engine connection status OK";
 
-    if (m_mqtt_client_tls) {
+    // Detach the old engine under the lock, then disconnect/destroy it outside
+    // the lock: ~MqttClient waits for the Paho threads, and those threads must
+    // never block on a mutex this function (or its callers) still hold.
+    std::shared_ptr<MqttClient> old_engine;
+    {
+        std::lock_guard<std::mutex> lock(m_client_mtx);
+        old_engine         = std::move(m_mqtt_client_tls);
+        m_mqtt_client_tls  = engine;
+    }
+
+    if (old_engine) {
         BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] checking old engine connection status...";
-        if (m_mqtt_client_tls->CheckConnected()) {
+        if (old_engine->CheckConnected()) {
             BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] old engine still connected, disconnecting...";
             std::string dis_msg = "success";
-            bool disconnect_result = m_mqtt_client_tls->Disconnect(dis_msg);
+            bool disconnect_result = old_engine->Disconnect(dis_msg);
             if (disconnect_result) {
                 BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] old engine disconnected successfully: " << dis_msg;
             } else {
@@ -983,16 +1009,14 @@ bool Moonraker_Mqtt::set_engine(const std::shared_ptr<MqttClient>& engine, std::
         } else {
             BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] old engine already disconnected";
         }
+        old_engine->SetMessageCallback(nullptr);
     } else {
         BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] no old engine to disconnect";
     }
 
-    BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] setting new engine pointer";
-    m_mqtt_client_tls = engine;
-
     BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] setting message callback";
     std::weak_ptr<TimeSyncManager> weak_tsm = time_sync_manager_;
-    m_mqtt_client_tls->SetMessageCallback([this, weak_tsm](const std::string& topic, const std::string& payload) {
+    engine->SetMessageCallback([this, weak_tsm](const std::string& topic, const std::string& payload) {
         if (weak_tsm.expired()) {
             BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] object destroyed, ignoring MQTTS message";
             return;
@@ -1014,13 +1038,14 @@ bool Moonraker_Mqtt::set_engine(const std::shared_ptr<MqttClient>& engine, std::
 bool Moonraker_Mqtt::ask_for_tls_info(const nlohmann::json& cn_params)
 {
     auto& wcp_loger = GUI::WCP_Logger::getInstance();
-    if (!m_mqtt_client) {
+    std::shared_ptr<MqttClient> client = get_mqtt_client();
+    if (!client) {
         return false;
     }
 
-    if(m_mqtt_client->CheckConnected()) {
+    if (client->CheckConnected()) {
         std::string dc_msg = "";
-        m_mqtt_client->Disconnect(dc_msg);
+        client->Disconnect(dc_msg);
     }
 
     m_sn_mtx.lock();
@@ -1028,7 +1053,7 @@ bool Moonraker_Mqtt::ask_for_tls_info(const nlohmann::json& cn_params)
     m_sn_mtx.unlock();
 
     std::string connection_msg = "";
-    bool is_connect = m_mqtt_client->Connect(connection_msg);
+    bool is_connect = client->Connect(connection_msg);
 
     if(!is_connect || !cn_params.count("code") || cn_params["code"].get<std::string>() == "") {
         return false;
@@ -1037,12 +1062,12 @@ bool Moonraker_Mqtt::ask_for_tls_info(const nlohmann::json& cn_params)
     std::string auth_code  = cn_params["code"].get<std::string>();
 
     std::string sub_msg             = "success";
-    bool response_subscribed = m_mqtt_client->Subscribe(auth_code + m_auth_topic, 1, sub_msg);
+    bool response_subscribed = client->Subscribe(auth_code + m_auth_topic, 1, sub_msg);
     if (!response_subscribed) {
         return false;
     }
     std::weak_ptr<TimeSyncManager> weak_tsm_mqtt = time_sync_manager_;
-    m_mqtt_client->SetMessageCallback([this, weak_tsm_mqtt](const std::string& topic, const std::string& payload) {
+    client->SetMessageCallback([this, weak_tsm_mqtt](const std::string& topic, const std::string& payload) {
         if (weak_tsm_mqtt.expired()) {
             BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] object destroyed, ignoring MQTT message";
             return;
@@ -1055,7 +1080,7 @@ bool Moonraker_Mqtt::ask_for_tls_info(const nlohmann::json& cn_params)
     body["method"] = "server.request_key";
     json params;
     std::string clientid = "";    
-    clientid = m_mqtt_client->get_client_id();   
+    clientid = client->get_client_id();
     if(clientid == "0.0.0.0") {
         return false;
     }
@@ -1109,7 +1134,7 @@ bool Moonraker_Mqtt::ask_for_tls_info(const nlohmann::json& cn_params)
     }
 
     std::string pub_msg = "";
-    if(!m_mqtt_client->Publish(auth_code + m_auth_req_topic, body.dump(), 1, pub_msg)){
+    if(!client->Publish(auth_code + m_auth_req_topic, body.dump(), 1, pub_msg)){
         return false;
     }
     
@@ -1213,23 +1238,30 @@ bool Moonraker_Mqtt::connect(wxString& msg, const nlohmann::json& params) {
         << "\n - private key present: " << (!m_key.empty() ? "yes" : "no");
     wcp_loger.add_log("MQTTS connection parameters: " + m_host + ":" + std::to_string(m_port) + ", client ID: " + m_client_id + ", CA cert present: " + (!m_ca.empty() ? "yes" : "no") + ", client cert present: " + (!m_cert.empty() ? "yes" : "no") + ", private key present: " + (!m_key.empty() ? "yes" : "no"), false, "", "Moonraker_Mqtt", "info");
 
-    // Ensure old connection is disconnected before creating a new one
-    if (m_mqtt_client) {
+    // Detach the old clients under the lock, then disconnect/destroy them
+    // outside it: ~MqttClient waits for the Paho threads to stop, so the lock
+    // must not be held during teardown (same pattern as disconnect()).
+    std::shared_ptr<MqttClient> old_client;
+    std::shared_ptr<MqttClient> old_client_tls;
+    {
+        std::lock_guard<std::mutex> lock(m_client_mtx);
+        old_client     = std::move(m_mqtt_client);
+        old_client_tls = std::move(m_mqtt_client_tls);
+    }
+    if (old_client) {
         BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] disconnecting old MQTT client";
         wcp_loger.add_log("disconnecting old MQTT client", false, "", "Moonraker_Mqtt", "info");
         std::string dc_msg = "success";
-        m_mqtt_client->Disconnect(dc_msg);
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        m_mqtt_client.reset();
+        old_client->Disconnect(dc_msg);
+        old_client.reset();
     }
 
-    if (m_mqtt_client_tls) {
+    if (old_client_tls) {
         BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] disconnecting old MQTTS client";
         wcp_loger.add_log("disconnecting old MQTTS client", false, "", "Moonraker_Mqtt", "info");
         std::string dc_msg = "success";
-        m_mqtt_client_tls->Disconnect(dc_msg);
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        m_mqtt_client_tls.reset();
+        old_client_tls->Disconnect(dc_msg);
+        old_client_tls.reset();
     }
 
     // Create new MQTTS connection
@@ -1244,23 +1276,32 @@ bool Moonraker_Mqtt::connect(wxString& msg, const nlohmann::json& params) {
     std::string mqtts_url = "mqtts://" + host_ip + ":" + std::to_string(m_port);
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] creating MQTTS client, URL: " << mqtts_url << ", client ID: " << m_client_id;
     wcp_loger.add_log("creating MQTTS client, URL: " + mqtts_url + ", client ID: " + m_client_id, false, "", "Moonraker_Mqtt", "info");
+    std::shared_ptr<MqttClient> new_client;
     try {
-        m_mqtt_client_tls.reset(new MqttClient(mqtts_url, m_client_id, m_ca, m_cert, m_key));
+        new_client = std::make_shared<MqttClient>(mqtts_url, m_client_id, m_ca, m_cert, m_key);
     } catch (const std::exception& e) {
         BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] failed to create MQTTS client: " << e.what();
         wcp_loger.add_log("failed to create MQTTS client: " + std::string(e.what()), false, "", "Moonraker_Mqtt", "error");
-        m_mqtt_client_tls.reset();
         return false;
     }
 
-    if (!m_mqtt_client_tls) {
+    if (!new_client) {
         BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] failed to create MQTT client";
         wcp_loger.add_log("failed to create MQTT client", false, "", "Moonraker_Mqtt", "error");
         return false;
     }
 
+    // Publish the new client under the lock before using it. Concurrent
+    // readers (send_to_request, subscribe/unsubscribe, disconnect) take their
+    // own snapshot, so they either see the old client (still alive) or this
+    // one — never a half-destroyed pointer.
+    {
+        std::lock_guard<std::mutex> lock(m_client_mtx);
+        m_mqtt_client_tls = new_client;
+    }
+
     std::string connection_msg = "";
-    bool is_connect = m_mqtt_client_tls->Connect(connection_msg);
+    bool is_connect = new_client->Connect(connection_msg);
     msg                        = connection_msg;
     if (!is_connect) {
         BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] MQTT connection failed";
@@ -1288,16 +1329,16 @@ bool Moonraker_Mqtt::connect(wxString& msg, const nlohmann::json& params) {
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     std::string no_sub_msg              = "success";
-    bool notification_subscribed = m_mqtt_client_tls->Subscribe(tmp_sn + m_notification_topic, 1, no_sub_msg);
+    bool notification_subscribed = new_client->Subscribe(tmp_sn + m_notification_topic, 1, no_sub_msg);
 
     std::string res_sub_msg         = "success";
-    bool response_subscribed = m_mqtt_client_tls->Subscribe(tmp_sn + m_response_topic, 1, res_sub_msg);
+    bool response_subscribed = new_client->Subscribe(tmp_sn + m_response_topic, 1, res_sub_msg);
     
     BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] topic subscription result - notification topic: " << (notification_subscribed ? "success" : "failed")
                            << ", response topic: " << (response_subscribed ? "success" : "failed");
     wcp_loger.add_log("topic subscription result - notification topic: " + std::string((notification_subscribed ? "success" : "failed")) + ", response topic: " + (response_subscribed ? "success" : "failed"), false, "", "Moonraker_Mqtt", "info");
     std::weak_ptr<TimeSyncManager> weak_tsm = time_sync_manager_;
-    m_mqtt_client_tls->SetMessageCallback([this, weak_tsm](const std::string& topic, const std::string& payload) {
+    new_client->SetMessageCallback([this, weak_tsm](const std::string& topic, const std::string& payload) {
         if (weak_tsm.expired()) {
             BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] object destroyed, ignoring MQTTS message";
             return;
@@ -1316,14 +1357,22 @@ bool Moonraker_Mqtt::disconnect(wxString& msg, const nlohmann::json& params) {
     auto& wcp_loger = GUI::WCP_Logger::getInstance();
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] starting MQTT disconnect";
     wcp_loger.add_log("starting MQTT disconnect", false, "", "Moonraker_Mqtt", "info");
-    if (!m_mqtt_client_tls) {
+
+    // Take a snapshot of the client: the shared_ptr keeps it alive for the
+    // whole teardown even if another thread disconnects/connects concurrently.
+    // This function can be entered from several threads at once (UI thread via
+    // sm_disconnect_current_machine, SSWCP worker thread, ...); previously the
+    // unsynchronized m_mqtt_client_tls.reset() below raced between them and
+    // corrupted the heap.
+    std::shared_ptr<MqttClient> client = get_mqtt_client_tls();
+    if (!client) {
         BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] MQTTS client does not exist, nothing to disconnect";
         wcp_loger.add_log("MQTTS client does not exist, nothing to disconnect", false, "", "Moonraker_Mqtt", "info");
         return false;
     }
 
     std::string dc_msg = "success";
-    bool flag = m_mqtt_client_tls->Disconnect(dc_msg);
+    bool flag = client->Disconnect(dc_msg);
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] MQTTS disconnect result: " << (flag ? "success" : "failed");
     wcp_loger.add_log("MQTTS disconnect result: " + std::string((flag ? "success" : "failed")), false, "", "Moonraker_Mqtt", "info");
 
@@ -1332,6 +1381,7 @@ bool Moonraker_Mqtt::disconnect(wxString& msg, const nlohmann::json& params) {
     time_sync_manager_.reset();
 
     if (flag) {
+        std::lock_guard<std::mutex> cbs_lock(m_cbs_mtx);
         m_status_cbs.clear();
         m_notification_cbs.clear();
     }
@@ -1342,9 +1392,23 @@ bool Moonraker_Mqtt::disconnect(wxString& msg, const nlohmann::json& params) {
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] SN reset";
     wcp_loger.add_log("SN reset", false, "", "Moonraker_Mqtt", "info");
     
-    // Wait for MQTT client cleanup to complete, avoiding memory access issues
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    m_mqtt_client_tls.reset();
+    // Stop delivering messages to this object before teardown: late
+    // message_arrived() calls on the Paho thread become no-ops.
+    client->SetMessageCallback(nullptr);
+
+    // Detach the global pointer (only if we still own this client — another
+    // thread may already have reconnected), then drop our reference OUTSIDE
+    // the lock. ~MqttClient waits for the Paho send/receive threads to exit,
+    // and those threads must never wait on m_client_mtx: destroying the client
+    // while holding the lock could deadlock against a message dispatch that
+    // publishes a new request.
+    {
+        std::lock_guard<std::mutex> lock(m_client_mtx);
+        if (m_mqtt_client_tls == client) {
+            m_mqtt_client_tls.reset();
+        }
+    }
+    client.reset();
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] MQTTS client reset";
     wcp_loger.add_log("MQTTS client reset", false, "", "Moonraker_Mqtt", "info");    
     return flag;
@@ -1357,7 +1421,12 @@ void Moonraker_Mqtt::async_subscribe_machine_info(const std::string& hash, std::
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] starting machine status subscription";
     wcp_loger.add_log("starting machine status subscription", false, "", "Moonraker_Mqtt", "info");
 
-    if (m_status_cbs.empty()) {
+    bool need_subscribe;
+    {
+        std::lock_guard<std::mutex> cbs_lock(m_cbs_mtx);
+        need_subscribe = m_status_cbs.empty();
+    }
+    if (need_subscribe) {
         std::string main_layer = "+";
 
         m_sn_mtx.lock();
@@ -1367,8 +1436,9 @@ void Moonraker_Mqtt::async_subscribe_machine_info(const std::string& hash, std::
         BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] using SN topic: " << main_layer;
         wcp_loger.add_log("using SN topic: " + main_layer, false, "", "Moonraker_Mqtt", "info");
         std::string sub_msg    = "success";
-        bool        res_status = m_mqtt_client_tls ? m_mqtt_client_tls->Subscribe(main_layer + m_status_topic, 1, sub_msg) : false;
-        bool res_notification  = m_mqtt_client_tls ? m_mqtt_client_tls->Subscribe(main_layer + m_notification_topic, 1, sub_msg) : false;
+        std::shared_ptr<MqttClient> client = get_mqtt_client_tls();
+        bool        res_status = client ? client->Subscribe(main_layer + m_status_topic, 1, sub_msg) : false;
+        bool res_notification  = client ? client->Subscribe(main_layer + m_notification_topic, 1, sub_msg) : false;
 
         if (!res_status || !res_notification) {
             BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] failed to subscribe to status topic";
@@ -1381,8 +1451,11 @@ void Moonraker_Mqtt::async_subscribe_machine_info(const std::string& hash, std::
         wcp_loger.add_log("successfully subscribed to status topic: " + main_layer + m_status_topic, false, "", "Moonraker_Mqtt", "info");
     }
 
-    m_status_cbs.insert({hash, callback});
-    m_notification_cbs.insert({hash, callback});
+    {
+        std::lock_guard<std::mutex> cbs_lock(m_cbs_mtx);
+        m_status_cbs.insert({hash, callback});
+        m_notification_cbs.insert({hash, callback});
+    }
     callback(json::object());
 
     
@@ -1493,7 +1566,8 @@ void Moonraker_Mqtt::test_async_wcp_mqtt_moonraker(const nlohmann::json& mqtt_re
         cb(json::value_t::null);
     }
 
-    if (m_mqtt_client_tls) {
+    std::shared_ptr<MqttClient> mqtt_client_tls = get_mqtt_client_tls();
+    if (mqtt_client_tls) {
         std::string main_layer = "+";
 
         if (wait_for_sn()) {
@@ -1512,7 +1586,7 @@ void Moonraker_Mqtt::test_async_wcp_mqtt_moonraker(const nlohmann::json& mqtt_re
             BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] publishing test request to topic: " << main_layer + m_request_topic;
             wcp_loger.add_log("publishing test request to topic: " + main_layer + m_request_topic, false, "", "Moonraker_Mqtt", "info");
             std::string pub_msg = "success";
-            bool res = m_mqtt_client_tls->Publish(main_layer + m_request_topic, mqtt_request_params.dump(), 1, pub_msg);
+            bool res = mqtt_client_tls->Publish(main_layer + m_request_topic, mqtt_request_params.dump(), 1, pub_msg);
             if (!res) {
                 BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] failed to publish test request";
                 wcp_loger.add_log("failed to publish test request", false, "", "Moonraker_Mqtt", "error");
@@ -1613,13 +1687,19 @@ void Moonraker_Mqtt::async_unsubscribe_machine_info(const std::string& hash, std
     BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] Starting unsubscribe machine status";
     wcp_loger.add_log("Starting unsubscribe machine status", false, "", "Moonraker_Mqtt", "info");
 
+    bool no_cbs_left;
+    {
+        std::lock_guard<std::mutex> cbs_lock(m_cbs_mtx);
     if (m_status_cbs.count(hash))
         m_status_cbs.erase(hash);
 
     if (m_notification_cbs.count(hash))
         m_notification_cbs.erase(hash);
 
-    if (m_status_cbs.empty()) {
+        no_cbs_left = m_status_cbs.empty();
+    }
+
+    if (no_cbs_left) {
         std::string main_layer = "+";
 
         m_sn_mtx.lock();
@@ -1627,7 +1707,8 @@ void Moonraker_Mqtt::async_unsubscribe_machine_info(const std::string& hash, std
         m_sn_mtx.unlock();
 
         std::string un_sub_msg = "success";
-        bool        res        = m_mqtt_client_tls ? m_mqtt_client_tls->Unsubscribe(main_layer + m_status_topic, un_sub_msg) : false;
+        std::shared_ptr<MqttClient> client = get_mqtt_client_tls();
+        bool        res        = client ? client->Unsubscribe(main_layer + m_status_topic, un_sub_msg) : false;
 
         if (!res) {
             BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] failed to unsubscribe from status topic";
@@ -2678,9 +2759,9 @@ bool Moonraker_Mqtt::send_to_request(
         body["id"] = seq_id;
     }
 
-    if (m_mqtt_client_tls) {
+    std::shared_ptr<MqttClient> mqtt_client_tls = get_mqtt_client_tls();
+    if (mqtt_client_tls) {
         std::string main_layer = "+";
-    
         m_sn_mtx.lock();
         main_layer = m_sn;
         m_sn_mtx.unlock();
@@ -2702,7 +2783,7 @@ bool Moonraker_Mqtt::send_to_request(
         }
 
         std::string pub_msg = "success";
-        bool res = m_mqtt_client_tls->Publish(topic, body.dump(), 1, pub_msg);
+        bool res = mqtt_client_tls->Publish(topic, body.dump(), 1, pub_msg);
         if (!res) {
             BOOST_LOG_TRIVIAL(error) << "[Moonraker_Mqtt] failed to publish request, method: " << method;
             wcp_loger.add_log("failed to publish request, method: " + method, false, "", "Moonraker_Mqtt", "error");
@@ -2924,14 +3005,23 @@ void Moonraker_Mqtt::on_status_arrived(const std::string& payload)
             wcp_loger.add_log("status update contains method: " + body["method"].get<std::string>(), false, "", "Moonraker_Mqtt", "info");
         }
 
-        if (m_status_cbs.empty()) {
+        // Snapshot the callbacks under m_cbs_mtx and invoke the copies:
+        // disconnect()/unsubscribe run on other threads and clear/erase these
+        // maps; iterating them directly raced with that and corrupted the heap.
+        std::unordered_map<std::string, std::function<void(const nlohmann::json&)>> cbs;
+        {
+            std::lock_guard<std::mutex> cbs_lock(m_cbs_mtx);
+            cbs = m_status_cbs;
+        }
+
+        if (cbs.empty()) {
             BOOST_LOG_TRIVIAL(info) << "[Moonraker_Mqtt] status callback not set";
             wcp_loger.add_log("status callback not set", false, "", "Moonraker_Mqtt", "info");
             return;
         }
         
         wcp_loger.add_log("invoking status callback", false, "", "Moonraker_Mqtt", "info");
-        for (const auto& func : m_status_cbs) {
+        for (const auto& func : cbs) {
             func.second(data);
         }
 
@@ -2967,11 +3057,18 @@ void Moonraker_Mqtt::on_notification_arrived(const std::string& payload)
             wcp_loger.add_log("status update contains method: " + body["method"].get<std::string>(), false, "", "Moonraker_Mqtt", "info");
         }
 
-        if (m_notification_cbs.empty()) {
+        // Snapshot the callbacks under m_cbs_mtx and invoke the copies:
+        // disconnect()/unsubscribe run on other threads and clear/erase these
+        // maps; iterating them directly raced with that and corrupted the heap.
+        std::unordered_map<std::string, std::function<void(const nlohmann::json&)>> cbs;
+        {
+            std::lock_guard<std::mutex> cbs_lock(m_cbs_mtx);
+            cbs = m_notification_cbs;
+        }
+        if (cbs.empty()) {
             return;
         }
-
-        for (const auto& func : m_notification_cbs) {
+        for (const auto& func : cbs) {
             func.second(data);
         }
     }
@@ -3008,8 +3105,8 @@ void Moonraker_Mqtt::set_connection_lost(std::function<void()> callback) {
     auto& wcp_loger = GUI::WCP_Logger::getInstance();
     BOOST_LOG_TRIVIAL(warning) << "[Moonraker_Mqtt] setting connection lost callback";
     wcp_loger.add_log("setting connection lost callback", false, "", "Moonraker_Mqtt", "info");
-    if (m_mqtt_client_tls)
-        m_mqtt_client_tls->SetConnectionFailureCallback(callback);
+    if (std::shared_ptr<MqttClient> client = get_mqtt_client_tls())
+        client->SetConnectionFailureCallback(callback);
 }
 
 

--- a/src/slic3r/Utils/MoonRaker.hpp
+++ b/src/slic3r/Utils/MoonRaker.hpp
@@ -2,6 +2,7 @@
 #define slic3r_Moonraker_hpp_
 
 #include <string>
+#include <mutex>
 #include <wx/string.h>
 #include <boost/optional.hpp>
 #include <boost/asio/ip/address.hpp>
@@ -384,6 +385,19 @@ private:
     static TimeoutMap<int64_t, RequestCallback> m_request_cb_map;
     static std::unordered_map<std::string, std::function<void(const nlohmann::json&)>> m_status_cbs;
     static std::unordered_map<std::string, std::function<void(const nlohmann::json&)>> m_notification_cbs;
+
+    // Serializes lifecycle changes of the static MQTT clients (connect /
+    // disconnect / engine swap). Readers must copy the shared_ptr under this
+    // lock (get_mqtt_client_tls()) and use the copy, so a concurrent
+    // disconnect can never destroy a client that is still being used.
+    static std::mutex m_client_mtx;
+    // Guards m_status_cbs / m_notification_cbs: they are inserted/erased from
+    // UI threads, iterated on the Paho receive thread and cleared on disconnect.
+    static std::mutex m_cbs_mtx;
+
+    // Snapshot helpers: return a copy of the static client under the lock.
+    static std::shared_ptr<MqttClient> get_mqtt_client();
+    static std::shared_ptr<MqttClient> get_mqtt_client_tls();
 
     // MQTT topics
     static std::string m_auth_topic;


### PR DESCRIPTION
### Problem
The application crashed intermittently when a printer's MQTT connection was closed (manual disconnect, machine switching or connection loss), with symptoms such as STATUS_HEAP_CORRUPTION on Windows and EXC_BAD_ACCESS / heap corruption reports in Sentry. The root cause was unsynchronized concurrent access between the Paho MQTT callback threads, the UI thread and SSWCP worker threads around client teardown:

1. `MqttClient`'s callback members (`message_callback_`, `message_callback1_`, `connection_failure_callback_`) were read on Paho threads and written/cleared on other threads with no locking — a callback could be destroyed while `message_arrived()` was invoking it.
2. `~MqttClient()` destroyed its members while Paho callbacks were still in flight, so a late callback could run on a half-destroyed object.
3. In `Moonraker_Mqtt`, `m_mqtt_client` / `m_mqtt_client_tls` were reset from several threads at once (`disconnect()` can be entered concurrently from the UI thread and the SSWCP worker thread); racing `shared_ptr::reset()` calls corrupted the heap. Teardown ordering relied on fixed sleeps.
4. `HttpServer::stop()`, `restart()` and `is_healthy()` raced each other: handlers running on the io thread mutated the session set while `stop_all()` iterated it, and `is_healthy()` could observe `server_ == nullptr` in the middle of a restart and trigger a second, overlapping restart.

### Changes

**MQTT.cpp / MQTT.hpp**
- Add `cb_mtx_`: all callback reads/writes are serialized; callbacks are copied under the lock and the copies are invoked outside it.
- Add a `SetMessageCallback(std::nullptr_t)` overload to resolve ambiguity between the two overloads.
- Guard `topics_to_resubscribe_` with `topics_mtx_`; `resubscribe_topics()` works on a snapshot so the lock is never held while blocking on the broker.
- Reorder `~MqttClient()` for safe teardown: (1) null the callbacks first so in-flight Paho callbacks become no-ops, (2) wait for detached reconnect-check threads, (3) `Disconnect()` to stop the auto-reconnect cycle, (4) destroy the async client (which stops the Paho send/receive threads) before our own members are destroyed.

**MoonRaker.cpp / MoonRaker.hpp**
- Guard `m_mqtt_client` / `m_mqtt_client_tls` with `m_client_mtx` and add `get_mqtt_client[_tls]()` accessors that return a snapshot; every user (publish, subscribe/unsubscribe, send_to_request, disconnect) now holds a `shared_ptr` copy, so it either sees the old (still alive) client or the new one — never a half-destroyed pointer.
- In `connect()` / `set_engine()` / `disconnect()`: detach the old client under the lock, then disconnect and destroy it *outside* the lock (`~MqttClient` waits for Paho threads that must never block on this mutex). `disconnect()` only clears the global pointer if it still points at the same client, so it can no longer clobber a concurrent reconnect.
- Guard `m_status_cbs` / `m_notification_cbs` with `m_cbs_mtx`; `on_status_arrived()` invokes a snapshot copy of the callbacks.
- Remove the sleep-based cleanup waits (100/500 ms) in favor of deterministic lifetime management.

**HttpServer.cpp / HttpServer.hpp**
- Add `m_server_mtx` to serialize `stop()`, `restart()` and `is_healthy()`.
- In `stop()`/`restart()`: close the acceptor with an error_code, join the io thread *before* calling `stop_all()` (handlers no longer mutate the session set concurrently), and hold the lock across the whole teardown+restart so the health check cannot trigger a nested restart.