### PR TITLE
Open a project from a URL as a project, and fix the drop dialog default

### DIFF
--- a/src/slic3r/GUI/Downloader.cpp
+++ b/src/slic3r/GUI/Downloader.cpp
@@ -265,7 +265,8 @@ void Downloader::on_complete(wxCommandEvent& event)
     set_download_state(event.GetInt(), DownloadState::DownloadDone);
 	wxArrayString paths;
 	paths.Add(event.GetString());
-	wxGetApp().plater()->load_files(paths);
+	// from_url: the user clicked "Open in ..." on this specific project.
+	wxGetApp().plater()->load_files(paths, /* from_url */ true);
 }
 bool Downloader::user_action_callback(DownloaderUserAction action, int id)
 {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -19384,7 +19384,13 @@ ProjectDropDialog::ProjectDropDialog(const std::string &filename)
                 wxDefaultPosition,
                 wxDefaultSize,
                 wxCAPTION | wxCLOSE_BOX)
-    , m_action(2)
+    // Default to the action the user chose last time, which this dialog already records in
+    // "import_project_action" on OK. Falling back to LoadType::OpenProject rather than
+    // LoadGeometry: this dialog is shown for a *project* file, and importing geometry only
+    // silently discards the embedded printer, filament and process settings.
+    , m_action(std::max(1, std::min(2, wxGetApp().app_config->get("import_project_action").empty()
+                                       ? 1
+                                       : std::atoi(wxGetApp().app_config->get("import_project_action").c_str()))))
 {
     // def setting
     SetBackgroundColour(m_def_color);
@@ -19550,7 +19556,7 @@ void ProjectDropDialog::on_dpi_changed(const wxRect& suggested_rect)
 }
 
 //BBS: remove GCodeViewer as seperate APP logic
-bool Plater::load_files(const wxArrayString& filenames)
+bool Plater::load_files(const wxArrayString& filenames, bool from_url)
 {
     const std::regex pattern_drop(".*[.](stp|step|stl|oltp|obj|amf|3mf|svg|zip)", std::regex::icase);
     const std::regex pattern_gcode_drop(".*[.](gcode|g)", std::regex::icase);
@@ -19659,7 +19665,7 @@ bool Plater::load_files(const wxArrayString& filenames)
 
     switch (loadfiles_type) {
     case LoadFilesType::Single3MF:
-        open_3mf_file(normal_paths[0]);
+        open_3mf_file(normal_paths[0], from_url);
         break;
 
     case LoadFilesType::SingleOther: {
@@ -19742,7 +19748,7 @@ LoadType determine_load_type(std::string filename, std::string override_setting)
     }
 }
 
-bool Plater::open_3mf_file(const fs::path &file_path)
+bool Plater::open_3mf_file(const fs::path &file_path, bool from_url)
 {
     std::string filename = encode_path(file_path.filename().string().c_str());
     if (!boost::algorithm::iends_with(filename, ".3mf")) {
@@ -19751,7 +19757,13 @@ bool Plater::open_3mf_file(const fs::path &file_path)
 
     bool not_empty_plate = !model().objects.empty();
     bool load_setting_ask_when_relevant = wxGetApp().app_config->get(SETTING_PROJECT_LOAD_BEHAVIOUR) == OPTION_PROJECT_LOAD_BEHAVIOUR_ASK_WHEN_RELEVANT;
-    LoadType load_type = determine_load_type(filename, (not_empty_plate && load_setting_ask_when_relevant) ? OPTION_PROJECT_LOAD_BEHAVIOUR_ALWAYS_ASK : "");
+    // A project opened from a snapmaker-orca:// URL is not an ambiguous drop: the user
+    // clicked "Open in Snapmaker Orca" on that specific project, so do not escalate to the
+    // "Open as project / Import geometry only" prompt just because the plate is occupied.
+    // The global Load Behaviour setting is still honoured, and load_project() still asks
+    // about unsaved changes to the current project.
+    LoadType load_type = determine_load_type(filename,
+        (!from_url && not_empty_plate && load_setting_ask_when_relevant) ? OPTION_PROJECT_LOAD_BEHAVIOUR_ALWAYS_ASK : "");
 
     if (load_type == LoadType::Unknown) return false;
 

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -335,7 +335,7 @@ public:
     // BBS: check snapshot
     bool up_to_date(bool saved, bool backup);
 
-    bool open_3mf_file(const fs::path &file_path);
+    bool open_3mf_file(const fs::path &file_path, bool from_url = false);
     int  get_3mf_file_count(std::vector<fs::path> paths);
     void add_file();
     void add_model(bool imperial_units = false, std::string fname = "");
@@ -387,8 +387,10 @@ public:
     std::vector<size_t> load_files(const std::vector<boost::filesystem::path>& input_files, LoadStrategy strategy = LoadStrategy::LoadModel | LoadStrategy::LoadConfig,  bool ask_multi = false);
     // To be called when providing a list of files to the GUI slic3r on command line.
     std::vector<size_t> load_files(const std::vector<std::string>& input_files, LoadStrategy strategy = LoadStrategy::LoadModel | LoadStrategy::LoadConfig,  bool ask_multi = false);
-    // to be called on drag and drop
-    bool load_files(const wxArrayString& filenames);
+    // to be called on drag and drop, or for a project downloaded from a
+    // snapmaker-orca:// URL, in which case from_url is true: the user has already
+    // said which project to open, so do not ask them again.
+    bool load_files(const wxArrayString& filenames, bool from_url = false);
 
     const wxString& get_last_loaded_gcode() const { return m_last_loaded_gcode; }
 


### PR DESCRIPTION
Two related but independent problems that show up when opening a model from Snapmaker Space while a project is already on the plate. Fixing either one alone leaves the other.

<img width="659" height="422" alt="Screenshot 2026-09-11 at 1 10 32 AM" src="https://github.com/user-attachments/assets/2cd13857-5d1d-43bf-8a86-76b82223bb68" />

**Platform scope.** Problem 1 is macOS specific in practice, because macOS delivers the URL to the already running instance through `MacOpenURL`, so the model lands on an occupied plate. On Windows the click starts a new instance with an empty plate, so the escalation never triggers. Linux untested.

Problem 2 is not platform specific. It affects anyone dragging a `.3mf` onto an occupied plate, on any OS.

## 1. The "Drop project file" dialog should not appear at all

Clicking "Open in Snapmaker Orca" on a Space page already tells the app which project to open. But the download is handed to `Plater::load_files(const wxArrayString&)`, which is the drag-and-drop entry point (its own comment says so), and `open_3mf_file()` escalates to the prompt whenever the plate is not empty:

```cpp
bool not_empty_plate = !model().objects.empty();
bool load_setting_ask_when_relevant = ... == OPTION_PROJECT_LOAD_BEHAVIOUR_ASK_WHEN_RELEVANT;
LoadType load_type = determine_load_type(filename,
    (not_empty_plate && load_setting_ask_when_relevant) ? OPTION_PROJECT_LOAD_BEHAVIOUR_ALWAYS_ASK : "");
```

So a cold launch opens the project without asking, and a warm one interrogates the user, for exactly the same action.

The download path now passes `from_url`, which suppresses that escalation and nothing else:

- The global **Load Behaviour** preference is still honored. A user who set "Always Ask" or "Load Geometry Only" still gets what they asked for.
- `load_project()` still calls `close_with_confirm()`, so unsaved changes to the current project are still protected. That is the prompt that belongs here, and it already existed.

## 2. The dialog defaulted to the destructive option

When the dialog does legitimately appear, it preselected "Import geometry only". It records the user's choice in `import_project_action` on OK, but never read it back, because `m_action` was hardcoded to `2` (`LoadGeometry`).

It now initializes from the stored choice, falling back to `OpenProject` rather than `LoadGeometry`.

That fallback matters. `LoadGeometry` sets `load_config = 0`, so the embedded printer, filament and process settings are dropped. On a multi-color model the practical result is that the paintwork is re-rendered in whatever filaments the *previously* loaded project happened to use, so the creator's color work is visibly lost rather than merely mis-referenced. The plate still renders and the model still slices, which is what makes it dangerous: nothing reports an error.

It is a poor default for a dialog titled "Drop project file", and a particularly poor one for the option a user is most likely to accept without reading. That leads to something like this:

<img width="335" height="205" alt="Screenshot 2026-09-11 at 12 27 21 AM" src="https://github.com/user-attachments/assets/4864a305-29a5-48b2-a57f-6513103c028b" />

<img width="2556" height="1783" alt="Screenshot 2026-09-11 at 1 11 15 AM" src="https://github.com/user-attachments/assets/83492502-173e-4711-8f47-5538bc26f85d" />


If the user _correctly_ changed it to `Open as project`, it would load properly:


<img width="2552" height="1784" alt="Screenshot 2026-09-11 at 1 46 27 AM" src="https://github.com/user-attachments/assets/8cc00709-ea12-4d1f-b7b5-3301ff3a77fd" />

## Testing

Built and run on macOS 26.6.2, Apple Silicon, Release build. Load Behaviour left at its default, "Ask When Relevant".

Confirmed:

- Cold launch from a Space link: unchanged, opens the project.
- Snapmaker Orca already open with a model on the plate, then "Open in Snapmaker Orca" on a second Space model: opens as a project, no dialog.
- Same, after making an unsaved change to the first model: still prompted to save changes first.
- Drag and drop a `.3mf` from Finder onto an occupied plate: dialog still appears, as it should, and now comes up with "Open as project" selected rather than "Import geometry only".

Not exercised: Load Behaviour explicitly set to "Always Ask" or "Load Geometry Only". Those paths are untouched by this change (`from_url` only suppresses the escalation to `ALWAYS_ASK`, it does not override the stored setting), but I have not run them.

Reproduction models for the original problem, both public on Snapmaker Space:

- https://space.snapmaker.com/en/model/5942-baby-dragon-rudolph-3mf-included-no-supports
- https://space.snapmaker.com/en/model/358-snap-carousel-by-riciery-techtronic3d

## Note

This code is inherited from upstream OrcaSlicer and the same two problems exist there. I am happy to send it upstream as well, but the impact is sharpest here, since Snapmaker Space exists specifically to distribute tuned profiles and this is the path that discards them.

