### PR TITLE
fix(wcp): guard deviceFilamentInfo cache parsing against double-encoded payload

### DIFF
--- a/src/slic3r/GUI/SSWCP.cpp
+++ b/src/slic3r/GUI/SSWCP.cpp
@@ -7575,29 +7575,51 @@ void SSWCP_MqttAgent_Instance::sw_mqtt_set_engine()
                                     wxGetApp().app_config->clear_filament_extruder_map();
 
                                     if (self->m_wcp_cache.count("deviceFilamentInfo")) {
-                                        std::string value_str = m_wcp_cache["deviceFilamentInfo"].get<std::string>();
-                                        json value                 = json::parse(value_str);
-                                        json value_item            = value["value"];
-                                        auto machines     = wxGetApp().app_config->get_devices();
-                                        bool find                  = false;
-                                        for (auto& [key, value] : value_item.items()) {
-                                            if (find) {
-                                                break;
+                                        try {
+                                            // Flutter writers encode this cache value inconsistently:
+                                            // one path jsonEncodes the payload once, another encodes it
+                                            // twice. Unwrap the extra string layer instead of assuming
+                                            // an object with a "value" key (operator[] would throw).
+                                            json value;
+                                            std::string value_str;
+                                            if (self->m_wcp_cache["deviceFilamentInfo"].is_string()) {
+                                                value_str = self->m_wcp_cache["deviceFilamentInfo"].get<std::string>();
+                                                value     = json::parse(value_str);
+                                                if (value.is_string())
+                                                    value = json::parse(value.get<std::string>());
+                                            } else {
+                                                value = self->m_wcp_cache["deviceFilamentInfo"];
                                             }
 
-                                            for (const auto& machine : machines) {
-                                                if (machine.sn == key && machine.connected) {
-                                                    find = true;
-                                                    json target = json::array();
-                                                    json object = json::object();
-                                                    object["key"] = key;
-                                                    object["value"]    = value.dump();
-                                                    target.push_back(object);
-                                                    self->update_filament_info(target, false);
-                                                    break;
+                                            if (value.is_object() && value.contains("value") && value["value"].is_object()) {
+                                                json value_item            = value["value"];
+                                                auto machines     = wxGetApp().app_config->get_devices();
+                                                bool find                  = false;
+                                                for (auto& [key, value] : value_item.items()) {
+                                                    if (find) {
+                                                        break;
+                                                    }
+
+                                                    for (const auto& machine : machines) {
+                                                        if (machine.sn == key && machine.connected) {
+                                                            find = true;
+                                                            json target = json::array();
+                                                            json object = json::object();
+                                                            object["key"] = key;
+                                                            object["value"]    = value.dump();
+                                                            target.push_back(object);
+                                                            self->update_filament_info(target, false);
+                                                            break;
+                                                        }
+                                                    }
+
                                                 }
+                                            } else {
+                                                BOOST_LOG_TRIVIAL(warning) << "[WCP] deviceFilamentInfo cache has unexpected format, skip. type=" << value.type_name()
+                                                                           << " raw=" << (value_str.empty() ? self->m_wcp_cache["deviceFilamentInfo"].dump() : value_str);
                                             }
-
+                                        } catch (const std::exception& e) {
+                                            BOOST_LOG_TRIVIAL(error) << "[WCP] deviceFilamentInfo cache parse failed: " << e.what();
                                         }
                                     }
 


### PR DESCRIPTION
## Summary

Fixes an intermittent crash (process termination) in the MQTT connect-success callback of `sw_mqtt_set_engine` when reading the `deviceFilamentInfo` WCP cache entry.

Crash stack (reproduced on Windows):

```
nlohmann::basic_json::operator[](const char* key)          json.hpp:3888  -> throws type_error.305
SSWCP_MqttAgent_Instance::sw_mqtt_set_engine::<lambda>     SSWCP.cpp:7580
[wx modal event loop via WebPreprintDialog::run() -> ShowModal()]
Plater::send_gcode_legacy -> on_action_send_gcode
```

## Root cause

The connect-success continuation assumed the cached `deviceFilamentInfo` value always parses to a JSON object with a `"value"` key:

```cpp
std::string value_str = m_wcp_cache["deviceFilamentInfo"].get<std::string>();
json value            = json::parse(value_str);
json value_item       = value["value"];   // throws type_error.305 if not an object
```

The Flutter side writes this cache key with **two different encodings**:

- one writer `jsonEncode`s the payload once → parses to an object (works)
- `writeFilamentInfoCacheObjects` (pre-upload-and-print flow, `moduleName: "preUploadAndPrint"`) encodes it **twice** → `json::parse` yields a JSON *string*, and `value["value"]` throws `type_error.305`

The lambda chain has no try/catch, so the exception terminates the process. Confirmed by logs: the last cache write before the crash was double-encoded (`"{\"moduleName\":...}"`), while earlier writes in the same session were single-encoded.

Since #838 (`sw_SetCache` now overwrites instead of keeping the first write) the **last** write wins, so the double-encoded value now actually reaches this reader — that is why the crash became intermittent-but-real after that change. Which write lands last is a race between the printTaskConfig callback and the MQTT connect callback, hence "sometimes".

## Fix (C++ side, defensive)

- Unwrap one extra string layer after `json::parse` (handles the double-encoded writer; data is still applied)
- Require an `{value: object}` shape before iterating; otherwise log a warning (with `type_name()` and the raw payload) and skip
- Wrap the block in try/catch so a malformed cache entry can no longer crash the connect callback

The original matching/update logic is unchanged.

## Follow-up (separate, Flutter side)

Unify the encoding in `writeFilamentInfoCacheObjects` (remove the extra `jsonEncode`) so both writers emit the same shape.

## Test plan

- [ ] Reproduce the original scenario (send to print → preprint dialog → connect) with a double-encoded cache entry: no crash, filament info applied after unwrapping
- [ ] Normal single-encoded cache entry: filament info applied as before
- [ ] Malformed / non-string cache entry: warning logged, connect flow unaffected
