### PR TITLE
Fix model opened from a URL being discarded on macOS

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1078,17 +1078,26 @@ void GUI_App::post_init()
         }
 //#endif
         mainframe->Thaw();
-        // Defer the final tab selection to after pending events are
-        // processed. During GL init, the PAGE_CHANGED handler posts
-        // EVT_GLVIEWTOOLBAR_3D which would undo a synchronous
-        // select_tab(0) and switch back to the Prepare tab.
-        CallAfter([this] {
-            if (is_editor() && app_config->get("default_page") != "1")
-                mainframe->select_tab(size_t(0));
-            else if (app_config->get("default_page") == "1")
-                mainframe->select_tab(size_t(1));
-        });
-        plater_->trigger_restore_project(1);
+        // A URL open already in flight loads its own project and has already selected the 3D
+        // view. Sending the user to the home page and starting a blank project would undo both.
+        // On macOS the URL arrives through MacOpenURL after launch, so it is never visible in
+        // init_params->input_files and switch_to_3d above cannot account for it. This mirrors
+        // what switch_to_3d already does on platforms that receive the URL as a launch argument.
+        if (m_url_open_pending) {
+            BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ", url open pending, staying on the 3D view and skipping the blank project";
+        } else {
+            // Defer the final tab selection to after pending events are
+            // processed. During GL init, the PAGE_CHANGED handler posts
+            // EVT_GLVIEWTOOLBAR_3D which would undo a synchronous
+            // select_tab(0) and switch back to the Prepare tab.
+            CallAfter([this] {
+                if (is_editor() && app_config->get("default_page") != "1")
+                    mainframe->select_tab(size_t(0));
+                else if (app_config->get("default_page") == "1")
+                    mainframe->select_tab(size_t(1));
+            });
+            plater_->trigger_restore_project(1);
+        }
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ", end load_gl_resources";
     }
 //#endif
@@ -6718,6 +6727,10 @@ void GUI_App::MacOpenURL(const wxString& url)
 {
     if (url.empty())
         return;
+    // post_init() decides whether to start a blank project based on init_params->input_files,
+    // which is always empty here: macOS launches the app first and delivers the URL afterwards.
+    // Without this flag post_init resets the project that this download is about to load.
+    m_url_open_pending = true;
     start_download(into_u8(url));
 }
 

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -251,6 +251,11 @@ public:
 private:
     bool            m_initialized { false };
     bool            m_post_initialized { false };
+    // Set when a snapmaker-orca:// URL is handed to us after launch (macOS delivers these
+    // through MacOpenURL rather than argv, so post_init cannot see them in input_files).
+    // post_init must not start a blank project in that case, or it discards the model the
+    // URL is in the middle of loading.
+    bool            m_url_open_pending { false };
     bool            m_app_conf_exists{ false };
     EAppMode        m_app_mode{ EAppMode::Editor };
     bool            m_is_recreating_gui{ false };


### PR DESCRIPTION
Fixes #851.

Opening a model from Snapmaker Space on macOS downloads and loads it correctly, and then the app discards it. The model is visible on the plate for a moment, the plate clears, and the title changes to "Untitled".

## Cause

macOS does not pass the URL in `argv`. LaunchServices launches the app first and delivers the URL afterwards through `GUI_App::MacOpenURL`, so `init_params->input_files` is empty by the time `post_init()` inspects it and `switch_to_3d` is never set.

`post_init()` therefore continues into its ordinary startup path, which selects the home page and calls `plater_->trigger_restore_project(1)`. That finds no backup to restore and starts a blank project, over the model `MacOpenURL` has just finished loading.

Windows is unaffected: the URL arrives in `argv`, `switch_to_3d` becomes `true`, and the whole block is skipped.

## The change

`MacOpenURL` sets `m_url_open_pending`, and `post_init()` checks it at the point `switch_to_3d` cannot reach. That gives the macOS URL path the same treatment the argv path already gets.

`MacOpenURL` is macOS-only, so Windows and Linux are unchanged by construction. The `info` log line makes it possible to confirm the path from a user's log without reproducing anything.

## Verification

Built and tested on macOS 26.6.2, Apple Silicon.

- Model opened from a Space link stays on the plate and the app stays on Prepare. Five consecutive runs, all with the `url open pending` line present and no `Reset Project` snapshot after `load project done`.
- Confirmed with both a small model and a large one (a 2 second download and a 12 second download), since the original report wrongly described this as a timing race.
- Normal launch still takes the unguarded path: several launches from the app icon, all reaching `trigger_restore_project` as before.

Not yet exercised on my side, and worth a look in review: restoring an unsaved project after a crash, and double-clicking a `.3mf` in Finder. Neither goes through `MacOpenURL`, so neither should see the flag set, but I would rather say so than imply I tested them.

The two public models used are linked in #851 for anyone wanting to reproduce. Note that it only reproduces on a **cold** launch: if Snapmaker Orca is already running and has finished starting up, it works fine, which is why this has been hard to recur.

## Note on crash recovery

`trigger_restore_project` is also what offers to restore an unsaved project after a crash. That prompt is skipped only when a URL open is in flight, which seems right: the user asked for a specific model. It is unaffected on every other launch path. Happy to gate it differently if you would prefer the prompt still appear.
